### PR TITLE
Stateless SEEMlessDirectory API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ crypto = { git  = "https://github.com/novifinancial/winterfell", package = "wint
 rand = "0.8"
 queues = "1.0.0"
 keyed_priority_queue = "0.3"
+
+[dev-dependencies]
+lazy_static = "1.4.0"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -123,6 +123,7 @@ impl fmt::Display for AzksError {
 #[derive(Debug)]
 pub enum SeemlessDirectoryError {
     AuditProofStartEpLess(u64, u64),
+    StorageError,
 }
 
 impl fmt::Display for SeemlessDirectoryError {
@@ -136,6 +137,15 @@ impl fmt::Display for SeemlessDirectoryError {
                     end
                 )
             }
+            Self::StorageError => {
+                write!(f, "Error with retrieving value from storage")
+            }
         }
     }
+}
+
+#[derive(Debug)]
+pub enum StorageError {
+    SetError,
+    GetError,
 }


### PR DESCRIPTION
Restructures the SEEMlessDirectory API to be stateless. Relies on a trait called Storage, which implements set and get.

In a test, implemented an InMemoryDB to demonstrate how the API could be used.