### PR TITLE
Pass down storage trait through low-level functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ bench = []
 [dependencies]
 crypto = { git  = "https://github.com/novifinancial/winterfell", package = "winter-crypto", branch = "main" }
 math = { git  = "https://github.com/novifinancial/winterfell", package = "winter-math", branch = "main" }
-
 rand = "0.8"
 queues = "1.0.0"
 keyed_priority_queue = "0.3"

--- a/benches/azks.rs
+++ b/benches/azks.rs
@@ -10,17 +10,50 @@ use criterion::Criterion;
 use crypto::{hashers::Blake3_256, Hasher};
 use math::fields::f128::BaseElement;
 use rand::{prelude::ThreadRng, thread_rng, RngCore};
-use seemless::{append_only_zks::Azks, node_state::NodeLabel};
+use seemless::{
+    append_only_zks::Azks, node_state::HistoryNodeState, node_state::NodeLabel, storage::Storage,
+};
 use std::time::{Duration, Instant};
 
 type Blake3 = Blake3_256<BaseElement>;
+
+use lazy_static::lazy_static;
+use seemless::errors::StorageError;
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+lazy_static! {
+    static ref HASHMAP: Mutex<HashMap<String, HistoryNodeState<Blake3>>> = {
+        let mut m = HashMap::new();
+        Mutex::new(m)
+    };
+}
+
+#[derive(Debug)]
+pub(crate) struct InMemoryDb(HashMap<String, HistoryNodeState<Blake3>>);
+
+impl Storage<HistoryNodeState<Blake3>> for InMemoryDb {
+    fn set(pos: String, node: HistoryNodeState<Blake3>) -> Result<(), StorageError> {
+        let mut hashmap = HASHMAP.lock().unwrap();
+        hashmap.insert(pos, node);
+        Ok(())
+    }
+
+    fn get(pos: String) -> Result<HistoryNodeState<Blake3>, StorageError> {
+        let mut hashmap = HASHMAP.lock().unwrap();
+        hashmap
+            .get(&pos)
+            .map(|v| v.clone())
+            .ok_or(StorageError::GetError)
+    }
+}
 
 fn single_insertion(c: &mut Criterion) {
     let num_nodes = 1000;
 
     let mut rng: ThreadRng = thread_rng();
 
-    let mut azks1 = Azks::<Blake3>::new();
+    let mut azks1 = Azks::<Blake3, InMemoryDb>::new();
 
     for _ in 0..num_nodes {
         let node = NodeLabel::random(&mut rng);

--- a/src/append_only_zks.rs
+++ b/src/append_only_zks.rs
@@ -8,20 +8,24 @@ use std::fmt::Error;
 use crate::{
     errors::HistoryTreeNodeError,
     history_tree_node::{NodeType, *},
+    storage::Storage,
 };
 use crate::{history_tree_node::HistoryTreeNode, node_state::*, ARITY, *};
 use crypto::Hasher;
+use std::marker::PhantomData;
 
 use keyed_priority_queue::{Entry, KeyedPriorityQueue};
 use queues::*;
 
-pub struct Azks<H: Hasher> {
+pub struct Azks<H: Hasher, S: Storage<HistoryNodeState<H>>> {
     root: usize,
     latest_epoch: u64,
     epochs: Vec<u64>,
-    tree_nodes: Vec<HistoryTreeNode<H>>, // This also needs to include a VRF key to actually compute
-                                         // labels but need to figure out how we want to instantiate.
-                                         // For now going to assume that the inserted leaves come with unique labels.
+    tree_nodes: Vec<HistoryTreeNode<H, S>>, // This also needs to include a VRF key to actually compute
+    // labels but need to figure out how we want to instantiate.
+    // For now going to assume that the inserted leaves come with unique labels.
+    _s: PhantomData<S>,
+    _h: PhantomData<H>,
 }
 
 #[derive(Debug)]
@@ -49,9 +53,9 @@ pub struct AppendOnlyProof<H: Hasher> {
     unchanged_nodes: Vec<(NodeLabel, H::Digest)>,
 }
 
-impl<H: Hasher> Azks<H> {
+impl<H: Hasher, S: Storage<HistoryNodeState<H>>> Azks<H, S> {
     pub fn new() -> Self {
-        let root = get_empty_root::<H>(Option::Some(0));
+        let root = get_empty_root::<H, S>(Option::Some(0));
         let latest_epoch = 0;
         let mut epochs = vec![latest_epoch];
         let mut tree_nodes = vec![root];
@@ -60,6 +64,8 @@ impl<H: Hasher> Azks<H> {
             latest_epoch,
             epochs,
             tree_nodes,
+            _s: PhantomData,
+            _h: PhantomData,
         }
     }
 
@@ -68,7 +74,7 @@ impl<H: Hasher> Azks<H> {
         // if self.latest_epoch != 0 {
         self.increment_epoch();
         // }
-        let mut new_leaf = get_leaf_node::<H>(label, 0, value.as_ref(), 0, self.latest_epoch);
+        let mut new_leaf = get_leaf_node::<H, S>(label, 0, value.as_ref(), 0, self.latest_epoch);
         let mut tree_repr = self.tree_nodes.clone();
         let (_, tree_repr) = self.tree_nodes[self.root].insert_single_leaf(
             new_leaf,
@@ -99,7 +105,7 @@ impl<H: Hasher> Azks<H> {
         let mut priorities: i32 = 0;
         for insertion_elt in insertion_set {
             let new_leaf_loc = self.tree_nodes.len();
-            let mut new_leaf = get_leaf_node::<H>(
+            let mut new_leaf = get_leaf_node::<H, S>(
                 insertion_elt.0,
                 0,
                 insertion_elt.1.as_ref(),
@@ -107,7 +113,7 @@ impl<H: Hasher> Azks<H> {
                 self.latest_epoch,
             );
             if append_only_usage {
-                new_leaf = get_leaf_node_without_hashing::<H>(
+                new_leaf = get_leaf_node_without_hashing::<H, S>(
                     insertion_elt.0,
                     0,
                     insertion_elt.1,
@@ -180,9 +186,8 @@ impl<H: Hasher> Azks<H> {
         let longest_prefix = lcp_node.label;
         let mut longest_prefix_children_labels = [NodeLabel::new(0, 0); ARITY];
         let mut longest_prefix_children_values = [H::hash(&[]); ARITY];
-        let children = lcp_node
-            .get_state_at_epoch(epoch)
-            .unwrap()
+        let state = lcp_node.get_state_at_epoch(epoch).unwrap();
+        let children = state
             .child_states
             .iter()
             .map(|x| self.tree_nodes[x.location].clone());
@@ -389,7 +394,7 @@ impl<H: Hasher> Azks<H> {
     }
 }
 
-impl<H: Hasher> Default for Azks<H> {
+impl<H: Hasher, S: Storage<HistoryNodeState<H>>> Default for Azks<H, S> {
     fn default() -> Self {
         Self::new()
     }
@@ -418,11 +423,11 @@ fn hash_layer<H: Hasher>(hashes: Vec<H::Digest>, parent_label: NodeLabel) -> H::
 
 type AppendOnlyHelper<D> = (Vec<(NodeLabel, D)>, Vec<(NodeLabel, D)>);
 
-fn get_append_only_proof_helper<H: Hasher>(
-    node: HistoryTreeNode<H>,
+fn get_append_only_proof_helper<H: Hasher, S: Storage<HistoryNodeState<H>>>(
+    node: HistoryTreeNode<H, S>,
     start_epoch: u64,
     end_epoch: u64,
-    tree_nodes: Vec<HistoryTreeNode<H>>,
+    tree_nodes: Vec<HistoryTreeNode<H, S>>,
 ) -> AppendOnlyHelper<H::Digest> {
     let mut unchanged = Vec::<(NodeLabel, H::Digest)>::new();
     let mut leaves = Vec::<(NodeLabel, H::Digest)>::new();
@@ -474,6 +479,7 @@ fn get_append_only_proof_helper<H: Hasher>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tests::InMemoryDb;
     use crypto::hashers::Blake3_256;
     use math::fields::f128::BaseElement;
     use rand::{rngs::OsRng, seq::SliceRandom, RngCore};
@@ -534,7 +540,7 @@ mod tests {
             hash_label::<Blake3>(NodeLabel::new(1, 1)),
         ]);
 
-        let mut azks1 = Azks::<Blake3>::new();
+        let mut azks1 = Azks::<Blake3, InMemoryDb>::new();
         let mut insertion_set: Vec<(NodeLabel, Blake3Digest)> = vec![];
 
         for _ in 0..num_nodes {
@@ -546,7 +552,7 @@ mod tests {
             azks1.insert_leaf(node, val).unwrap();
         }
 
-        let mut azks2 = Azks::<Blake3>::new();
+        let mut azks2 = Azks::<Blake3, InMemoryDb>::new();
 
         azks2.batch_insert_leaves(insertion_set);
 
@@ -563,7 +569,7 @@ mod tests {
         let num_nodes = 100;
         let mut rng = OsRng;
 
-        let mut azks1 = Azks::<Blake3>::new();
+        let mut azks1 = Azks::<Blake3, InMemoryDb>::new();
         let mut insertion_set: Vec<(NodeLabel, Blake3Digest)> = vec![];
 
         for _ in 0..num_nodes {
@@ -578,7 +584,7 @@ mod tests {
         // Try randomly permuting
         insertion_set.shuffle(&mut rng);
 
-        let mut azks2 = Azks::<Blake3>::new();
+        let mut azks2 = Azks::<Blake3, InMemoryDb>::new();
 
         azks2.batch_insert_leaves(insertion_set);
 
@@ -609,7 +615,7 @@ mod tests {
         // Try randomly permuting
         insertion_set.shuffle(&mut rng);
 
-        let mut azks = Azks::<Blake3>::new();
+        let mut azks = Azks::<Blake3, InMemoryDb>::new();
         azks.batch_insert_leaves(insertion_set.clone());
 
         let proof = azks.get_membership_proof(insertion_set[0].0, 1);
@@ -624,7 +630,7 @@ mod tests {
 
     #[test]
     fn test_membership_proof_failing() -> Result<(), HistoryTreeNodeError> {
-        let num_nodes = 1000;
+        let num_nodes = 100;
         let mut rng = OsRng;
 
         let mut insertion_set: Vec<(NodeLabel, Blake3Digest)> = vec![];
@@ -640,7 +646,7 @@ mod tests {
         // Try randomly permuting
         insertion_set.shuffle(&mut rng);
 
-        let mut azks = Azks::<Blake3>::new();
+        let mut azks = Azks::<Blake3, InMemoryDb>::new();
         azks.batch_insert_leaves(insertion_set.clone());
 
         let mut proof = azks.get_membership_proof(insertion_set[0].0, 1);
@@ -669,7 +675,7 @@ mod tests {
         insertion_set.push((NodeLabel::new(0b11 << 62, 64), Blake3::hash(&[])));
         insertion_set.push((NodeLabel::new(0b01 << 62, 64), Blake3::hash(&[])));
         insertion_set.push((NodeLabel::new(0b111 << 61, 64), Blake3::hash(&[])));
-        let mut azks = Azks::<Blake3>::new();
+        let mut azks = Azks::<Blake3, InMemoryDb>::new();
         azks.batch_insert_leaves(insertion_set);
         let search_label = NodeLabel::new(0b1111 << 60, 64);
         let proof = azks.get_non_membership_proof(search_label, 1);
@@ -682,7 +688,7 @@ mod tests {
 
     #[test]
     fn test_nonmembership_proof() -> Result<(), HistoryTreeNodeError> {
-        let num_nodes = 1000;
+        let num_nodes = 100;
         let mut rng = OsRng;
 
         let mut insertion_set: Vec<(NodeLabel, Blake3Digest)> = vec![];
@@ -695,7 +701,7 @@ mod tests {
             insertion_set.push((node, input));
         }
 
-        let mut azks = Azks::<Blake3>::new();
+        let mut azks = Azks::<Blake3, InMemoryDb>::new();
         let search_label = insertion_set[num_nodes - 1].0;
         azks.batch_insert_leaves(insertion_set.clone()[0..num_nodes - 1].to_vec());
         let proof = azks.get_non_membership_proof(search_label, 1);
@@ -710,7 +716,7 @@ mod tests {
 
     #[test]
     fn test_append_only_proof_tiny() -> Result<(), HistoryTreeNodeError> {
-        let mut azks = Azks::<Blake3>::new();
+        let mut azks = Azks::<Blake3, InMemoryDb>::new();
 
         let mut insertion_set_1: Vec<(NodeLabel, Blake3Digest)> = vec![];
         insertion_set_1.push((NodeLabel::new(0b0, 64), Blake3::hash(&[])));
@@ -736,7 +742,7 @@ mod tests {
 
     #[test]
     fn test_append_only_proof() -> Result<(), HistoryTreeNodeError> {
-        let num_nodes = 301;
+        let num_nodes = 50;
 
         let mut rng = OsRng;
 
@@ -750,7 +756,7 @@ mod tests {
             insertion_set_1.push((node, input));
         }
 
-        let mut azks = Azks::<Blake3>::new();
+        let mut azks = Azks::<Blake3, InMemoryDb>::new();
         azks.batch_insert_leaves(insertion_set_1.clone());
 
         let start_hash = azks.get_root_hash()?;

--- a/src/history_tree_node.rs
+++ b/src/history_tree_node.rs
@@ -5,10 +5,14 @@
 
 use std::collections::HashMap;
 
+use crate::errors::StorageError;
+use crate::storage::{get_state_map, set_state_map, Storage};
 use crate::{node_state::*, Direction, ARITY};
 use crypto::Hasher;
 
 use crate::errors::HistoryTreeNodeError;
+
+use std::marker::PhantomData;
 
 #[derive(PartialEq, Debug, Copy, Clone)]
 pub enum NodeType {
@@ -24,49 +28,57 @@ pub type HistoryNodeHash<H> = Option<H>;
  * HistoryNode will represent a generic interior node of a compressed history tree
  **/
 #[derive(Debug)]
-pub struct HistoryTreeNode<H: Hasher> {
+pub struct HistoryTreeNode<H: Hasher, S: Storage<HistoryNodeState<H>>> {
     pub label: NodeLabel,
     pub location: usize,
     pub epochs: Vec<u64>,
-    pub state_map: HashMap<u64, HistoryNodeState<H>>,
     pub parent: usize,
     // Just use usize and have the 0th position be empty and that can be the parent of root. This makes things simpler.
     pub node_type: NodeType,
+    #[cfg(test)]
+    pub(crate) state_map: HashMap<u64, HistoryNodeState<H>>,
     // Note that the NodeType along with the parent/children being options
     // allows us to use this struct to represent child and parent nodes as well.
+    _s: PhantomData<S>,
+    _h: PhantomData<H>,
 }
 
-impl<H: Hasher> Clone for HistoryTreeNode<H> {
+impl<H: Hasher, S: Storage<HistoryNodeState<H>>> Clone for HistoryTreeNode<H, S> {
     fn clone(&self) -> Self {
         Self {
             label: self.label,
             location: self.location,
             epochs: self.epochs.clone(),
-            state_map: self.state_map.clone(),
             parent: self.parent,
             node_type: self.node_type,
+            #[cfg(test)]
+            state_map: self.state_map.clone(),
+            _s: PhantomData,
+            _h: PhantomData,
         }
     }
 }
 
-impl<H: Hasher> HistoryTreeNode<H> {
+impl<H: Hasher, S: Storage<HistoryNodeState<H>>> HistoryTreeNode<H, S> {
     pub fn new(label: NodeLabel, location: usize, parent: usize, node_type: NodeType) -> Self {
         let ep: Vec<u64> = Vec::new();
-        let s_map: HashMap<u64, HistoryNodeState<H>> = HashMap::new();
         HistoryTreeNode {
             label,
             location,
             epochs: ep,
-            state_map: s_map,
             parent, // Root node is its own parent
             node_type,
+            #[cfg(test)]
+            state_map: HashMap::new(),
+            _s: PhantomData,
+            _h: PhantomData,
         }
     }
 
     // Inserts a single leaf node and updates the required hashes
     pub fn insert_single_leaf(
         &mut self,
-        mut new_leaf: HistoryTreeNode<H>,
+        mut new_leaf: Self,
         epoch: u64,
         tree_repr_original: Vec<Self>,
     ) -> Result<(Self, Vec<Self>), HistoryTreeNodeError> {
@@ -182,7 +194,7 @@ impl<H: Hasher> HistoryTreeNode<H> {
     // Inserts a single leaf node
     pub fn insert_single_leaf_without_hash(
         &mut self,
-        mut new_leaf: HistoryTreeNode<H>,
+        mut new_leaf: Self,
         epoch: u64,
         tree_repr_original: Vec<Self>,
     ) -> Result<(Self, Vec<Self>), HistoryTreeNodeError> {
@@ -278,7 +290,7 @@ impl<H: Hasher> HistoryTreeNode<H> {
         match self.node_type {
             NodeType::Leaf => {
                 // the hash of this is just the value, simply place in parent
-                let leaf_hash_val = H::merge(&[*self.get_value()?, hash_label::<H>(self.label)]);
+                let leaf_hash_val = H::merge(&[self.get_value()?, hash_label::<H>(self.label)]);
                 self.update_hash_at_parent(epoch, leaf_hash_val, tree_repr)
             }
             _ => {
@@ -288,9 +300,9 @@ impl<H: Hasher> HistoryTreeNode<H> {
                     hash_digest = H::merge(&[hash_digest, hash_label::<H>(self.label)]);
                 }
                 let epoch_state = self.get_state_at_epoch(epoch).unwrap();
-                let mut updated_state = epoch_state.clone();
+                let mut updated_state = epoch_state;
                 updated_state.value = hash_digest;
-                self.state_map.insert(epoch, updated_state);
+                set_state_map(self, &epoch, updated_state);
                 let mut updated_tree = tree_repr;
                 updated_tree[self.location] = self.clone();
                 let hash_digest = H::merge(&[hash_digest, hash_label::<H>(self.label)]);
@@ -317,9 +329,9 @@ impl<H: Hasher> HistoryTreeNode<H> {
         &mut self,
         epoch: u64,
     ) -> Result<H::Digest, HistoryTreeNodeError> {
-        match self.state_map.get(&epoch) {
-            None => Err(HistoryTreeNodeError::NoChildrenInTreeAtEpoch(epoch)),
-            Some(mut epoch_node_state) => {
+        match get_state_map(self, &epoch) {
+            Err(_) => Err(HistoryTreeNodeError::NoChildrenInTreeAtEpoch(epoch)),
+            Ok(mut epoch_node_state) => {
                 let mut new_hash = H::hash(&[]); //hash_label::<H>(self.label);
                 for child_index in 0..ARITY {
                     new_hash = H::merge(&[
@@ -350,18 +362,17 @@ impl<H: Hasher> HistoryTreeNode<H> {
             Ok(tree_repr_copy)
         } else {
             let mut parent = tree_repr_copy[self.parent].clone();
-            match parent.state_map.get(&epoch) {
-                //&parent_latest_ep) {
-                None => Err(HistoryTreeNodeError::ParentNextEpochInvalid(epoch)),
-                Some(parent_state) => match parent.get_direction_at_ep(self, epoch) {
+            match get_state_map(&parent, &epoch) {
+                Err(_) => Err(HistoryTreeNodeError::ParentNextEpochInvalid(epoch)),
+                Ok(parent_state) => match parent.get_direction_at_ep(self, epoch) {
                     None => Err(HistoryTreeNodeError::HashUpdateOnlyAllowedAfterNodeInsertion),
                     Some(s_dir) => {
-                        let mut parent_updated_state = parent_state.clone();
+                        let mut parent_updated_state = parent_state;
                         let mut self_child_state =
                             parent_updated_state.get_child_state_in_dir(s_dir);
                         self_child_state.hash_val = new_hash_val;
                         parent_updated_state.child_states[s_dir] = self_child_state;
-                        parent.state_map.insert(epoch, parent_updated_state);
+                        set_state_map(&mut parent, &epoch, parent_updated_state);
                         tree_repr_copy[self.parent] = parent.clone();
                         Ok(tree_repr_copy)
                     }
@@ -378,30 +389,30 @@ impl<H: Hasher> HistoryTreeNode<H> {
         let (direction, child_node) = child;
 
         match direction {
-            Direction::Some(dir) => match self.state_map.get(&epoch) {
-                Some(&HistoryNodeState {
+            Direction::Some(dir) => match get_state_map(self, &epoch) {
+                Ok(HistoryNodeState {
                     value,
                     mut child_states,
                 }) => {
                     child_states[dir] = child_node;
-                    let mut new_state_map = self.state_map.clone();
-                    new_state_map.insert(
-                        epoch,
+                    set_state_map(
+                        self,
+                        &epoch,
                         HistoryNodeState {
                             value,
                             child_states,
                         },
                     );
-                    self.state_map = new_state_map;
                     Ok(self.clone())
                 }
-                None => {
-                    self.state_map.insert(
-                        epoch,
-                        match self.state_map.get(&self.get_latest_epoch().unwrap_or(0)) {
-                            Some(latest_st) => latest_st.clone(),
+                Err(_) => {
+                    set_state_map(
+                        self,
+                        &epoch,
+                        match get_state_map(self, &self.get_latest_epoch().unwrap_or(0)) {
+                            Ok(latest_st) => latest_st,
 
-                            None => HistoryNodeState::<H>::new(),
+                            Err(_) => HistoryNodeState::<H>::new(),
                         },
                     );
 
@@ -463,11 +474,11 @@ impl<H: Hasher> HistoryTreeNode<H> {
     }
 
     // gets value at current epoch
-    pub fn get_value(&self) -> Result<&H::Digest, HistoryTreeNodeError> {
+    pub fn get_value(&self) -> Result<H::Digest, HistoryTreeNodeError> {
         //&HistoryNodeHash<H> {
-        match self.state_map.get(&self.get_latest_epoch().unwrap()) {
-            Some(node_state) => Ok(&node_state.value),
-            None => Err(HistoryTreeNodeError::NodeCreatedWithoutEpochs(
+        match get_state_map(self, &self.get_latest_epoch().unwrap()) {
+            Ok(node_state) => Ok(node_state.value),
+            Err(_) => Err(HistoryTreeNodeError::NodeCreatedWithoutEpochs(
                 self.label.get_val(),
             )),
         }
@@ -487,7 +498,7 @@ impl<H: Hasher> HistoryTreeNode<H> {
 
     // gets the direction of node, i.e. if it's a left
     // child or right. If not found, return None
-    pub fn get_direction_at_ep(&self, node: &HistoryTreeNode<H>, ep: u64) -> Direction {
+    pub fn get_direction_at_ep(&self, node: &Self, ep: u64) -> Direction {
         let mut outcome: Direction = None;
         let state_at_ep = self.get_state_at_epoch(ep).unwrap();
         for node_index in 0..ARITY {
@@ -522,10 +533,10 @@ impl<H: Hasher> HistoryTreeNode<H> {
         match direction {
             Direction::None => Err(HistoryTreeNodeError::DirectionIsNone),
             Direction::Some(dir) => {
-                let state_map_val = self.state_map.get(&epoch);
+                let state_map_val = get_state_map(self, &epoch);
                 match state_map_val {
-                    Some(curr) => Ok(curr.get_child_state_in_dir(dir)),
-                    None => Err(HistoryTreeNodeError::NoChildInTreeAtEpoch(epoch, dir)),
+                    Ok(curr) => Ok(curr.get_child_state_in_dir(dir)),
+                    Err(_) => Err(HistoryTreeNodeError::NoChildInTreeAtEpoch(epoch, dir)),
                 }
             }
         }
@@ -571,18 +582,15 @@ impl<H: Hasher> HistoryTreeNode<H> {
     pub fn get_state_at_existing_epoch(
         &self,
         epoch: u64,
-    ) -> Result<&HistoryNodeState<H>, HistoryTreeNodeError> {
-        self.state_map
-            .get(&epoch)
-            .ok_or(HistoryTreeNodeError::NodeDidNotHaveExistingStateAtEp(
-                self.label, epoch,
-            ))
+    ) -> Result<HistoryNodeState<H>, HistoryTreeNodeError> {
+        get_state_map(self, &epoch)
+            .map_err(|_| HistoryTreeNodeError::NodeDidNotHaveExistingStateAtEp(self.label, epoch))
     }
 
     pub fn get_state_at_epoch(
         &self,
         epoch: u64,
-    ) -> Result<&HistoryNodeState<H>, HistoryTreeNodeError> {
+    ) -> Result<HistoryNodeState<H>, HistoryTreeNodeError> {
         if self.get_birth_epoch() > epoch {
             Err(HistoryTreeNodeError::NodeDidNotExistAtEp(self.label, epoch))
         } else {
@@ -673,7 +681,7 @@ impl<H: Hasher> HistoryTreeNode<H> {
             dummy_marker: DummyChildState::Real,
             location: self.location,
             label: self.label,
-            hash_val: H::merge(&[*self.get_value()?, hash_label::<H>(self.label)]),
+            hash_val: H::merge(&[self.get_value()?, hash_label::<H>(self.label)]),
             epoch_version: epoch_val,
         })
     }
@@ -684,7 +692,7 @@ impl<H: Hasher> HistoryTreeNode<H> {
             dummy_marker: DummyChildState::Real,
             location: self.location,
             label: self.label,
-            hash_val: H::merge(&[*self.get_value()?, hash_label::<H>(self.label)]),
+            hash_val: H::merge(&[self.get_value()?, hash_label::<H>(self.label)]),
             epoch_version: epoch_val,
         })
     }
@@ -692,110 +700,126 @@ impl<H: Hasher> HistoryTreeNode<H> {
 
 /////// Helpers //////
 
-pub fn get_empty_root<H: Hasher>(ep: Option<u64>) -> HistoryTreeNode<H> {
+pub fn get_empty_root<H: Hasher, S: Storage<HistoryNodeState<H>>>(
+    ep: Option<u64>,
+) -> HistoryTreeNode<H, S> {
     let label = NodeLabel::new(0u64, 0u32);
     let loc = 0;
     let parent = 0;
-    let mut node: HistoryTreeNode<H> = HistoryTreeNode::new(label, loc, parent, NodeType::Root);
+    let mut node: HistoryTreeNode<H, S> = HistoryTreeNode::new(label, loc, parent, NodeType::Root);
     if let Some(epoch) = ep {
         node.epochs.push(epoch);
     }
     node
 }
 
-pub fn get_leaf_node<H: Hasher>(
+pub fn get_leaf_node<H: Hasher, S: Storage<HistoryNodeState<H>>>(
     label: NodeLabel,
     location: usize,
     value: &[u8],
     parent: usize,
     birth_epoch: u64,
-) -> HistoryTreeNode<H> {
-    HistoryTreeNode {
+) -> HistoryTreeNode<H, S> {
+    let mut node = HistoryTreeNode {
         label,
         location,
         epochs: vec![birth_epoch],
-        state_map: get_state_map_for_leaf::<H>(
-            H::merge(&[H::hash(&[]), H::hash(value)]),
-            birth_epoch,
-        ),
         parent,
         node_type: NodeType::Leaf,
-    }
+        #[cfg(test)]
+        state_map: HashMap::new(),
+        _s: PhantomData,
+        _h: PhantomData,
+    };
+
+    let mut new_state = HistoryNodeState::new();
+    new_state.value = H::merge(&[H::hash(&[]), H::hash(value)]);
+
+    set_state_map(&mut node, &birth_epoch, new_state);
+
+    node
 }
 
-pub fn get_leaf_node_without_empty<H: Hasher>(
+pub fn get_leaf_node_without_empty<H: Hasher, S: Storage<HistoryNodeState<H>>>(
     label: NodeLabel,
     location: usize,
     value: &[u8],
     parent: usize,
     birth_epoch: u64,
-) -> HistoryTreeNode<H> {
-    HistoryTreeNode {
+) -> HistoryTreeNode<H, S> {
+    let mut node = HistoryTreeNode {
         label,
         location,
         epochs: vec![birth_epoch],
-        state_map: get_state_map_for_leaf::<H>(H::hash(value), birth_epoch),
         parent,
         node_type: NodeType::Leaf,
-    }
+        #[cfg(test)]
+        state_map: HashMap::new(),
+        _s: PhantomData,
+        _h: PhantomData,
+    };
+
+    let mut new_state = HistoryNodeState::new();
+    new_state.value = H::hash(value);
+
+    set_state_map(&mut node, &birth_epoch, new_state);
+
+    node
 }
 
-pub fn get_leaf_node_without_hashing<H: Hasher>(
+pub fn get_leaf_node_without_hashing<H: Hasher, S: Storage<HistoryNodeState<H>>>(
     label: NodeLabel,
     location: usize,
     value: H::Digest,
     parent: usize,
     birth_epoch: u64,
-) -> HistoryTreeNode<H> {
-    HistoryTreeNode {
+) -> HistoryTreeNode<H, S> {
+    let mut node = HistoryTreeNode {
         label,
         location,
         epochs: vec![birth_epoch],
-        state_map: get_state_map_for_leaf::<H>(value, birth_epoch),
         parent,
         node_type: NodeType::Leaf,
-    }
-}
+        #[cfg(test)]
+        state_map: HashMap::new(),
+        _s: PhantomData,
+        _h: PhantomData,
+    };
 
-pub fn get_interior_node<H: Hasher>(
-    label: NodeLabel,
-    location: usize,
-    value: H::Digest,
-    parent: usize,
-    birth_epoch: u64,
-    child_states: [HistoryChildState<H>; 2],
-) -> HistoryTreeNode<H> {
-    HistoryTreeNode {
-        label,
-        location,
-        epochs: vec![birth_epoch],
-        state_map: get_state_map_for_interior::<H>(birth_epoch, value, child_states),
-        parent,
-        node_type: NodeType::Interior,
-    }
-}
-
-fn get_state_map_for_leaf<H: Hasher>(
-    value: H::Digest,
-    epoch: u64,
-) -> HashMap<u64, HistoryNodeState<H>> {
-    let mut state_map: HashMap<u64, HistoryNodeState<H>> = HashMap::new();
     let mut new_state = HistoryNodeState::new();
     new_state.value = value;
-    state_map.insert(epoch, new_state);
-    state_map
+
+    set_state_map(&mut node, &birth_epoch, new_state);
+
+    node
 }
 
-fn get_state_map_for_interior<H: Hasher>(
-    epoch: u64,
+pub fn get_interior_node<H: Hasher, S: Storage<HistoryNodeState<H>>>(
+    label: NodeLabel,
+    location: usize,
     value: H::Digest,
+    parent: usize,
+    birth_epoch: u64,
     child_states: [HistoryChildState<H>; 2],
-) -> HashMap<u64, HistoryNodeState<H>> {
-    let mut state_map: HashMap<u64, HistoryNodeState<H>> = HashMap::new();
-    let mut new_state = HistoryNodeState {
+) -> HistoryTreeNode<H, S> {
+    let mut node = HistoryTreeNode {
+        label,
+        location,
+        epochs: vec![birth_epoch],
+        parent,
+        node_type: NodeType::Interior,
+        #[cfg(test)]
+        state_map: HashMap::new(),
+        _s: PhantomData,
+        _h: PhantomData,
+    };
+
+    let new_state = HistoryNodeState {
         value,
         child_states,
     };
-    state_map.insert(epoch, new_state);
-    state_map
+
+    set_state_map(&mut node, &birth_epoch, new_state);
+
+    node
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,11 +12,11 @@ extern crate queues;
 extern crate rand;
 
 pub mod append_only_zks;
+pub mod errors;
 pub mod history_tree_node;
 pub mod node_state;
 pub mod seemless_directory;
-
-pub mod errors;
+pub mod storage;
 pub use errors::*;
 
 #[cfg(test)]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,53 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use crate::errors::StorageError;
+use crate::history_tree_node::HistoryTreeNode;
+use crate::node_state::HistoryNodeState;
+use crypto::Hasher;
+
+pub trait Storage<N> {
+    fn set(pos: String, node: N) -> Result<(), StorageError>;
+    fn get(pos: String) -> Result<N, StorageError>;
+}
+
+pub(crate) fn set_state_map<H: Hasher, S: Storage<HistoryNodeState<H>>>(
+    node: &mut HistoryTreeNode<H, S>,
+    key: &u64,
+    val: HistoryNodeState<H>,
+) -> Result<(), StorageError> {
+    #[cfg(test)]
+    {
+        node.state_map.insert(*key, val.clone());
+        Ok(())
+    }
+
+    #[cfg(not(test))]
+    {
+        let k = format!("location: {}, key: {}", node.location, key);
+        S::set(k, val)
+    }
+}
+
+pub(crate) fn get_state_map<H: Hasher, S: Storage<HistoryNodeState<H>>>(
+    node: &HistoryTreeNode<H, S>,
+    key: &u64,
+) -> Result<HistoryNodeState<H>, StorageError> {
+    #[cfg(test)]
+    {
+        let val = node.state_map.get(key);
+
+        match val {
+            Some(v) => Ok(v.clone()),
+            None => Err(StorageError::GetError),
+        }
+    }
+
+    #[cfg(not(test))]
+    {
+        let k = format!("location: {}, key: {}", node.location, key);
+        S::get(k)
+    }
+}


### PR DESCRIPTION
This ensures that the lower-level APIs (append_only_zks, history_tree_node) use the storage trait passed down in order to store things. However, for tests, local storage (through the node's state_map struct) is still used because I couldn't get this to work nicely for tests.

This way, if we need to store things per-node, we can just call get_state_map and set_state_map.