### PR TITLE
General cleanups

### DIFF
--- a/benches/azks.rs
+++ b/benches/azks.rs
@@ -54,7 +54,7 @@ fn single_insertion(c: &mut Criterion) {
 
     let mut rng: ThreadRng = thread_rng();
 
-    let mut azks1 = Azks::<Blake3, InMemoryDb>::new(&mut rng);
+    let mut azks1 = Azks::<Blake3, InMemoryDb>::new(&mut rng).unwrap();
 
     for _ in 0..num_nodes {
         let node = NodeLabel::random(&mut rng);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -12,6 +12,7 @@ pub enum SeemlessError {
     HistoryTreeNodeErr(HistoryTreeNodeError),
     SeemlessDirectoryErr(SeemlessDirectoryError),
     AzksErr(AzksError),
+    NoDirectionError,
 }
 
 impl From<HistoryTreeNodeError> for SeemlessError {

--- a/src/node_state.rs
+++ b/src/node_state.rs
@@ -92,14 +92,6 @@ impl NodeLabel {
             return Direction::None;
         }
         Direction::Some(other.get_bit_at(self.get_len()).try_into().unwrap())
-        // let other_self_difference = other.get_len() - self.get_len();
-        // let self_at_other_len = self.get_val().wrapping_shl(other_self_difference);
-        // let other_xored = self_at_other_len ^ other.get_val();
-        // let dir: usize = other_xored
-        //     .wrapping_shr(other_self_difference - 1)
-        //     .try_into()
-        //     .unwrap();
-        // Direction::Some(dir)
     }
 }
 
@@ -161,25 +153,7 @@ impl<H: Hasher> fmt::Display for HistoryNodeState<H> {
         write!(f, "")
     }
 }
-/*
 
-pub type HistoryChildLabel = NodeLabel;
-
-pub type HistoryChildHash<H: Hasher> = Option<H::Digest>;
-
-pub type HistoryChildEpochVersion = Option<u64>;
-
-pub type HistoryChildLocation = Option<usize>;
-
-
-#[derive(Debug, Copy, Clone)]
-pub struct HistoryChildState<H: Hasher> {
-    pub location: HistoryChildLocation,
-    pub label: HistoryChildLabel,
-    pub hash_val: HistoryChildHash<H>,
-    pub epoch_version: HistoryChildEpochVersion,
-}
-*/
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum DummyChildState {
     Dummy,

--- a/src/seemless_directory.rs
+++ b/src/seemless_directory.rs
@@ -65,7 +65,7 @@ impl<S: Storage<HistoryTreeNode<H, S>>, H: Hasher> SeemlessDirectory<S, H> {
         for (_key, _val) in updates {
             S::set(
                 "0".to_string(),
-                crate::history_tree_node::get_empty_root(&[], None),
+                crate::history_tree_node::get_empty_root(&[], None).unwrap(),
             )
             .map_err(|_| SeemlessDirectoryError::StorageError)?;
         }


### PR DESCRIPTION
Turning `.unwrap()`s into `?`, clearing return types that don't need to be set, and other general improvements.