### PR TITLE
Storage Enum

### DIFF
--- a/benches/azks.rs
+++ b/benches/azks.rs
@@ -11,8 +11,9 @@ use crypto::{hashers::Blake3_256, Hasher};
 use math::fields::f128::BaseElement;
 use rand::{prelude::ThreadRng, thread_rng, RngCore};
 use seemless::{
-    append_only_zks::Azks, history_tree_node::HistoryTreeNode, node_state::NodeLabel,
-    storage::Storage,
+    append_only_zks::Azks,
+    node_state::NodeLabel,
+    storage::{Storage, StorageEnum},
 };
 use std::time::{Duration, Instant};
 
@@ -24,23 +25,23 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 
 lazy_static! {
-    static ref HASHMAP: Mutex<HashMap<String, HistoryTreeNode<Blake3, InMemoryDb>>> = {
+    static ref HASHMAP: Mutex<HashMap<String, StorageEnum<Blake3, InMemoryDb>>> = {
         let m = HashMap::new();
         Mutex::new(m)
     };
 }
 
 #[derive(Debug)]
-pub(crate) struct InMemoryDb(HashMap<String, HistoryTreeNode<Blake3, InMemoryDb>>);
+pub(crate) struct InMemoryDb(HashMap<String, StorageEnum<Blake3, InMemoryDb>>);
 
-impl Storage<HistoryTreeNode<Blake3, InMemoryDb>> for InMemoryDb {
-    fn set(pos: String, node: HistoryTreeNode<Blake3, InMemoryDb>) -> Result<(), StorageError> {
+impl Storage<StorageEnum<Blake3, InMemoryDb>> for InMemoryDb {
+    fn set(pos: String, node: StorageEnum<Blake3, InMemoryDb>) -> Result<(), StorageError> {
         let mut hashmap = HASHMAP.lock().unwrap();
         hashmap.insert(pos, node);
         Ok(())
     }
 
-    fn get(pos: String) -> Result<HistoryTreeNode<Blake3, InMemoryDb>, StorageError> {
+    fn get(pos: String) -> Result<StorageEnum<Blake3, InMemoryDb>, StorageError> {
         let hashmap = HASHMAP.lock().unwrap();
         hashmap
             .get(&pos)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -157,6 +157,7 @@ impl fmt::Display for AzksError {
 pub enum SeemlessDirectoryError {
     AuditProofStartEpLess(u64, u64),
     LookedUpNonExistentUser(String, u64),
+    LookupVerificationErr(String),
     KeyHistoryVerificationErr(String),
     StorageError,
 }
@@ -181,6 +182,9 @@ impl fmt::Display for SeemlessDirectoryError {
             Self::KeyHistoryVerificationErr(err_string) => {
                 write!(f, "{}", err_string)
             }
+            Self::LookupVerificationErr(err_string) => {
+                write!(f, "{}", err_string)
+            }
         }
     }
 }
@@ -189,4 +193,7 @@ impl fmt::Display for SeemlessDirectoryError {
 pub enum StorageError {
     SetError,
     GetError,
+    WrongMemoryTypeError,
+    WrongIdTypeError,
+    UnsupportedStorageTypeError,
 }

--- a/src/seemless_directory.rs
+++ b/src/seemless_directory.rs
@@ -5,9 +5,12 @@
 use crate::append_only_zks::{AppendOnlyProof, NonMembershipProof};
 use crate::append_only_zks::{Azks, MembershipProof};
 use crate::errors::{SeemlessDirectoryError, SeemlessError};
-use crate::history_tree_node::HistoryTreeNode;
+
 use crate::node_state::NodeLabel;
-use crate::storage::Storage;
+use crate::storage::{
+    IdEnum::{self, *},
+    Storage, StorageEnum,
+};
 use crypto::Hasher;
 use rand::{prelude::ThreadRng, thread_rng};
 use std::collections::HashMap;
@@ -78,19 +81,22 @@ pub struct HistoryProof<H: Hasher> {
     proofs: Vec<UpdateProof<H>>,
 }
 
-pub struct SeemlessDirectory<S: Storage<HistoryTreeNode<H, S>>, H: Hasher> {
-    azks: Azks<H, S>,
+pub struct SeemlessDirectory<S: Storage<StorageEnum<H, S>>, H: Hasher> {
+    azks_id: Vec<u8>,
     user_data: HashMap<Username, UserData>,
     current_epoch: u64,
     _s: PhantomData<S>,
     _h: PhantomData<H>,
 }
 
-impl<S: Storage<HistoryTreeNode<H, S>>, H: Hasher> SeemlessDirectory<S, H> {
+impl<S: Storage<StorageEnum<H, S>>, H: Hasher> SeemlessDirectory<S, H> {
     pub fn new() -> Result<Self, SeemlessError> {
         let mut rng: ThreadRng = thread_rng();
+        let azks = Azks::<H, S>::new(&mut rng)?;
+        let azks_id = azks.get_azks_id();
+        StorageEnum::write_data(IdEnum::AzksId(azks_id), StorageEnum::Azks(azks.clone()))?;
         Ok(SeemlessDirectory {
-            azks: Azks::<H, S>::new(&mut rng)?,
+            azks_id: azks_id.to_vec(),
             user_data: HashMap::<Username, UserData>::new(),
             current_epoch: 0,
             _s: PhantomData::<S>,
@@ -141,7 +147,10 @@ impl<S: Storage<HistoryTreeNode<H, S>>, H: Hasher> SeemlessDirectory<S, H> {
         let insertion_set = update_set.iter().map(|(x, y)| (*x, *y)).collect();
         // ideally the azks and the state would be updated together.
         // It may also make sense to have a temp version of the server's database
-        let output = self.azks.batch_insert_leaves(insertion_set);
+        let mut current_azks =
+            StorageEnum::<H, S>::to_azks(StorageEnum::read_data("azks", self.get_azks_id_enum()))?;
+        let output = current_azks.batch_insert_leaves(insertion_set);
+        StorageEnum::write_data(self.get_azks_id_enum(), StorageEnum::Azks(current_azks))?;
         // Not sure how to remove clones from here?
         user_data_update_set.iter_mut().for_each(|(x, y)| {
             self.user_data.insert(x.clone(), y.clone());
@@ -170,19 +179,20 @@ impl<S: Storage<HistoryTreeNode<H, S>>, H: Hasher> SeemlessDirectory<S, H> {
                 let latest_st = user_data_val.states.last().unwrap();
                 let plaintext_value = latest_st.plaintext_val.clone();
                 let current_version = latest_st.version;
-                let marker_version = Self::get_marker_version(current_version);
+                let marker_version = 1 << Self::get_marker_version(current_version);
                 let existent_label = Self::get_nodelabel(&uname, false, current_version);
                 let non_existent_label = Self::get_nodelabel(&uname, true, current_version);
                 let marker_label = Self::get_nodelabel(&uname, false, marker_version);
-                let existence_proof = self
-                    .azks
-                    .get_membership_proof(existent_label, self.current_epoch)?;
-                let freshness_proof = self
-                    .azks
+                let current_azks = StorageEnum::<H, S>::to_azks(StorageEnum::read_data(
+                    "azks",
+                    self.get_azks_id_enum(),
+                ))?;
+                let existence_proof =
+                    current_azks.get_membership_proof(existent_label, self.current_epoch)?;
+                let freshness_proof = current_azks
                     .get_non_membership_proof(non_existent_label, self.current_epoch)?;
-                let marker_proof = self
-                    .azks
-                    .get_membership_proof(marker_label, self.current_epoch)?;
+                let marker_proof =
+                    current_azks.get_membership_proof(marker_label, self.current_epoch)?;
                 Ok(LookupProof {
                     epoch: self.current_epoch,
                     plaintext_value,
@@ -204,51 +214,57 @@ impl<S: Storage<HistoryTreeNode<H, S>>, H: Hasher> SeemlessDirectory<S, H> {
         proof: LookupProof<H>,
     ) -> Result<(), SeemlessError> {
         let epoch = proof.epoch;
-        let root_node = self.azks.get_root_hash_at_epoch(epoch).unwrap();
-        // pub struct LookupProof<H: Hasher> {
-        //     plaintext_value: Values,
-        //     version: u64,
-        //     existence_proof: MembershipProof<H>,
-        //     marker_proof: MembershipProof<H>,
-        //     freshness_proof: NonMembershipProof<H>,
-        // }
+        let node = StorageEnum::<H, S>::to_node(StorageEnum::read_data(
+            "history_tree_node",
+            NodeLocation(self.get_azks_id(), 0),
+        ))?;
+        let root_node = node.get_value_at_epoch(epoch)?;
         let plaintext_value = proof.plaintext_value;
         let _curr_value = H::hash(&Self::value_to_bytes(&plaintext_value));
         let version = proof.version;
+
         let marker_version = 1 << Self::get_marker_version(version);
         let existence_proof = proof.existence_proof;
         let marker_proof = proof.marker_proof;
         let freshness_proof = proof.freshness_proof;
 
         let existence_label = Self::get_nodelabel(&uname, false, version);
-        assert!(existence_label != existence_proof.label);
+        if existence_label != existence_proof.label {
+            return Err(SeemlessError::SeemlessDirectoryErr(
+                SeemlessDirectoryError::LookupVerificationErr(
+                    "Existence proof label does not match computed label".to_string(),
+                ),
+            ));
+        }
         let non_existence_label = Self::get_nodelabel(&uname, true, version);
-        assert!(non_existence_label != freshness_proof.label);
+        if non_existence_label != freshness_proof.label {
+            return Err(SeemlessError::SeemlessDirectoryErr(
+                SeemlessDirectoryError::LookupVerificationErr(
+                    "Freshness proof label does not match computed label".to_string(),
+                ),
+            ));
+        }
         let marker_label = Self::get_nodelabel(&uname, false, marker_version);
-        assert!(marker_label != marker_proof.label);
+        if marker_label != marker_proof.label {
+            return Err(SeemlessError::SeemlessDirectoryErr(
+                SeemlessDirectoryError::LookupVerificationErr(
+                    "Marker proof label does not match computed label".to_string(),
+                ),
+            ));
+        }
+        let current_azks =
+            StorageEnum::<H, S>::to_azks(StorageEnum::read_data("azks", self.get_azks_id_enum()))?;
+        current_azks.verify_membership(root_node, epoch, existence_proof)?;
+        current_azks.verify_membership(root_node, epoch, marker_proof)?;
 
-        assert!(
-            self.azks
-                .verify_membership(root_node, epoch, existence_proof)?,
-            "Existence proof did not verify!"
-        );
-        assert!(
-            self.azks
-                .verify_membership(root_node, epoch, marker_proof)?,
-            "Marker proof did not verify!"
-        );
-        assert!(
-            self.azks.verify_nonmembership(
-                non_existence_label,
-                root_node,
-                epoch,
-                freshness_proof
-            )?,
-            "Freshness proof did not verify!"
-        );
+        current_azks.verify_nonmembership(
+            non_existence_label,
+            root_node,
+            epoch,
+            freshness_proof,
+        )?;
 
         Ok(())
-        // unimplemented!()
     }
 
     /// Takes in the current state of the server and a label.
@@ -316,18 +332,43 @@ impl<S: Storage<HistoryTreeNode<H, S>>, H: Hasher> SeemlessDirectory<S, H> {
     /// HELPERS ///
 
     #[allow(unused)]
+    fn get_azks_id_enum(&self) -> IdEnum {
+        IdEnum::AzksId(&self.azks_id)
+    }
+
+    #[allow(unused)]
+    fn get_azks_id(&self) -> &[u8] {
+        &self.azks_id
+    }
+
+    #[allow(unused)]
     fn username_to_nodelabel(_uname: &Username) -> NodeLabel {
         // this function will need to read the VRF key off some function
         unimplemented!()
     }
 
-    fn get_nodelabel(_uname: &Username, _stale: bool, _version: u64) -> NodeLabel {
-        // this function will need to read the VRF key off some function
-        unimplemented!()
+    fn get_nodelabel(uname: &Username, stale: bool, version: u64) -> NodeLabel {
+        // this function will need to read the VRF key using some function
+        let name_hash_bytes = H::hash(uname.0.as_bytes());
+        let mut stale_bytes = &[1u8];
+        if stale {
+            stale_bytes = &[0u8];
+        }
+
+        let hashed_label = H::merge(&[
+            name_hash_bytes,
+            H::merge_with_int(H::hash(stale_bytes), version),
+        ]);
+        let label_slice = hashed_label.as_ref();
+        // let (hashed_label_bytes_ref, _) = label_slice.split_at(std::mem::size_of::<u64>());
+        let hashed_label_bytes = convert_byte_slice_to_array(label_slice);
+        NodeLabel::new(u64::from_ne_bytes(hashed_label_bytes), 64u32)
+        // unimplemented!()
     }
 
     fn value_to_bytes(_value: &Values) -> [u8; 64] {
-        unimplemented!()
+        [0u8; 64]
+        // unimplemented!()
     }
 
     fn get_marker_version(version: u64) -> u64 {
@@ -346,9 +387,14 @@ impl<S: Storage<HistoryTreeNode<H, S>>, H: Hasher> SeemlessDirectory<S, H> {
         let label_at_ep = Self::get_nodelabel(uname, false, *version);
         let prev_label_at_ep = Self::get_nodelabel(uname, true, *version);
 
-        let existence_at_ep = self.azks.get_membership_proof(label_at_ep, epoch)?;
-        let previous_val_stale_at_ep = self.azks.get_membership_proof(prev_label_at_ep, epoch)?;
-        let non_existence_before_ep = self.azks.get_non_membership_proof(label_at_ep, epoch - 1)?;
+        let current_azks =
+            StorageEnum::<H, S>::to_azks(StorageEnum::read_data("azks", self.get_azks_id_enum()))?;
+
+        let existence_at_ep = current_azks.get_membership_proof(label_at_ep, epoch)?;
+        let previous_val_stale_at_ep =
+            current_azks.get_membership_proof(prev_label_at_ep, epoch)?;
+        let non_existence_before_ep =
+            current_azks.get_non_membership_proof(label_at_ep, epoch - 1)?;
 
         let next_marker = Self::get_marker_version(*version) + 1;
         let final_marker = Self::get_marker_version(epoch);
@@ -357,7 +403,8 @@ impl<S: Storage<HistoryTreeNode<H, S>>, H: Hasher> SeemlessDirectory<S, H> {
 
         for ver in version + 1..(1 << next_marker) {
             let label_for_ver = Self::get_nodelabel(uname, false, ver);
-            let non_existence_of_ver = self.azks.get_non_membership_proof(label_for_ver, epoch)?;
+            let non_existence_of_ver =
+                current_azks.get_non_membership_proof(label_for_ver, epoch)?;
             non_existence_of_next_few.push(non_existence_of_ver);
         }
 
@@ -366,7 +413,8 @@ impl<S: Storage<HistoryTreeNode<H, S>>, H: Hasher> SeemlessDirectory<S, H> {
         for marker_power in next_marker..final_marker + 1 {
             let ver = 1 << marker_power;
             let label_for_ver = Self::get_nodelabel(uname, false, ver);
-            let non_existence_of_ver = self.azks.get_non_membership_proof(label_for_ver, epoch)?;
+            let non_existence_of_ver =
+                current_azks.get_non_membership_proof(label_for_ver, epoch)?;
             non_existence_of_future_markers.push(non_existence_of_ver);
         }
 
@@ -395,8 +443,11 @@ impl<S: Storage<HistoryTreeNode<H, S>>, H: Hasher> SeemlessDirectory<S, H> {
         let existence_at_ep = proof.existence_at_ep;
         let previous_val_stale_at_ep = proof.previous_val_stale_at_ep;
 
+        let current_azks =
+            StorageEnum::<H, S>::to_azks(StorageEnum::read_data("azks", self.get_azks_id_enum()))?;
+
         let non_existence_before_ep = proof.non_existence_before_ep;
-        let root_hash = self.azks.get_root_hash_at_epoch(epoch)?;
+        let root_hash = current_azks.get_root_hash_at_epoch(epoch)?;
 
         if label_at_ep != existence_at_ep.label {
             return Err(SeemlessError::SeemlessDirectoryErr(
@@ -404,10 +455,7 @@ impl<S: Storage<HistoryTreeNode<H, S>>, H: Hasher> SeemlessDirectory<S, H> {
                     format!("Label of user {:?}'s version {:?} at epoch {:?} does not match the one in the proof",
                     uname, version, epoch))));
         }
-        if !self
-            .azks
-            .verify_membership(root_hash, epoch, existence_at_ep)?
-        {
+        if !current_azks.verify_membership(root_hash, epoch, existence_at_ep)? {
             return Err(SeemlessError::SeemlessDirectoryErr(
                 SeemlessDirectoryError::KeyHistoryVerificationErr(format!(
                     "Existence proof of user {:?}'s version {:?} at epoch {:?} does not verify",
@@ -416,10 +464,7 @@ impl<S: Storage<HistoryTreeNode<H, S>>, H: Hasher> SeemlessDirectory<S, H> {
             ));
         }
         // Edge case here! We need to account for version = 1 where the previous version won't have a proof.
-        if !self
-            .azks
-            .verify_membership(root_hash, epoch, previous_val_stale_at_ep)?
-        {
+        if !current_azks.verify_membership(root_hash, epoch, previous_val_stale_at_ep)? {
             return Err(SeemlessError::SeemlessDirectoryErr(
                 SeemlessDirectoryError::KeyHistoryVerificationErr(format!(
                     "Staleness proof of user {:?}'s version {:?} at epoch {:?} does not verify",
@@ -429,7 +474,7 @@ impl<S: Storage<HistoryTreeNode<H, S>>, H: Hasher> SeemlessDirectory<S, H> {
                 )),
             ));
         }
-        if !self.azks.verify_nonmembership(
+        if !current_azks.verify_nonmembership(
             label_at_ep,
             root_hash,
             epoch - 1,
@@ -459,6 +504,23 @@ impl<S: Storage<HistoryTreeNode<H, S>>, H: Hasher> SeemlessDirectory<S, H> {
     }
 }
 
+/// Helpers
+
+/// Converts a slice of u8 to an array of length 8. If the
+/// slice is not long enough, just pads with zeros.
+fn convert_byte_slice_to_array(slice: &[u8]) -> [u8; 8] {
+    let mut out_arr = [0u8; 8];
+    for (count, elt) in slice.iter().enumerate() {
+        if count < 8 {
+            out_arr[count] = *elt;
+        } else {
+            break;
+        }
+    }
+    out_arr
+    // unimplemented!()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -468,6 +530,7 @@ mod tests {
 
     // FIXME: #[test]
     #[allow(unused)]
+    #[test]
     fn test_simple_publish() -> Result<(), SeemlessError> {
         let mut seemless = SeemlessDirectory::<InMemoryDb, Blake3_256<BaseElement>>::new()?;
 
@@ -475,9 +538,22 @@ mod tests {
             Username("hello".to_string()),
             Values("world".to_string()),
         )])?;
+        // seemless.lookup(Username("hello".to_string()))?;
 
-        seemless.lookup(Username("hello".to_string()))?;
+        Ok(())
+    }
 
+    #[test]
+    fn test_simiple_lookup() -> Result<(), SeemlessError> {
+        let mut seemless = SeemlessDirectory::<InMemoryDb, Blake3_256<BaseElement>>::new()?;
+
+        seemless.publish(vec![
+            (Username("hello".to_string()), Values("world".to_string())),
+            (Username("hello2".to_string()), Values("world2".to_string())),
+        ])?;
+
+        let lookup_proof = seemless.lookup(Username("hello".to_string()))?;
+        seemless.lookup_verify(Username("hello".to_string()), lookup_proof)?;
         Ok(())
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -3,36 +3,146 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+use crate::append_only_zks::Azks;
 use crate::errors::StorageError;
 use crate::history_tree_node::HistoryTreeNode;
 use crate::node_state::HistoryNodeState;
 use crypto::Hasher;
+
+#[derive(Debug)]
+pub enum StorageEnum<H: Hasher, S: Storage<Self>> {
+    Node(HistoryTreeNode<H, S>),
+    Azks(Azks<H, S>),
+}
+
+pub enum IdEnum<'a> {
+    NodeLocation(&'a [u8], usize),
+    AzksId(&'a [u8]),
+}
+
+impl<H: Hasher, S: Storage<Self>> StorageEnum<H, S> {
+    pub(crate) fn read_data(data_type: &str, id: IdEnum) -> Result<Self, StorageError> {
+        match data_type {
+            "history_tree_node" => match id {
+                IdEnum::NodeLocation(azks_id, location) => {
+                    let k = format_node_key(azks_id, location);
+                    let retrieved = S::get(k)?;
+                    match retrieved {
+                        Self::Node(retrieved_node) => Ok(Self::Node(retrieved_node)),
+                        _ => Err(StorageError::WrongMemoryTypeError),
+                    }
+                }
+                _ => Err(StorageError::WrongIdTypeError),
+            },
+            "azks" => match id {
+                IdEnum::AzksId(azks_id) => {
+                    let k = format_azks_id_key(azks_id);
+                    let retrieved = S::get(k)?;
+                    match retrieved {
+                        Self::Azks(azks) => Ok(Self::Azks(azks)),
+                        _ => Err(StorageError::WrongMemoryTypeError),
+                    }
+                }
+                _ => Err(StorageError::WrongIdTypeError),
+            },
+            _ => Err(StorageError::UnsupportedStorageTypeError),
+        }
+    }
+    pub(crate) fn write_data(id: IdEnum, data: Self) -> Result<(), StorageError> {
+        match data {
+            Self::Node(node) => match id {
+                IdEnum::NodeLocation(azks_id, location) => {
+                    let k = format_node_key(azks_id, location);
+                    let _retrieved = S::set(k, Self::Node(node))?;
+                    Ok(())
+                }
+                _ => Err(StorageError::WrongIdTypeError),
+            },
+            Self::Azks(azks) => match id {
+                IdEnum::AzksId(azks_id) => {
+                    let k = format_azks_id_key(azks_id);
+                    let _retrieved = S::set(k, Self::Azks(azks))?;
+                    Ok(())
+                }
+                _ => Err(StorageError::WrongIdTypeError),
+            },
+        }
+    }
+
+    pub fn to_node(
+        acquired_data: Result<Self, StorageError>,
+    ) -> Result<HistoryTreeNode<H, S>, StorageError> {
+        match acquired_data {
+            Ok(Self::Node(node)) => Ok(node),
+            Err(e) => Err(e),
+            _ => Err(StorageError::WrongMemoryTypeError),
+        }
+    }
+
+    pub fn to_azks(acquired_data: Result<Self, StorageError>) -> Result<Azks<H, S>, StorageError> {
+        match acquired_data {
+            Ok(Self::Azks(azks)) => Ok(azks),
+            Err(e) => Err(e),
+            _ => Err(StorageError::WrongMemoryTypeError),
+        }
+    }
+}
+
+// impl<H: Hasher, S: Storage<StorageEnum<H, S>>> From<StorageEnum<H, S>> for HistoryTreeNode<H, S> {
+//     fn from(node: StorageEnum<H, S>) -> Self {
+//         StorageEnum::Node(node_val)
+
+//     }
+// }
+
+impl<H: Hasher, S: Storage<StorageEnum<H, S>>> Clone for StorageEnum<H, S> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Node(history_tree_node) => Self::Node(history_tree_node.clone()),
+            Self::Azks(azks) => Self::Azks(azks.clone()),
+        }
+    }
+}
 
 pub trait Storage<N> {
     fn set(pos: String, node: N) -> Result<(), StorageError>;
     fn get(pos: String) -> Result<N, StorageError>;
 }
 
-#[allow(unused)]
-pub(crate) fn set_node<H: Hasher, S: Storage<HistoryTreeNode<H, S>>>(
-    azks_id: &[u8],
-    location: usize,
-    val: HistoryTreeNode<H, S>,
-) -> Result<(), StorageError> {
-    let k = format!("azks_id: {}, location: {}", hex::encode(azks_id), location);
-    S::set(k, val)
-}
+// #[allow(unused)]
+// pub(crate) fn set_node<H: Hasher, S: Storage<StorageEnum<H, S>>>(
+//     azks_id: &[u8],
+//     location: usize,
+//     val: StorageEnum<H, S>,
+// ) -> Result<(), StorageError> {
+//     // let k = format!("azks_id: {}, location: {}", hex::encode(azks_id), location);
+//     let k = format_node_key(azks_id, location);
+//     S::set(k, val)
+// }
 
 #[allow(unused)]
-pub(crate) fn get_node<H: Hasher, S: Storage<HistoryTreeNode<H, S>>>(
+pub(crate) fn get_node<H: Hasher, S: Storage<StorageEnum<H, S>>>(
     azks_id: &[u8],
     location: usize,
-) -> Result<HistoryTreeNode<H, S>, StorageError> {
-    let k = format!("azks_id: {}, location: {}", hex::encode(azks_id), location);
+) -> Result<StorageEnum<H, S>, StorageError> {
+    // let k = format!("azks_id: {}, location: {}", hex::encode(azks_id), location);
+    let k = format_node_key(azks_id, location);
     S::get(k)
 }
 
-pub(crate) fn set_state_map<H: Hasher, S: Storage<HistoryTreeNode<H, S>>>(
+pub(crate) fn format_node_key(azks_id: &[u8], location: usize) -> String {
+    format!(
+        "HistoryTreeNode: azks_id: {}, location: {}",
+        hex::encode(azks_id),
+        location
+    )
+}
+
+pub(crate) fn format_azks_id_key(azks_id: &[u8]) -> String {
+    format!("AzksId: {}", hex::encode(azks_id))
+}
+
+pub(crate) fn set_state_map<H: Hasher, S: Storage<StorageEnum<H, S>>>(
     node: &mut HistoryTreeNode<H, S>,
     key: &u64,
     val: HistoryNodeState<H>,
@@ -41,7 +151,7 @@ pub(crate) fn set_state_map<H: Hasher, S: Storage<HistoryTreeNode<H, S>>>(
     Ok(())
 }
 
-pub(crate) fn get_state_map<H: Hasher, S: Storage<HistoryTreeNode<H, S>>>(
+pub(crate) fn get_state_map<H: Hasher, S: Storage<StorageEnum<H, S>>>(
     node: &HistoryTreeNode<H, S>,
     key: &u64,
 ) -> Result<HistoryNodeState<H>, StorageError> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -16,7 +16,7 @@ use crate::{
     history_tree_node::HistoryTreeNode,
     node_state::HistoryChildState,
     node_state::{hash_label, NodeLabel},
-    storage::Storage,
+    storage::{Storage, StorageEnum},
     *,
 };
 
@@ -27,28 +27,28 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 
 lazy_static! {
-    static ref HASHMAP: Mutex<HashMap<String, HistoryTreeNode<Blake3, InMemoryDb>>> = {
+    static ref HASHMAP: Mutex<HashMap<String, StorageEnum<Blake3, InMemoryDb>>> = {
         let m = HashMap::new();
         Mutex::new(m)
     };
 }
 
 #[derive(Debug)]
-pub(crate) struct InMemoryDb(HashMap<String, HistoryTreeNode<Blake3, InMemoryDb>>);
+pub(crate) struct InMemoryDb(HashMap<String, StorageEnum<Blake3, InMemoryDb>>);
 
-impl Storage<HistoryTreeNode<Blake3, InMemoryDb>> for InMemoryDb {
-    fn set(pos: String, node: HistoryTreeNode<Blake3, InMemoryDb>) -> Result<(), StorageError> {
+impl Storage<StorageEnum<Blake3, InMemoryDb>> for InMemoryDb {
+    fn set(pos: String, node: StorageEnum<Blake3, InMemoryDb>) -> Result<(), StorageError> {
         let mut hashmap = HASHMAP.lock().unwrap();
         hashmap.insert(pos, node);
         Ok(())
     }
 
-    fn get(pos: String) -> Result<HistoryTreeNode<Blake3, InMemoryDb>, StorageError> {
+    fn get(pos: String) -> Result<StorageEnum<Blake3, InMemoryDb>, StorageError> {
         let hashmap = HASHMAP.lock().unwrap();
-        hashmap
+        Ok(hashmap
             .get(&pos)
             .map(|v| v.clone())
-            .ok_or(StorageError::GetError)
+            .ok_or(StorageError::GetError)?)
     }
 }
 


### PR DESCRIPTION
Introduced a storageEnum, used to put azks and history tree nodes in storage, instead of as member variables.