### PR TITLE
Adding measurements example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,16 +9,14 @@ bench = []
 
 [dependencies]
 bincode = "1.3"
-crypto = { git  = "https://github.com/novifinancial/winterfell", package = "winter-crypto", branch = "main" }
-math = { git  = "https://github.com/novifinancial/winterfell", package = "winter-math", branch = "main" }
-winter-utils = { git  = "https://github.com/novifinancial/winterfell", package = "winter-utils", branch = "main" }
+winter-crypto = "0.1"
+winter-utils = "0.1"
+winter-math = "0.1"
 rand = "0.8"
 queues = "1.0.0"
 keyed_priority_queue = "0.3"
 hex = "0.4.2"
-backtrace = "0.3"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/benches/azks.rs
+++ b/benches/azks.rs
@@ -7,11 +7,11 @@
 extern crate criterion;
 
 use criterion::Criterion;
-use crypto::{hashers::Blake3_256, Hasher};
-use math::fields::f128::BaseElement;
 use rand::{prelude::ThreadRng, thread_rng, RngCore};
 use seemless::{append_only_zks::Azks, node_state::NodeLabel, storage::Storage};
 use std::time::{Duration, Instant};
+use winter_crypto::{hashers::Blake3_256, Hasher};
+use winter_math::fields::f128::BaseElement;
 
 type Blake3 = Blake3_256<BaseElement>;
 

--- a/examples/measurements.rs
+++ b/examples/measurements.rs
@@ -1,0 +1,126 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use rand::{prelude::ThreadRng, thread_rng, RngCore};
+use seemless::{append_only_zks::Azks, node_state::NodeLabel, storage::Storage};
+use winter_crypto::{hashers::Blake3_256, Hasher};
+use winter_math::fields::f128::BaseElement;
+
+type Blake3 = Blake3_256<BaseElement>;
+
+use lazy_static::lazy_static;
+use seemless::errors::StorageError;
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+lazy_static! {
+    static ref HASHMAP: Mutex<HashMap<String, String>> = {
+        let m = HashMap::new();
+        Mutex::new(m)
+    };
+    static ref STATS: Mutex<HashMap<String, usize>> = {
+        let m = HashMap::new();
+        Mutex::new(m)
+    };
+}
+
+#[derive(Debug)]
+pub(crate) struct InMemoryDb(HashMap<String, String>);
+
+impl Storage for InMemoryDb {
+    fn set(pos: String, value: String) -> Result<(), StorageError> {
+        let mut stats = STATS.lock().unwrap();
+        let calls_to_set = stats.entry(String::from("calls_to_set")).or_insert(0);
+        *calls_to_set += 1;
+
+        let mut hashmap = HASHMAP.lock().unwrap();
+        hashmap.insert(pos, value);
+
+        Ok(())
+    }
+
+    fn get(pos: String) -> Result<String, StorageError> {
+        let mut stats = STATS.lock().unwrap();
+        let calls_to_get = stats.entry(String::from("calls_to_get")).or_insert(0);
+        *calls_to_get += 1;
+
+        let hashmap = HASHMAP.lock().unwrap();
+        hashmap
+            .get(&pos)
+            .map(|v| v.clone())
+            .ok_or(StorageError::GetError)
+    }
+}
+
+fn clear_stats() {
+    let mut stats = STATS.lock().unwrap();
+    stats.clear();
+}
+
+fn print_stats() {
+    println!("Statistics collected:");
+    println!("---------------------");
+
+    let stats = STATS.lock().unwrap();
+    for (key, val) in stats.iter() {
+        println!("{}: {}", key, val);
+    }
+
+    println!("---------------------");
+}
+
+fn print_hashmap_distribution() {
+    println!("Hashmap distrubtion of length of entries (in bytes):");
+    println!("---------------------");
+
+    let hashmap = HASHMAP.lock().unwrap();
+
+    let mut distribution: HashMap<usize, usize> = HashMap::new();
+
+    for (_, val) in hashmap.iter() {
+        let len = val.len();
+
+        let counter = distribution.entry(len).or_insert(0);
+        *counter += 1;
+    }
+
+    let mut sorted_keys: Vec<usize> = distribution.keys().cloned().collect();
+    sorted_keys.sort();
+
+    for key in sorted_keys {
+        println!("{}: {}", key, distribution[&key]);
+    }
+    println!("---------------------");
+    println!("HashMap number of elements: {}", hashmap.len());
+    println!("---------------------");
+}
+
+fn main() {
+    let num_nodes = 200;
+
+    let mut rng: ThreadRng = thread_rng();
+
+    let mut azks1 = Azks::<Blake3, InMemoryDb>::new(&mut rng).unwrap();
+
+    for _ in 0..num_nodes {
+        let node = NodeLabel::random(&mut rng);
+        let mut input = [0u8; 32];
+        rng.fill_bytes(&mut input);
+        let val = Blake3::hash(&input);
+        azks1.insert_leaf(node, val).unwrap();
+    }
+
+    let node = NodeLabel::random(&mut rng);
+    let mut input = [0u8; 32];
+    rng.fill_bytes(&mut input);
+    let val = Blake3::hash(&input);
+
+    // Start measurement
+    clear_stats();
+    azks1.insert_leaf(node, val).unwrap();
+
+    print_hashmap_distribution();
+    print_stats();
+}

--- a/src/append_only_zks.rs
+++ b/src/append_only_zks.rs
@@ -13,9 +13,9 @@ use std::collections::HashMap;
 
 use crate::serialization::to_digest;
 use crate::{history_tree_node::HistoryTreeNode, node_state::*, ARITY, *};
-use crypto::Hasher;
 use rand::{rngs::OsRng, CryptoRng, RngCore};
 use std::marker::PhantomData;
+use winter_crypto::Hasher;
 
 use serde::{Deserialize, Serialize};
 
@@ -258,7 +258,6 @@ impl<H: Hasher, S: Storage> Azks<H, S> {
 
         let (longest_prefix_membership_proof, lcp_node_id) =
             self.get_membership_proof_and_node(label, epoch)?;
-
         let lcp_node =
             HistoryTreeNode::<H, S>::retrieve(NodeKey(self.azks_id.clone(), lcp_node_id))?;
         let longest_prefix = lcp_node.label;
@@ -268,7 +267,7 @@ impl<H: Hasher, S: Storage> Azks<H, S> {
         let children = state
             .child_states
             .iter()
-            .map(|x: &node_state::HistoryChildState<H>| -> Result<HistoryTreeNode<H, S>, HistoryTreeNodeError> {
+            .map(|x: &node_state::HistoryChildState<H, S>| -> Result<HistoryTreeNode<H, S>, HistoryTreeNodeError> {
                 let node = HistoryTreeNode::retrieve(NodeKey(self.azks_id.clone(), x.location))?;
                 Ok(node)
             });
@@ -554,12 +553,12 @@ type AppendOnlyHelper<D> = (Vec<(NodeLabel, D)>, Vec<(NodeLabel, D)>);
 mod tests {
     use super::*;
     use crate::tests::InMemoryDb;
-    use crypto::hashers::Blake3_256;
-    use math::fields::f128::BaseElement;
     use rand::{rngs::OsRng, seq::SliceRandom, RngCore};
+    use winter_crypto::hashers::Blake3_256;
+    use winter_math::fields::f128::BaseElement;
 
     type Blake3 = Blake3_256<BaseElement>;
-    type Blake3Digest = <Blake3_256<math::fields::f128::BaseElement> as Hasher>::Digest;
+    type Blake3Digest = <Blake3_256<winter_math::fields::f128::BaseElement> as Hasher>::Digest;
 
     #[test]
     fn test_batch_insert_basic() -> Result<(), SeemlessError> {

--- a/src/node_state.rs
+++ b/src/node_state.rs
@@ -3,18 +3,17 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+use crate::serialization::from_digest;
+use crate::storage::{Storable, Storage};
 use crate::{Direction, ARITY};
-use crypto::Hasher;
+use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
 use std::{
     convert::TryInto,
     fmt::{self, Debug},
 };
+use winter_crypto::Hasher;
 
-use crate::serialization::from_digest;
-use serde::{Deserialize, Serialize};
-use std::marker::PhantomData;
-
-#[cfg(any(test, feature = "bench"))]
 use rand::{CryptoRng, RngCore};
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
@@ -35,7 +34,6 @@ impl NodeLabel {
         self.val
     }
 
-    #[cfg(any(test, feature = "bench"))]
     /// Generate a random NodeLabel for testing purposes
     pub fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
         // FIXME: should we always select length-64 labels?
@@ -112,32 +110,44 @@ pub fn hash_label<H: Hasher>(label: NodeLabel) -> H::Digest {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct HistoryNodeState<H> {
+pub struct HistoryNodeState<H, S> {
     pub value: Vec<u8>,
-    pub child_states: Vec<HistoryChildState<H>>,
+    pub child_states: Vec<HistoryChildState<H, S>>,
 }
 
-impl<H: Hasher> HistoryNodeState<H> {
+// parameters are azks_id, node location, and epoch
+#[derive(Serialize, Deserialize)]
+pub struct NodeStateKey(pub(crate) Vec<u8>, pub(crate) usize, pub(crate) usize);
+
+impl<H: Hasher, S: Storage> Storable<S> for HistoryNodeState<H, S> {
+    type Key = NodeStateKey;
+
+    fn identifier() -> String {
+        String::from("HistoryNodeState")
+    }
+}
+
+impl<H: Hasher, S: Storage> HistoryNodeState<H, S> {
     pub fn new() -> Self {
-        let children = vec![HistoryChildState::<H>::new_dummy(); ARITY];
+        let children = vec![HistoryChildState::<H, S>::new_dummy(); ARITY];
         HistoryNodeState {
             value: from_digest::<H>(H::hash(&[0u8])).unwrap(),
             child_states: children,
         }
     }
 
-    pub fn get_child_state_in_dir(&self, dir: usize) -> HistoryChildState<H> {
+    pub fn get_child_state_in_dir(&self, dir: usize) -> HistoryChildState<H, S> {
         self.child_states[dir].clone()
     }
 }
 
-impl<H: Hasher> Default for HistoryNodeState<H> {
+impl<H: Hasher, S: Storage> Default for HistoryNodeState<H, S> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<H: Hasher> Clone for HistoryNodeState<H> {
+impl<H: Hasher, S: Storage> Clone for HistoryNodeState<H, S> {
     fn clone(&self) -> Self {
         Self {
             value: self.value.clone(),
@@ -148,7 +158,7 @@ impl<H: Hasher> Clone for HistoryNodeState<H> {
 
 // To use the `{}` marker, the trait `fmt::Display` must be implemented
 // manually for the type.
-impl<H: Hasher> fmt::Display for HistoryNodeState<H> {
+impl<H: Hasher, S: Storage> fmt::Display for HistoryNodeState<H, S> {
     // This trait requires `fmt` with this exact signature.
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "\tvalue = {:?}", self.value).unwrap();
@@ -165,16 +175,34 @@ pub enum DummyChildState {
     Real,
 }
 #[derive(Debug, Serialize, Deserialize)]
-pub struct HistoryChildState<H> {
+pub struct HistoryChildState<H, S> {
     pub dummy_marker: DummyChildState,
     pub location: usize,
     pub label: NodeLabel,
     pub hash_val: Vec<u8>,
     pub epoch_version: u64,
     pub(crate) _h: PhantomData<H>,
+    pub(crate) _s: PhantomData<S>,
 }
 
-impl<H: Hasher> HistoryChildState<H> {
+// parameters are azks_id, node location, epoch, child index
+#[derive(Serialize, Deserialize)]
+pub struct ChildStateKey(
+    pub(crate) Vec<u8>,
+    pub(crate) usize,
+    pub(crate) usize,
+    pub(crate) usize,
+);
+
+impl<H: Hasher, S: Storage> Storable<S> for HistoryChildState<H, S> {
+    type Key = ChildStateKey;
+
+    fn identifier() -> String {
+        String::from("HistoryChildState")
+    }
+}
+
+impl<H: Hasher, S: Storage> HistoryChildState<H, S> {
     pub fn new(loc: usize, label: NodeLabel, hash_val: H::Digest, ep: u64) -> Self {
         HistoryChildState {
             dummy_marker: DummyChildState::Real,
@@ -183,6 +211,7 @@ impl<H: Hasher> HistoryChildState<H> {
             hash_val: from_digest::<H>(hash_val).unwrap(),
             epoch_version: ep,
             _h: PhantomData,
+            _s: PhantomData,
         }
     }
 
@@ -194,11 +223,12 @@ impl<H: Hasher> HistoryChildState<H> {
             hash_val: from_digest::<H>(H::hash(&[0u8])).unwrap(),
             epoch_version: 0,
             _h: PhantomData,
+            _s: PhantomData,
         }
     }
 }
 
-impl<H: Hasher> Clone for HistoryChildState<H> {
+impl<H: Hasher, S: Storage> Clone for HistoryChildState<H, S> {
     fn clone(&self) -> Self {
         Self {
             dummy_marker: self.dummy_marker,
@@ -207,11 +237,12 @@ impl<H: Hasher> Clone for HistoryChildState<H> {
             hash_val: self.hash_val.clone(),
             epoch_version: self.epoch_version,
             _h: PhantomData,
+            _s: PhantomData,
         }
     }
 }
 
-impl<H: Hasher> PartialEq for HistoryChildState<H> {
+impl<H: Hasher, S: Storage> PartialEq for HistoryChildState<H, S> {
     fn eq(&self, other: &Self) -> bool {
         self.dummy_marker == other.dummy_marker
             && self.location == other.location
@@ -221,7 +252,7 @@ impl<H: Hasher> PartialEq for HistoryChildState<H> {
     }
 }
 
-impl<H: Hasher> fmt::Display for HistoryChildState<H> {
+impl<H: Hasher, S: Storage> fmt::Display for HistoryChildState<H, S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,

--- a/src/seemless_directory.rs
+++ b/src/seemless_directory.rs
@@ -8,10 +8,10 @@ use crate::errors::{SeemlessDirectoryError, SeemlessError};
 use crate::history_tree_node::{HistoryTreeNode, NodeKey};
 use crate::node_state::NodeLabel;
 use crate::storage::{Storable, Storage};
-use crypto::Hasher;
 use rand::{prelude::ThreadRng, thread_rng};
 use std::collections::HashMap;
 use std::marker::PhantomData;
+use winter_crypto::Hasher;
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct Username(String);
@@ -507,8 +507,8 @@ fn convert_byte_slice_to_array(slice: &[u8]) -> [u8; 8] {
 mod tests {
     use super::*;
     use crate::tests::InMemoryDb;
-    use crypto::hashers::Blake3_256;
-    use math::fields::f128::BaseElement;
+    use winter_crypto::hashers::Blake3_256;
+    use winter_math::fields::f128::BaseElement;
 
     // FIXME: #[test]
     #[allow(unused)]

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 use crate::errors::HistoryTreeNodeError;
-use crypto::Hasher;
+use winter_crypto::Hasher;
 use winter_utils::{Deserializable, Serializable, SliceReader};
 
 /// Converts from &[u8] to H::Digest

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -3,28 +3,13 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use crate::append_only_zks::Azks;
 use crate::errors::StorageError;
-use crate::history_tree_node::HistoryTreeNode;
-use crate::node_state::HistoryNodeState;
-use crypto::Hasher;
-
-#[derive(Debug)]
-pub enum StorageEnum<H, S> {
-    Node(HistoryTreeNode<H, S>),
-    Azks(Azks<H, S>),
-}
-
-pub enum IdEnum<'a> {
-    NodeLocation(&'a [u8], usize),
-    AzksId(&'a [u8]),
-}
-
 use serde::{de::DeserializeOwned, Serialize};
 
 pub trait Storable<S: Storage>: Serialize + DeserializeOwned {
     type Key: Serialize;
 
+    /// Must return a unique String identifier for this struct
     fn identifier() -> String;
 
     fn retrieve(key: Self::Key) -> Result<Self, StorageError> {
@@ -46,37 +31,7 @@ pub trait Storable<S: Storage>: Serialize + DeserializeOwned {
     }
 }
 
-impl<H: Hasher, S: Storage> Clone for StorageEnum<H, S> {
-    fn clone(&self) -> Self {
-        match self {
-            Self::Node(history_tree_node) => Self::Node(history_tree_node.clone()),
-            Self::Azks(azks) => Self::Azks(azks.clone()),
-        }
-    }
-}
-
 pub trait Storage {
     fn set(pos: String, val: String) -> Result<(), StorageError>;
     fn get(pos: String) -> Result<String, StorageError>;
-}
-
-pub(crate) fn set_state_map<H: Hasher, S: Storage>(
-    node: &mut HistoryTreeNode<H, S>,
-    key: &u64,
-    val: HistoryNodeState<H>,
-) -> Result<(), StorageError> {
-    node.state_map.insert(*key, val);
-    Ok(())
-}
-
-pub(crate) fn get_state_map<H: Hasher, S: Storage>(
-    node: &HistoryTreeNode<H, S>,
-    key: &u64,
-) -> Result<HistoryNodeState<H>, StorageError> {
-    let val = node.state_map.get(key);
-
-    match val {
-        Some(v) => Ok(v.clone()),
-        None => Err(StorageError::GetError),
-    }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5,8 +5,8 @@
 
 use std::convert::TryInto;
 
-use crypto::{hashers::Blake3_256, Hasher};
-use math::fields::f128::BaseElement;
+use winter_crypto::{hashers::Blake3_256, Hasher};
+use winter_math::fields::f128::BaseElement;
 
 type Blake3 = Blake3_256<BaseElement>;
 
@@ -17,7 +17,7 @@ use crate::{
     history_tree_node::HistoryTreeNode,
     node_state::HistoryChildState,
     node_state::{hash_label, NodeLabel},
-    storage::{Storage, StorageEnum},
+    storage::Storage,
     *,
 };
 
@@ -35,7 +35,7 @@ lazy_static! {
 }
 
 #[derive(Debug)]
-pub(crate) struct InMemoryDb(HashMap<String, StorageEnum<Blake3, InMemoryDb>>);
+pub(crate) struct InMemoryDb(HashMap<String, String>);
 
 impl Storage for InMemoryDb {
     fn set(pos: String, value: String) -> Result<(), StorageError> {
@@ -97,7 +97,7 @@ fn test_set_children_without_hash_at_root() -> Result<(), HistoryTreeNodeError> 
     let ep = 1;
     let child_hist_node_1 =
         HistoryChildState::new(1, NodeLabel::new(1, 1), Blake3::hash(&[0u8]), ep);
-    let child_hist_node_2: HistoryChildState<Blake3> =
+    let child_hist_node_2: HistoryChildState<Blake3, InMemoryDb> =
         HistoryChildState::new(2, NodeLabel::new(0, 1), Blake3::hash(&[0u8]), ep);
     assert!(
         root.set_child_without_hash(ep, &(Direction::Some(1), child_hist_node_1.clone()))
@@ -142,7 +142,7 @@ fn test_set_children_without_hash_multiple_at_root() -> Result<(), HistoryTreeNo
     let mut ep = 1;
     let child_hist_node_1 =
         HistoryChildState::new(1, NodeLabel::new(11, 2), Blake3::hash(&[0u8]), ep);
-    let child_hist_node_2: HistoryChildState<Blake3> =
+    let child_hist_node_2: HistoryChildState<Blake3, InMemoryDb> =
         HistoryChildState::new(2, NodeLabel::new(00, 2), Blake3::hash(&[0u8]), ep);
     assert!(
         root.set_child_without_hash(ep, &(Direction::Some(1), child_hist_node_1))
@@ -157,9 +157,9 @@ fn test_set_children_without_hash_multiple_at_root() -> Result<(), HistoryTreeNo
 
     ep = 2;
 
-    let child_hist_node_3: HistoryChildState<Blake3> =
+    let child_hist_node_3: HistoryChildState<Blake3, InMemoryDb> =
         HistoryChildState::new(1, NodeLabel::new(1, 1), Blake3::hash(&[0u8]), ep);
-    let child_hist_node_4: HistoryChildState<Blake3> =
+    let child_hist_node_4: HistoryChildState<Blake3, InMemoryDb> =
         HistoryChildState::new(2, NodeLabel::new(0, 1), Blake3::hash(&[0u8]), ep);
     assert!(
         root.set_child_without_hash(ep, &(Direction::Some(1), child_hist_node_3.clone()))
@@ -204,7 +204,7 @@ fn test_get_child_at_existing_epoch_multiple_at_root() -> Result<(), HistoryTree
     let mut ep = 1;
     let child_hist_node_1 =
         HistoryChildState::new(1, NodeLabel::new(11, 2), Blake3::hash(&[0u8]), ep);
-    let child_hist_node_2: HistoryChildState<Blake3> =
+    let child_hist_node_2: HistoryChildState<Blake3, InMemoryDb> =
         HistoryChildState::new(2, NodeLabel::new(00, 2), Blake3::hash(&[0u8]), ep);
     assert!(
         root.set_child_without_hash(ep, &(Direction::Some(1), child_hist_node_1.clone()))
@@ -219,9 +219,9 @@ fn test_get_child_at_existing_epoch_multiple_at_root() -> Result<(), HistoryTree
 
     ep = 2;
 
-    let child_hist_node_3: HistoryChildState<Blake3> =
+    let child_hist_node_3: HistoryChildState<Blake3, InMemoryDb> =
         HistoryChildState::new(1, NodeLabel::new(1, 1), Blake3::hash(&[0u8]), ep);
-    let child_hist_node_4: HistoryChildState<Blake3> =
+    let child_hist_node_4: HistoryChildState<Blake3, InMemoryDb> =
         HistoryChildState::new(2, NodeLabel::new(0, 1), Blake3::hash(&[0u8]), ep);
     assert!(
         root.set_child_without_hash(ep, &(Direction::Some(1), child_hist_node_3.clone()))
@@ -272,7 +272,7 @@ pub fn test_get_child_at_epoch_at_root() -> Result<(), HistoryTreeNodeError> {
             Blake3::hash(&[0u8]),
             2 * ep,
         );
-        let child_hist_node_2: HistoryChildState<Blake3> = HistoryChildState::new(
+        let child_hist_node_2: HistoryChildState<Blake3, InMemoryDb> = HistoryChildState::new(
             ep.try_into().unwrap(),
             NodeLabel::new(0, ep.clone().try_into().unwrap()),
             Blake3::hash(&[0u8]),
@@ -301,7 +301,7 @@ pub fn test_get_child_at_epoch_at_root() -> Result<(), HistoryTreeNodeError> {
         Blake3::hash(&[0u8]),
         2 * ep_existing,
     );
-    let child_hist_node_2: HistoryChildState<Blake3> = HistoryChildState::new(
+    let child_hist_node_2: HistoryChildState<Blake3, InMemoryDb> = HistoryChildState::new(
         0,
         NodeLabel::new(0, ep_existing.clone().try_into().unwrap()),
         Blake3::hash(&[0u8]),


### PR DESCRIPTION
This will measure how many times the storage module is called. Can be run with:

cargo run --example measurements

Current output:

```
Hashmap distrubtion of length of entries (in bytes):
---------------------
592: 272
992: 13
1008: 27
1392: 3
1408: 6
1424: 14
1808: 1
1824: 3
1840: 5
2208: 2
2240: 2
2256: 5
2656: 1
2672: 5
3040: 1
3056: 3
3072: 2
3088: 7
3504: 1
3872: 1
3904: 1
4336: 2
4752: 4
5584: 1
6416: 2
6816: 1
7248: 1
8080: 1
8912: 2
9328: 1
10160: 1
10976: 1
11824: 2
17232: 1
19728: 1
20976: 1
23888: 1
38864: 1
44272: 1
84208: 1
---------------------
HashMap number of elements: 401
---------------------
Statistics collected:
---------------------
calls_to_get: 6
calls_to_set: 8
---------------------
```