### PR TITLE
MySql driver w/test bed (requires starting docker container db)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.3'
+
+# Use root/example as user/password credentials
+services:
+  db:
+    container_name: seemless-test-db
+    image: mysql
+    command: --default-authentication-plugin=mysql_native_password
+    restart: unless-stopped
+    ports:
+      - "8001:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: example
+      MYSQL_DATABASE: default


### PR DESCRIPTION
Start the test db with ```docker compose up``` assuming docker is installed

The test bench will determine if the container is running via a system call to check the docker output of the running containers. See ```MySqlDatabase::test_guard()```