### PR TITLE
Adding AKD audit quorum general structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
       - main
   pull_request:
     types: [opened, repoened, synchronize]
-
 jobs:
   test:
     name: Test Rust ${{matrix.toolchain}} on ${{matrix.os}}
@@ -34,6 +33,8 @@ jobs:
           echo "MySQL container is up"
       - name: Check container akd-test-db logs
         run: docker logs akd-test-db
+      - name: Setup protoc
+        uses: arduino/setup-protoc@v1.1.2
       - name: Test
         uses: actions-rs/cargo@v1
         with:
@@ -52,7 +53,6 @@ jobs:
         with:
           command: test
           args: --package akd_client --no-default-features --features wasm,blake3
-
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
@@ -65,13 +65,13 @@ jobs:
           toolchain: stable
           components: clippy
           override: true
-
+      - name: Setup protoc
+        uses: arduino/setup-protoc@v1.1.2
       - name: Clippy
         uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: --all -- -D clippy::all -D warnings
-
   rustfmt:
     name: rustfmt
     runs-on: ubuntu-latest
@@ -84,9 +84,7 @@ jobs:
           toolchain: stable
           components: rustfmt
           override: true
-
       - name: rustfmt
         uses: actions-rs/cargo@v1
         with:
           command: fmt
-          args: --all -- --check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,9 @@ jobs:
     - uses: hecrj/setup-rust-action@v1
       with:
         rust-version: ${{ matrix.rust }}
-    - uses: actions/checkout@master
+    - name: Setup protoc
+      uses: arduino/setup-protoc@v1.1.2
+    - uses: actions/checkout@main
     - name: Login to crates.io
       run: cargo login $CRATES_IO_TOKEN
       env:
@@ -38,5 +40,11 @@ jobs:
       run: cargo publish --dry-run --manifest-path Cargo.toml -p akd_client
     - name: Publish crate akd_client
       run: cargo publish --manifest-path Cargo.toml -p akd_client
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}
+    - name: Dry run publish AKD_AUDIT_QUORUM
+      run: cargo publish --dry-run --manifest-path Cargo.toml -p akd_audit_quorum
+    - name: Publish crate akd_audit_quorum
+      run: cargo publish --manifest-path Cargo.toml -p akd_auditor_quorum
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,6 @@ members = [
     "akd_mysql",
     "poc",
     "integration_tests",
-    "akd_client"
+    "akd_client",
+    "akd_audit_quorum",
 ]

--- a/akd/src/node_state.rs
+++ b/akd/src/node_state.rs
@@ -381,6 +381,7 @@ mod tests {
     #[test]
     pub fn test_node_label_equal_leading_zero() {
         let label_1 = NodeLabel::new(10000000u64, 9u32);
+        #[allow(clippy::zero_prefixed_literal)]
         let label_2 = NodeLabel::new(010000000u64, 9u32);
         assert!(
             label_1 == label_2,

--- a/akd/src/tests.rs
+++ b/akd/src/tests.rs
@@ -289,10 +289,7 @@ pub async fn test_get_child_at_epoch_at_root() -> Result<(), HistoryTreeNodeErro
     let ep_existing = 0u64;
 
     let child_hist_node_1 = HistoryChildState::new::<Blake3>(
-        NodeLabel::new(
-            0b1u64 << ep_existing,
-            ep_existing.try_into().unwrap(),
-        ),
+        NodeLabel::new(0b1u64 << ep_existing, ep_existing.try_into().unwrap()),
         Blake3::hash(&[0u8]),
         2 * ep_existing,
     )

--- a/akd/src/tests.rs
+++ b/akd/src/tests.rs
@@ -268,13 +268,13 @@ pub async fn test_get_child_at_epoch_at_root() -> Result<(), HistoryTreeNodeErro
 
     for ep in 0..3 {
         let child_hist_node_1 = HistoryChildState::new::<Blake3>(
-            NodeLabel::new(0b1u64 << ep.clone(), ep.try_into().unwrap()),
+            NodeLabel::new(0b1u64 << ep, ep.try_into().unwrap()),
             Blake3::hash(&[0u8]),
             2 * ep,
         )
         .unwrap();
         let child_hist_node_2: HistoryChildState = HistoryChildState::new::<Blake3>(
-            NodeLabel::new(0, ep.clone().try_into().unwrap()),
+            NodeLabel::new(0, ep.try_into().unwrap()),
             Blake3::hash(&[0u8]),
             2 * ep,
         )
@@ -290,7 +290,7 @@ pub async fn test_get_child_at_epoch_at_root() -> Result<(), HistoryTreeNodeErro
 
     let child_hist_node_1 = HistoryChildState::new::<Blake3>(
         NodeLabel::new(
-            0b1u64 << ep_existing.clone(),
+            0b1u64 << ep_existing,
             ep_existing.try_into().unwrap(),
         ),
         Blake3::hash(&[0u8]),
@@ -298,7 +298,7 @@ pub async fn test_get_child_at_epoch_at_root() -> Result<(), HistoryTreeNodeErro
     )
     .unwrap();
     let child_hist_node_2: HistoryChildState = HistoryChildState::new::<Blake3>(
-        NodeLabel::new(0, ep_existing.clone().try_into().unwrap()),
+        NodeLabel::new(0, ep_existing.try_into().unwrap()),
         Blake3::hash(&[0u8]),
         2 * ep_existing,
     )
@@ -596,7 +596,7 @@ async fn test_insert_single_leaf_full_tree() -> Result<(), HistoryTreeNodeError>
     for i in 0u64..8u64 {
         let new_leaf = get_leaf_node::<Blake3, _>(
             &db,
-            NodeLabel::new(i.clone(), 3u32),
+            NodeLabel::new(i, 3u32),
             &i.to_ne_bytes(),
             NodeLabel::root(),
             7 - i,

--- a/akd_audit_quorum/Cargo.toml
+++ b/akd_audit_quorum/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "akd_audit_quorum"
+version = "0.4.0"
+authors = ["Sean Lawlor <seanlawlor@fb.com>", "Kevin Lewi <klewi@fb.com>"]
+description = "Validation of a key directory's latest epoch using a quorum of members which validate the append-only nature of the AKD"
+license = "MIT OR Apache-2.0"
+edition = "2018"
+keywords = ["key-transparency", "akd", "akd-validation"]
+repository = "https://github.com/novifinancial/akd"
+build = "src/build.rs"
+
+[dependencies]
+winter-crypto = "0.2"
+winter-utils = "0.2"
+winter-math = "0.2"
+akd = { path = "../akd", version = "^0.4.0" }
+log = { version = "0.4.8", features = ["kv_unstable"] }
+rand = "0.8"
+serde = { version = "1", features = ["derive"] }
+async-trait = "0.1"
+tokio = { version = "1.10", features = ["full"] }
+async-recursion = "0.3"
+once_cell = "1"
+protobuf = "=2.8.1"
+itertools = "0.10.3"
+futures = { version = "0.3.13", features = ["async-await", "compat"] }
+
+shamirsecretsharing = "0.1"
+
+[build-dependencies]
+protoc = "=2.8.1"
+protoc-rust = "=2.8.1"
+
+[dev-dependencies]
+serial_test = "0.5"

--- a/akd_audit_quorum/README.MD
+++ b/akd_audit_quorum/README.MD
@@ -1,0 +1,54 @@
+## akd ![Build Status](https://github.com/novifinancial/akd/workflows/CI/badge.svg)
+
+An implementation of a distributed auditor for the auditable key directory (also known as a verifiable registry).
+
+Auditable key directories can be used to help provide key transparency for end-to-end encrypted
+messaging.
+
+This implementation is based off of the protocol described in
+[SEEMless: Secure End-to-End Encrypted Messaging with less trust](https://eprint.iacr.org/2018/607).
+
+This library is the distributed, shard-based proof signature on the epoch and the changes which have been published in that
+epoch.
+
+### Purpose
+
+To prevent a split-view attack the root hash of every epoch needs to have a signature signed by a private key which cannot be leaked
+from the quorum (via shared-secret methodology). This quorum participates to independently validate the append-only proof of the
+key directory and each one provides their partial shard of the quorum signing key and when enough participants agree, the changes
+are signed off on and stored in stable storage. That way only a proof only needs to give the root hash, and the signature on it to acertain
+the quorum has agreed on the changes, and the AKD (or any other 3rd party) cannot generate its own signatures.
+
+⚠️ **Warning**: This implementation has not been audited and is not ready for a production application. Use at your own risk!
+
+Documentation
+-------------
+
+The API can be found [here](https://docs.rs/akd_audit_quorum/) along with an example for usage.
+
+Installation
+------------
+
+Add the following line to the dependencies of your `Cargo.toml`:
+
+```
+akd_audit_quorum = "0.4"
+```
+
+### Minimum Supported Rust Version
+
+Rust **1.51** or higher.
+
+Contributors
+------------
+
+The authors of this code are
+Sean Lawlor ([@slawlor](https://github.com/slawlor)), and
+Kevin Lewi ([@kevinlewi](https://github.com/kevinlewi)).
+
+To learn more about contributing to this project, [see this document](https://github.com/novifinancial/akd/blob/main/CONTRIBUTING.md).
+
+License
+-------
+
+This project is licensed under either [Apache 2.0](https://github.com/novifinancial/akd/blob/main/LICENSE-APACHE) or [MIT](https://github.com/novifinancial/akd/blob/main/LICENSE-MIT), at your option.

--- a/akd_audit_quorum/src/build.rs
+++ b/akd_audit_quorum/src/build.rs
@@ -1,0 +1,45 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree and the Apache
+// License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+// of this source tree.
+
+//! This is the pre-compilation build script for the crate akd_audit_quorum.
+//! Mainly it'll used to compile protobuf files into rust code prior to compilation.
+
+// NOTE: build.rs documentation = https://doc.rust-lang.org/cargo/reference/build-scripts.html
+
+extern crate protoc_rust;
+
+/// The list of protobuf files to generate
+/// e.g.: "src/proto/inter-node"
+const PROTOBUF_FILES: Vec<&str> = vec![];
+
+fn build_protobuf(file: &str) {
+    // Tell Cargo that if the given files change, rerun this build script
+    let proto_file = format!("{}.proto", file);
+    println!("cargo:rerun-if-changed={}.rs", file);
+    println!("cargo:rerun-if-changed={}.proto", file);
+
+    // compile the file
+    protoc_rust::run(protoc_rust::Args {
+        out_dir: "src/proto",
+        input: &[&proto_file],
+        includes: &[],
+        customize: protoc_rust::Customize {
+            ..Default::default()
+        },
+    })
+    .expect("protoc");
+}
+
+fn build_protobufs() {
+    for file in PROTOBUF_FILES.iter() {
+        build_protobuf(file);
+    }
+}
+
+fn main() {
+    build_protobufs();
+}

--- a/akd_audit_quorum/src/comms/mod.rs
+++ b/akd_audit_quorum/src/comms/mod.rs
@@ -1,0 +1,139 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree and the Apache
+// License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+// of this source tree.
+
+//! This module contains communication paths for various node-node and node-proxy communications
+
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::oneshot::Sender;
+
+pub mod nonces;
+
+// =====================================================
+// Types and constants
+// =====================================================
+
+/// The id of this node in the quorum members
+pub(crate) type NodeId = u64;
+/// Nonce for inter-node messages to prevent replay attacks.
+pub(crate) type Nonce = u128;
+
+// =====================================================
+// Structs w/implementations
+// =====================================================
+
+/// Contact information for a node
+#[derive(Clone, PartialEq)]
+pub struct ContactInformation {
+    /// Node ip address
+    pub ip_address: String,
+    /// Node port
+    pub port: u16,
+}
+
+impl Display for ContactInformation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.ip_address, self.port)
+    }
+}
+/// An encrypted inter-node message
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct EncryptedMessage {
+    /// Which node is the intended target
+    pub to: NodeId,
+    /// Which node is the sender
+    pub from: NodeId,
+    /// Encrypted payload with embedded nonce
+    pub encrypted_message_with_nonce: Vec<u8>,
+}
+
+/// Represents a communication error
+#[derive(Debug, PartialEq)]
+pub enum CommunicationError {
+    /// An error occurred sending the message over the communication channel
+    SendError(String),
+    /// An error occurred receiving a message over the communication channel
+    ReceiveError(String),
+    /// An error occurred processing a nonce
+    NonceError(NodeId, Nonce, String),
+    /// A serialization error occurred
+    Serialization(String),
+    /// Message reception timeout
+    Timeout,
+}
+
+impl From<protobuf::ProtobufError> for CommunicationError {
+    fn from(pe: protobuf::ProtobufError) -> Self {
+        Self::Serialization(format!("Protobuf serialization error\n{}", pe))
+    }
+}
+
+/// Represents a result to an message processing
+pub enum MessageProcessingResult {
+    /// Result, with optional payload to send to client
+    Ok(Option<EncryptedMessage>),
+    /// Error occurred
+    Error(String),
+    /// Timeout
+    Timeout,
+}
+
+/// Represents a message received by this node
+pub struct MessageResult {
+    /// The received message
+    pub message: EncryptedMessage,
+    /// Optional handling timeout
+    pub timeout: Option<tokio::time::Duration>,
+    /// Reply (RPC) channel
+    pub reply: Sender<MessageProcessingResult>,
+}
+
+// =====================================================
+// Trait definitions
+// =====================================================
+
+/// Represents a quorum member _reliable_ inter-node communication channel. It is
+/// critical that these calls only fail in the face of _real_ failure, meaning that
+/// they implement retries with exponential backoff internally when attempting inter-node
+/// communications.
+#[async_trait::async_trait]
+pub trait QuorumCommunication<H>: Send + Sync + Clone
+where
+    H: winter_crypto::Hasher,
+{
+    /// A call to send a message to a quorum member node, with an optional reply
+    /// when on the same tcp channel.
+    async fn send_and_maybe_receive(
+        &self,
+        message: EncryptedMessage,
+        timeout: Option<tokio::time::Duration>,
+    ) -> Result<Option<EncryptedMessage>, CommunicationError>;
+
+    /// Blocking receive call which waits for messages coming from other raft nodes
+    async fn receive_inter_node(
+        &self,
+        timeout_ms: u64,
+    ) -> Result<MessageResult, CommunicationError>;
+
+    /// Send a message to not a node id, but the specified contact information. This is
+    /// utilized for testing new potential members of the quorum and is a blocking call
+    /// waiting on the result to come back
+    async fn send_to_contact_info(
+        &self,
+        contact_info: ContactInformation,
+        message: EncryptedMessage,
+        timeout_ms: u64,
+    ) -> Result<EncryptedMessage, CommunicationError>;
+
+    // /// Blocking receive call which waits for messages coming from the public communication channel
+    // /// (i.e. messages from admin interface or AKD)
+    // async fn receive_public(
+    //     &self,
+    //     timeout_ms: u64,
+    // ) -> Result<crate::node::messages::PublicNodeMessage<H>, CommunicationError>;
+}

--- a/akd_audit_quorum/src/comms/nonces.rs
+++ b/akd_audit_quorum/src/comms/nonces.rs
@@ -24,6 +24,12 @@ pub struct NonceManager {
     incoming: Arc<RwLock<HashMap<NodeId, Nonce>>>,
 }
 
+impl Default for NonceManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl NonceManager {
     /// Create a new nonce manager instance
     pub fn new() -> Self {

--- a/akd_audit_quorum/src/comms/nonces.rs
+++ b/akd_audit_quorum/src/comms/nonces.rs
@@ -74,6 +74,13 @@ impl NonceManager {
                     from, nonce, expected
                 ),
             );
+
+            // reject this message but additionaly reset the nonce to what was received + 1. This handles when
+            // nodes restart or get corrupted and nonces may legitimately drift apart. In the event
+            // that a reply attack occurs, we're rejecting the message anyways if the nonce doesn't match
+            // what's expected so it's still protected.
+            self.incoming.write().await.insert(from, nonce + 1);
+
             Err(err)
         }
     }

--- a/akd_audit_quorum/src/comms/nonces.rs
+++ b/akd_audit_quorum/src/comms/nonces.rs
@@ -1,0 +1,89 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree and the Apache
+// License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+// of this source tree.
+
+//! This module provides management for message nonces (incoming & outgoing).
+//!
+//! The purpose of managing nonces is to protect against replay attacks in inter-node
+//! messages. The [`NonceManager`] manages both _expected_ incoming nonces from nodes
+//! and the outgoing nonces for messages being sent to nodes.
+
+use super::{NodeId, Nonce};
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Manages the state of incoming & outgoing "nonces" per-node,
+/// which are effectively message counts to/from each node
+pub struct NonceManager {
+    outgoing: Arc<RwLock<HashMap<NodeId, Nonce>>>,
+    incoming: Arc<RwLock<HashMap<NodeId, Nonce>>>,
+}
+
+impl NonceManager {
+    /// Create a new nonce manager instance
+    pub fn new() -> Self {
+        Self {
+            outgoing: Arc::new(RwLock::new(HashMap::new())),
+            incoming: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Retrieve the "next" nonce for message send, will auto-increment the nonce
+    /// mapping
+    pub async fn get_next_outgoing_nonce(&self, to: NodeId) -> Nonce {
+        let mut guard = self.outgoing.write().await;
+        let next = guard.get(&to).map_or(0, |a| *a + 1);
+        // safe the updated nonce
+        guard.insert(to, next);
+        next
+    }
+
+    /// Validate the incoming nonce from the specified node
+    pub async fn validate_nonce(
+        &self,
+        from: NodeId,
+        nonce: Nonce,
+    ) -> Result<(), crate::comms::CommunicationError> {
+        if from == u64::MAX {
+            // special case for new-node test's
+            return Ok(());
+        }
+
+        let expected = self.get_expected_nonce(from).await;
+
+        if nonce == expected {
+            self.incoming.write().await.insert(from, expected + 1);
+            Ok(())
+        } else {
+            let err = crate::comms::CommunicationError::NonceError(
+                from,
+                nonce,
+                format!(
+                    "Nonce mismatch in raft inter-messages: Node {}, Nonce: {}, Expected Nonce: {}",
+                    from, nonce, expected
+                ),
+            );
+            Err(err)
+        }
+    }
+
+    async fn get_expected_nonce(&self, from: NodeId) -> Nonce {
+        self.incoming.read().await.get(&from).map_or(0, |v| *v)
+    }
+}
+
+unsafe impl Sync for NonceManager {}
+unsafe impl Send for NonceManager {}
+impl Clone for NonceManager {
+    fn clone(&self) -> Self {
+        Self {
+            outgoing: self.outgoing.clone(),
+            incoming: self.incoming.clone(),
+        }
+    }
+}

--- a/akd_audit_quorum/src/crypto/mod.rs
+++ b/akd_audit_quorum/src/crypto/mod.rs
@@ -107,6 +107,7 @@ impl QuorumKeyShard {
     /// Flatten the crypto shard into a single array of the components in-order
     pub fn flatten(&self) -> [u8; SHARE_SIZE * QUORUM_KEY_NUM_PARTS] {
         let mut data = [0u8; SHARE_SIZE * QUORUM_KEY_NUM_PARTS];
+        #[allow(clippy::needless_range_loop)]
         for part_i in 0..QUORUM_KEY_NUM_PARTS {
             let start = part_i * SHARE_SIZE;
             let end = (part_i + 1) * SHARE_SIZE;
@@ -120,7 +121,7 @@ impl QuorumKeyShard {
         raw: [u8; SHARE_SIZE * QUORUM_KEY_NUM_PARTS],
     ) -> Result<Self, QuorumOperationError> {
         let mut components = [[0u8; SHARE_SIZE]; QUORUM_KEY_NUM_PARTS];
-
+        #[allow(clippy::needless_range_loop)]
         for part_i in 0..QUORUM_KEY_NUM_PARTS {
             let start = part_i * SHARE_SIZE;
             let end = (part_i + 1) * SHARE_SIZE;

--- a/akd_audit_quorum/src/crypto/mod.rs
+++ b/akd_audit_quorum/src/crypto/mod.rs
@@ -1,0 +1,308 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree and the Apache
+// License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+// of this source tree.
+
+//! This module contains the cryptographic operations which need to be
+//! performed, including storage & retrieval of private cryptographic operations.
+//!
+//! It also provides functionality to manage "shards" of the cryptographic secret,
+//! i.e. the signing key. Shamir secret sharing is presently used with the imported
+//! crate, however there are alternatives we could attempt to visit in the future (
+//! see note below).
+//!
+//! NOTE: Instead of Shamir secret sharing, we may want to look into
+//! threshold signatures (e.g. https://github.com/poanetwork/threshold_crypto)
+//! which will avoid the need to ever reconstruct the private key while maintaining
+//! a public key which can be used to verify the signatures from a consensus of the network
+//! HOWEVER if we remain within a secure context when reconstructing the shards and generating
+//! the signed commitment, then we should be safe from exploit. Moving to a public
+//! participation might require an adjustment to this.
+//!
+//! Additionally it is unclear if threshold signatures can be adjusted after they are
+//! initially created. Which is a requirement for mutation of the quorum set.
+
+use crate::comms::{NodeId, Nonce};
+use crate::storage::QuorumCommitment;
+use crate::QuorumOperationError;
+
+use async_trait::async_trait;
+use shamirsecretsharing::{combine_shares, create_shares, DATA_SIZE, SHARE_SIZE};
+use std::convert::TryInto;
+use winter_crypto::Hasher;
+
+#[cfg(test)]
+mod tests;
+
+// =====================================================
+// Consts and Typedefs
+// =====================================================
+
+/// The multiplicitave factor of DATA_SIZE which denotes the size of the
+/// quorum key. Probably should be a factor of 2
+pub(crate) const QUORUM_KEY_NUM_PARTS: usize = 8;
+
+/// The size of the quorum key private key in bytes.
+/// NOTE: SSS's DATA_SIZE = 64 bytes, which the quorum key private key
+/// need to be a multiple of
+pub const QUORUM_KEY_SIZE: usize = QUORUM_KEY_NUM_PARTS * DATA_SIZE;
+
+/// A component of a specific shard
+type ShardComponent = Vec<u8>;
+/// A shard, which is a collection of components of a shard in order
+type Shard = Vec<ShardComponent>;
+
+// =====================================================
+// Structs
+// =====================================================
+
+/// Represents the node's "shard" of the secret quorum's private
+/// signing key. A single shard cannot be utilized to reconstruct the
+/// full quorum key.
+///
+/// Due to limitations of the Shamir's Secret Sharing lib, we are constrained
+/// to break the secret information into batches of DATA_SIZE _exactly_ to generate
+/// the shards. This means that to support a key bigger than DATA_SIZE, we need to
+/// have multiple shards for each slice of the secret information.
+#[derive(PartialEq, Debug)]
+pub struct QuorumKeyShard {
+    pub(crate) components: [[u8; SHARE_SIZE]; QUORUM_KEY_NUM_PARTS],
+}
+
+impl Clone for QuorumKeyShard {
+    fn clone(&self) -> Self {
+        Self {
+            components: self.components,
+        }
+    }
+}
+
+impl QuorumKeyShard {
+    pub(crate) fn build_from_vec_vec_vec(
+        data: Vec<Shard>,
+    ) -> Result<Vec<Self>, QuorumOperationError> {
+        let mut results = vec![];
+
+        for shards in data.into_iter() {
+            let mut formatted_shards: Vec<[u8; SHARE_SIZE]> = vec![];
+            for shard in shards.into_iter() {
+                formatted_shards.push(shard.try_into().map_err(|_| {
+                    QuorumOperationError::Sharding(format!(
+                        "Unable to convert shard vec into array of len {}",
+                        DATA_SIZE
+                    ))
+                })?)
+            }
+            let formatted_shard = Self {
+                components: formatted_shards.try_into().map_err(|_| QuorumOperationError::Sharding(format!("Unable to format vector of shards into quorum key shard struct with {} components", QUORUM_KEY_NUM_PARTS)))?
+            };
+            results.push(formatted_shard);
+        }
+
+        Ok(results)
+    }
+
+    /// Flatten the crypto shard into a single array of the components in-order
+    pub fn flatten(&self) -> [u8; SHARE_SIZE * QUORUM_KEY_NUM_PARTS] {
+        let mut data = [0u8; SHARE_SIZE * QUORUM_KEY_NUM_PARTS];
+        for part_i in 0..QUORUM_KEY_NUM_PARTS {
+            let start = part_i * SHARE_SIZE;
+            let end = (part_i + 1) * SHARE_SIZE;
+            data[start..end].clone_from_slice(&self.components[part_i]);
+        }
+        data
+    }
+
+    /// Inflate a decrypted crypto shard from the flattened components
+    pub fn inflate(
+        raw: [u8; SHARE_SIZE * QUORUM_KEY_NUM_PARTS],
+    ) -> Result<Self, QuorumOperationError> {
+        let mut components = [[0u8; SHARE_SIZE]; QUORUM_KEY_NUM_PARTS];
+
+        for part_i in 0..QUORUM_KEY_NUM_PARTS {
+            let start = part_i * SHARE_SIZE;
+            let end = (part_i + 1) * SHARE_SIZE;
+
+            let slice = raw[start..end].to_vec();
+            components[part_i] = slice.try_into().map_err(|_| {
+                QuorumOperationError::Sharding(
+                    "Unable to deserialize raw binary vec to QuorumKeyShard".to_string(),
+                )
+            })?;
+        }
+
+        Ok(Self { components })
+    }
+}
+
+/// Represents an encrypted quorum key shard which is encrypted with
+/// the public key of the reliant party. These shards cannot be decoded in
+/// user-space, and must be handled WITHIN the crypto layer such that they
+/// public key cannot be reconstructed by "non secure" memory. The private key
+/// which can decrpyt the shards is the node's "transient" key used for communication
+/// channels, and never is exposed outside of the cryptographer service
+#[derive(Clone)]
+pub struct EncryptedQuorumKeyShard {
+    /// The flattened QuorumKeyShard components are encrypted
+    /// using the leader's public key and can only be
+    /// reconstructed within the secure layer such that the
+    /// encrypted shard components must be passed within
+    /// the secure crypto layer to be reconstructed and generate a
+    /// commitment
+    pub payload: Vec<u8>,
+}
+
+// =====================================================
+// Trait definitions
+// =====================================================
+
+/// Represents the cryptographic operations which the node needs to execute
+/// within a secure context (e.g. HSM)
+#[async_trait]
+pub trait QuorumCryptographer: Send + Sync + Clone {
+    // ==================================================================
+    // To be implemented
+    // ==================================================================
+
+    /// Retrieve the public key of this quorum node
+    async fn retrieve_public_key(&self) -> Result<Vec<u8>, QuorumOperationError>;
+
+    /// Retrieve the public key of the Quorum Key
+    async fn retrieve_qk_public_key(&self) -> Result<Vec<u8>, QuorumOperationError>;
+
+    /// Retrieve this node's shard of the quorum key from persistent secure storage
+    async fn retrieve_qk_shard(
+        &self,
+        node_id: NodeId,
+    ) -> Result<EncryptedQuorumKeyShard, QuorumOperationError>;
+
+    /// Save this node's shard of the quorum key to persistent secure storage
+    async fn update_qk_shard(
+        &self,
+        shard: EncryptedQuorumKeyShard,
+    ) -> Result<(), QuorumOperationError>;
+
+    /// Generate the encrypted shards for nodes [0, node_public_keys.len()) encrypted with the public keys of the nodes.
+    /// The provided shards are the quorum key shards, encrypted with THIS node's public key as the leader.
+    async fn generate_encrypted_shards(
+        &self,
+        shards: Vec<EncryptedQuorumKeyShard>,
+        node_public_keys: Vec<Vec<u8>>,
+    ) -> Result<Vec<EncryptedQuorumKeyShard>, QuorumOperationError>;
+
+    /// Encrypt the given material using the provided public key, optionally with the provided nonce
+    async fn encrypt_message(
+        &self,
+        public_key: Vec<u8>,
+        plaintext: Vec<u8>,
+        nonce: Nonce,
+    ) -> Result<Vec<u8>, QuorumOperationError>;
+
+    /// Decrypt the specified message utilizing this node's
+    /// private key. This will require that the message contain
+    /// a nonce. I.e. this cannot be used to decrypt the encrypted
+    /// shard partials
+    async fn decrypt_message(
+        &self,
+        cyphertext: Vec<u8>,
+    ) -> Result<(Vec<u8>, Nonce), QuorumOperationError>;
+
+    /// Generate a commitment on the epoch changes using the quorum key
+    async fn generate_commitment<H: Hasher>(
+        &self,
+        quorum_key_shards: Vec<EncryptedQuorumKeyShard>,
+        epoch: u64,
+        previous_hash: H::Digest,
+        current_hash: H::Digest,
+    ) -> Result<QuorumCommitment<H>, QuorumOperationError>;
+
+    /// Validate the commitment applied on the specified epoch settings
+    async fn validate_commitment<H: Hasher>(
+        public_key: Vec<u8>,
+        commitment: QuorumCommitment<H>,
+    ) -> Result<bool, QuorumOperationError>;
+
+    // ==================================================================
+    // Common trait logic
+    // ==================================================================
+
+    /// Get the number of shards required to reconstruct the quorum key
+    fn shards_required(n: u8) -> u8 {
+        let f = if (n - 1) % 3 == 0 {
+            (n - 1) / 3
+        } else {
+            // there's remainders
+            1 + (n - 1) / 3
+        };
+        2 * f + 1
+    }
+
+    /// Generate num_shards shards of the quorum key, and return the shard pieces.
+    /// We take ownership of the quorum key here to help prevent leakage of the key.
+    /// By taking ownership, someone needs to explicitely clone it to use it elsewhere
+    fn generate_shards(
+        quorum_key: [u8; QUORUM_KEY_SIZE],
+        num_shards: u8,
+    ) -> Result<Vec<QuorumKeyShard>, QuorumOperationError> {
+        let num_approvals = Self::shards_required(num_shards);
+
+        let mut parts = vec![vec![]; num_shards.into()];
+
+        for i in 0..QUORUM_KEY_NUM_PARTS {
+            let part: [u8; DATA_SIZE] = quorum_key[i * DATA_SIZE..(i + 1) * DATA_SIZE]
+                .try_into()
+                .map_err(|_| {
+                QuorumOperationError::Sharding(format!(
+                    "Unable to convert quorum key slice into SSS shardable component of len {}",
+                    DATA_SIZE
+                ))
+            })?;
+            let results = create_shares(&part, num_shards, num_approvals)?;
+            for node_i in 0..num_shards {
+                let idx: usize = node_i.into();
+                match results.get(idx) {
+                    None => {
+                        return Err(QuorumOperationError::Sharding(format!(
+                            "Resulting shards did not have an shard at entry {}",
+                            node_i
+                        )));
+                    }
+                    Some(part) => {
+                        parts[idx].push(part.clone());
+                    }
+                }
+            }
+        }
+
+        let formatted_shards = QuorumKeyShard::build_from_vec_vec_vec(parts)?;
+        Ok(formatted_shards)
+    }
+
+    /// Reconstruct the quorum key from a specific collection of shards
+    fn reconstruct_shards(
+        shards: Vec<QuorumKeyShard>,
+    ) -> Result<[u8; QUORUM_KEY_SIZE], QuorumOperationError> {
+        let mut potential_result = [0u8; QUORUM_KEY_SIZE];
+        // there should be QUORUM_KEY_NUM_PARTS in each shard
+        for i in 0..QUORUM_KEY_NUM_PARTS {
+            let part_i = shards
+                .iter()
+                .map(|shard| shard.components[i].to_vec())
+                .collect::<Vec<_>>();
+            let some_key = combine_shares(&part_i)?;
+            if let Some(key) = some_key {
+                let deconstructed_partial: [u8; DATA_SIZE] = key.try_into().map_err(|_| QuorumOperationError::Sharding(format!("Reconstructing the quorum key resulted in an invalid key length. It _MUST_ be of length {} bytes", DATA_SIZE)))?;
+                potential_result[i * DATA_SIZE..(i + 1) * DATA_SIZE]
+                    .clone_from_slice(&deconstructed_partial);
+            } else {
+                return Err(QuorumOperationError::Sharding(
+                    "Sharding request to recombine shares resulted in no constructed quorum key"
+                        .to_string(),
+                ));
+            }
+        }
+        Ok(potential_result)
+    }
+}

--- a/akd_audit_quorum/src/crypto/tests.rs
+++ b/akd_audit_quorum/src/crypto/tests.rs
@@ -1,0 +1,126 @@
+use super::{
+    EncryptedQuorumKeyShard, QuorumCryptographer, QuorumKeyShard, QUORUM_KEY_NUM_PARTS,
+    QUORUM_KEY_SIZE,
+};
+use crate::comms::{NodeId, Nonce};
+use crate::storage::QuorumCommitment;
+use crate::QuorumOperationError;
+
+use async_trait::async_trait;
+use rand::{seq::IteratorRandom, thread_rng, Rng};
+use shamirsecretsharing::SHARE_SIZE;
+use std::convert::TryInto;
+use winter_crypto::Hasher;
+
+#[derive(Clone)]
+struct TestCryptographer;
+
+#[async_trait]
+impl QuorumCryptographer for TestCryptographer {
+    async fn retrieve_public_key(&self) -> Result<Vec<u8>, QuorumOperationError> {
+        unimplemented!();
+    }
+
+    async fn retrieve_qk_public_key(&self) -> Result<Vec<u8>, QuorumOperationError> {
+        unimplemented!();
+    }
+
+    async fn retrieve_qk_shard(
+        &self,
+        _node_id: NodeId,
+    ) -> Result<EncryptedQuorumKeyShard, QuorumOperationError> {
+        unimplemented!();
+    }
+
+    async fn update_qk_shard(
+        &self,
+        _shard: EncryptedQuorumKeyShard,
+    ) -> Result<(), QuorumOperationError> {
+        unimplemented!();
+    }
+
+    async fn generate_encrypted_shards(
+        &self,
+        _shards: Vec<EncryptedQuorumKeyShard>,
+        _node_public_keys: Vec<Vec<u8>>,
+    ) -> Result<Vec<EncryptedQuorumKeyShard>, QuorumOperationError> {
+        unimplemented!();
+    }
+
+    async fn encrypt_message(
+        &self,
+        _public_key: Vec<u8>,
+        _material: Vec<u8>,
+        _nonce: Nonce,
+    ) -> Result<Vec<u8>, QuorumOperationError> {
+        unimplemented!();
+    }
+
+    async fn decrypt_message(
+        &self,
+        _material: Vec<u8>,
+    ) -> Result<(Vec<u8>, Nonce), QuorumOperationError> {
+        unimplemented!();
+    }
+
+    async fn generate_commitment<H: Hasher>(
+        &self,
+        _quorum_key_shards: Vec<EncryptedQuorumKeyShard>,
+        _epoch: u64,
+        _previous_hash: H::Digest,
+        _current_hash: H::Digest,
+    ) -> Result<QuorumCommitment<H>, QuorumOperationError> {
+        unimplemented!();
+    }
+
+    async fn validate_commitment<H: Hasher>(
+        _public_key: Vec<u8>,
+        _commitment: QuorumCommitment<H>,
+    ) -> Result<bool, QuorumOperationError> {
+        unimplemented!();
+    }
+}
+
+#[test]
+fn test_shard_generation_and_reconstruction() {
+    let data: [u8; QUORUM_KEY_SIZE] = [42; QUORUM_KEY_SIZE];
+    let shards = TestCryptographer::generate_shards(data, 7).unwrap();
+    assert_eq!(7, shards.len());
+
+    // all shards should be fine
+    let construction_ok = TestCryptographer::reconstruct_shards(shards.to_vec());
+    assert_eq!(Ok(data), construction_ok);
+
+    // using 5 shards should be fine, given a factor of 2 in f
+    let construction_ok = TestCryptographer::reconstruct_shards(shards[0..5].to_vec());
+    assert_eq!(Ok(data), construction_ok);
+
+    // using a random subset of shards of size <= 4 should fail
+    let mut rng = thread_rng();
+    for _ in 1..5 {
+        let sample = shards.clone().into_iter().choose_multiple(&mut rng, 4);
+        let construction_fail = TestCryptographer::reconstruct_shards(sample);
+        assert!(construction_fail.is_err());
+    }
+}
+
+#[test]
+fn test_quorum_shard_serialize_deserialize() {
+    let mut rng = rand::thread_rng();
+    let mut components = [[0u8; SHARE_SIZE]; QUORUM_KEY_NUM_PARTS];
+    for i in 0..QUORUM_KEY_NUM_PARTS {
+        let bytes: [u8; SHARE_SIZE] = (0..SHARE_SIZE)
+            .map(|_| rng.gen::<u8>())
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap();
+        components[i] = bytes;
+    }
+    let shard = QuorumKeyShard { components };
+
+    let flat = shard.flatten();
+    assert_eq!(SHARE_SIZE * QUORUM_KEY_NUM_PARTS, flat.len());
+
+    let inflated = QuorumKeyShard::inflate(flat).unwrap();
+    assert_eq!(shard, inflated);
+}

--- a/akd_audit_quorum/src/lib.rs
+++ b/akd_audit_quorum/src/lib.rs
@@ -1,0 +1,137 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree and the Apache
+// License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+// of this source tree.
+
+//! This crate implements the membership logic for a participant of a the witness pool which verifies
+//! the append-only nature of the key directory. This is to be deployed in a cluster and will inter-communicate
+//! between nodes in order to pass shard logic, manage enrollment & de-enrollment, and sign proof + emit it to stable storage.
+//!
+//! ⚠️ **Warning**: This implementation has not been audited and is not ready for use in a real system. Use at your own risk!
+//!
+//! # Overview
+//!
+//! To prevent a split-view attack the root hash of every epoch needs to have a signature signed by a private key which cannot be leaked from the quorum
+//! (via shared-secret methodology). This quorum participates to independently validate the append-only proof of the key directory and each participant
+//! provides their partial shard of the quorum signing key and when enough participants agree, the changes are signed off on and stored in persistent storage.
+//!
+//! That way a proof only needs to give the root hash, and the signature on it to ascertain the quorum has agreed on the changes, and the AKD
+//! (or any other 3rd party) cannot generate its own signatures.
+//!
+//! Eventually these auditors can be participants from external entities who can participate in the quorum vote.
+//!
+//! ## Requirements
+//!
+//! 1. The Quorum Key (QK) is long-lived and securely managed such that individual (or a few) participants cannot generate their own signatures and invalidate the trust of the system
+//! 2. The quorum participants can evolve over time (i.e. removal in the face of failures, and additions for future collaborative growth or upgrades).
+//! 3. Communication channels are secure, such that 3rd parties cannot sniff the key shares over the wire and compromise the QK.
+//! 4. The public key of the QK is publicly distributed such that it's easy to client-side validate the validity of the epochs without additional I/O operations to a potentially malicious acting key directory.
+//!
+//! # Design overview:
+//!
+//! A Quorum Key is generated at the beginning of the life of the quorum, and the private key is broken into "shards" via
+//! [Shamir secret sharing](https://github.com/dsprenkels/sss-rs).
+//! These shards are transmitted to the quorum participants who hold them in secure storage. The shards are generated with the following properties
+//!
+//! 1. There are 3 _f_ + 1 nodes in the quorum
+//! 2. 2 _f_ + 1 nodes need to agree to reconstruct the signing key (quorum key)
+//! 3. The public key is given publicly to every client which will need to verify the signature
+//!
+//! ## Communcation with the quorum
+//!
+//! The collection of nodes in this quorum receive commands from an external 3rd party (key directory epoch notification or admin interface for example).
+//! The messages they can receive are the following
+//!
+//! 1. New epoch publication - The AKD has published a new epoch and the quorum should validate the changes and generate a signature
+//! 2. Quorum member enrollment - The quorum should attempt to add the new member to the set. A series of independent tests will be
+//! performed against the new member and if they pass, a new shard-set will be generated and the node enrolled
+//! 3. Quorum member removal - The quorum has a member which should be removed. If 2 _f_ + 1 nodes agree, the Quorum Key is reconstructed and new shards are generated and
+//! distributed to the remaining membership.
+//!
+//! For any of these messages, whichever node receives the request is denoted as the leader. We do not need the full [RAFT](https://en.wikipedia.org/wiki/Raft_(algorithm))
+//! protocol, since we have no need for a persistent leader and the nodes are effectively stateless in between operations.
+//! The temporary request leader is responsible for communicating with the other quorum members and gathering
+//! their votes, reconstructing the shards, and either signing the commitment or enrolling the new member (re-generating shards and transmitting them).
+//!
+//! ## Inter-node communication scheme
+//!
+//! The inter-node messages are still to be defined at the state of this version, however they should be built & encoded with a backwards-compatable
+//! encoding scheme such that they can be upgraded in the future as new members, with potentially upgraded logic, are deployed.
+//!
+//! ## Retrieval of the latest commitment
+//!
+//! Since the public key is available to anyone who cares, external parties can read directly from the storage layer to minimize I/O to the quorum, as they
+//! will likely be resource constrained with validating the commitments between epochs and processing membership changes.
+//!
+//! NOTE: If the storage layer is mutated directly, then the quorum will start failing commitments and signatures will not match so the system fault will be detectable.
+
+#![warn(missing_docs)]
+#![allow(clippy::multiple_crate_versions)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+use std::fmt;
+
+pub mod comms;
+pub mod crypto;
+pub mod storage;
+
+#[derive(Debug, PartialEq)]
+/// A failure occurred encrypting or decrypting a message
+pub enum QuorumOperationError {
+    /// An encryption error occurred
+    Encryption(String),
+    /// A storage error occurred
+    Storage(akd::errors::StorageError),
+    /// A sharding error occurred (generation or reconstruction)
+    Sharding(String),
+    /// A communication error occurred
+    Communication(crate::comms::CommunicationError),
+
+    /// An untyped error has occurred
+    Unknown(String),
+}
+
+impl std::fmt::Display for QuorumOperationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use QuorumOperationError::*;
+        match self {
+            Encryption(err) => write!(f, "Encryption error ({})", err),
+            Storage(err) => write!(f, "Storage error ({:?})", err),
+            Sharding(err) => write!(f, "Sharding error ({})", err),
+            Communication(comm_err) => write!(f, "Communication error ({:?})", comm_err),
+            Unknown(msg) => write!(f, "Unknown error ({})", msg),
+        }
+    }
+}
+
+impl From<akd::errors::StorageError> for QuorumOperationError {
+    fn from(err: akd::errors::StorageError) -> Self {
+        Self::Storage(err)
+    }
+}
+
+impl From<shamirsecretsharing::SSSError> for QuorumOperationError {
+    fn from(err: shamirsecretsharing::SSSError) -> Self {
+        QuorumOperationError::Sharding(format!("Shamir Sharding Error \"{}\"", err))
+    }
+}
+
+impl From<crate::comms::CommunicationError> for QuorumOperationError {
+    fn from(err: crate::comms::CommunicationError) -> Self {
+        QuorumOperationError::Communication(err)
+    }
+}
+
+impl From<String> for QuorumOperationError {
+    fn from(err: String) -> Self {
+        QuorumOperationError::Unknown(err)
+    }
+}
+
+impl From<tokio::task::JoinError> for QuorumOperationError {
+    fn from(_err: tokio::task::JoinError) -> Self {
+        QuorumOperationError::Unknown("Tokio task join error".to_string())
+    }
+}

--- a/akd_audit_quorum/src/storage.rs
+++ b/akd_audit_quorum/src/storage.rs
@@ -1,0 +1,86 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree and the Apache
+// License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+// of this source tree.
+
+//! Storage definition for the quorum node non-secure storage
+
+use crate::comms::NodeId;
+
+use akd::errors::StorageError;
+use async_trait::async_trait;
+
+// =====================================================
+// Structs w/implementations
+// =====================================================
+
+/// Represents a commitment from >= 2f+1 nodes
+/// forming a "quorum" which states that at least 2f+1
+/// nodes agree that the current epoch hsa passed all
+/// necessary checks
+pub struct QuorumCommitment<H>
+where
+    H: winter_crypto::Hasher,
+{
+    /// The epoch of this commitment
+    pub current_epoch: u64,
+    /// The hash from the previous commitment
+    pub previous_hash: H::Digest,
+    /// The hash of the current directory structure at epoch ```current_epoch```
+    pub current_hash: H::Digest,
+    /// The signature on the hash
+    pub signature: Vec<u8>,
+}
+
+/// Represents the information about a member
+/// of the quorum and all the necessary properties
+/// to encrypt messages to this member (i.e. their public
+/// key information)
+#[derive(Clone)]
+pub struct MemberInformation {
+    /// The public key of the member node
+    pub public_key: Vec<u8>,
+    /// The id of the member node
+    pub node_id: NodeId,
+    /// Node contact information (ip/port/etc)
+    pub contact_information: crate::comms::ContactInformation,
+}
+
+// =====================================================
+// Trait definitions
+// =====================================================
+
+/// Implements a storage layer for the quorum which handles I/O
+/// for the necessary stable-state functionality which is needed by the
+/// operators on the quorum node
+#[async_trait]
+pub trait QuorumStorage<H>: Send + Sync + Clone
+where
+    H: winter_crypto::Hasher,
+{
+    /// Retrieve the other members of the quorum set
+    async fn retrieve_quorum_members(&self) -> Result<Vec<MemberInformation>, StorageError>; // stored in node-private storage
+
+    /// Retrieve a specific raft member by its id
+    async fn retrieve_quorum_member(
+        &self,
+        node_id: NodeId,
+    ) -> Result<MemberInformation, StorageError>; // stored in node-private storage
+
+    /// Update the members of the quorum set (triggered by removal or addition of a node)
+    async fn add_quorum_member(&self, node: MemberInformation) -> Result<(), StorageError>; // stored in node-private storage
+
+    /// Remove the specific quorum member from our set of membership and decrement all node id's > this id
+    async fn remove_quorum_member(&self, node_id: NodeId) -> Result<(), StorageError>; // stored in node-private storage
+
+    /// Retrieve the latest commitment (i.e. if you're validating a epoch, the previous one)
+    async fn get_latest_commitment(&self) -> Result<QuorumCommitment<H>, StorageError>; // stored in public storage
+
+    /* Leader-only operations */
+
+    /// Commit a new commitment to the data layer, with associated signature using
+    /// the quorum key
+    async fn save_commitment(&self, commitment: QuorumCommitment<H>) -> Result<(), StorageError>; // stored in public storage
+}

--- a/akd_client/src/tests.rs
+++ b/akd_client/src/tests.rs
@@ -81,7 +81,7 @@ where
     H: winter_crypto::Hasher,
 {
     crate::types::LayerProof {
-        direction: direction,
+        direction,
         label: convert_label(parent),
         siblings: [convert_node(sibling)],
     }


### PR DESCRIPTION
This PR introduces an initial skeleton structure for what a AKD Quorum node can look like.

# Overview

Here we introduce the boiler-plate traits and structure for auditor quorum trait. This cluster of nodes independently verify the append-only nature of the AKD and jointly submit a signature & commitment that the AKD is valid.

The traits added here are
1. Unencrypted, basic storage layer: ```storage.rs```
2. Communication layer between nodes in the quorum & externally with the quorum: ```comms/mod.rs```
3. Inter-node message replay protection via nonce's and nonce management.: ```comms/nonces.rs```
4. Cryptographic operations which the membership need to perform: ```crypto/mod.rs```

Additionally since we'll be using protobuf for the messages sent between nodes, I've also included a ```build.rs``` which will automate code generation for protobuf specs as needed.

Addresses: #125 

NOTE: This PR is based off of #126 which was a work-in-progress PR. Subsequent PRs will follow with the inner node logic and message structures