### PR TITLE
Parallelize leaf insertion and hashing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,13 @@ jobs:
             package: akd
             flags:
 
+          - name: Test the base library, without parallelism
+            package: akd
+            flags: --features blake3,public_auditing --no-default-features
+
           - name: Test the base library, with truncated SHA512 hashing (sha512_256)
             package: akd
-            flags: --features sha512_256,public_auditing --no-default-features
+            flags: --features sha512_256,public_auditing,parallel_insert,parallel_vrf --no-default-features
 
           - name: Test the base library, enabling runtime metrics processing
             package: akd

--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -26,9 +26,11 @@ serde_serialization = ["serde", "ed25519-dalek/serde", "akd_core/serde_serializa
 runtime_metrics = []
 # Parallelize VRF calculations during publish
 parallel_vrf = ["akd_core/parallel_vrf"]
+# Parallelize node insertion during publish
+parallel_insert = []
 
 # Default features mix (blake3 + audit-proof protobuf mgmt support)
-default = ["blake3", "public_auditing", "parallel_vrf"]
+default = ["blake3", "public_auditing", "parallel_vrf", "parallel_insert"]
 
 [dependencies]
 ## Required dependencies ##

--- a/akd/benches/azks.rs
+++ b/akd/benches/azks.rs
@@ -55,6 +55,9 @@ fn batch_insertion(c: &mut Criterion) {
                 let db = StorageManager::new_no_cache(&database);
                 let mut azks = runtime.block_on(Azks::new(&db)).unwrap();
 
+                // create transaction object
+                db.begin_transaction();
+
                 // insert initial leaves as part of setup
                 runtime
                     .block_on(azks.batch_insert_nodes(

--- a/akd/benches/azks.rs
+++ b/akd/benches/azks.rs
@@ -52,7 +52,7 @@ fn batch_insertion(c: &mut Criterion) {
         b.iter_batched(
             || {
                 let database = AsyncInMemoryDatabase::new();
-                let db = StorageManager::new_no_cache(&database);
+                let db = StorageManager::new(database, None, None, None);
                 let mut azks = runtime.block_on(Azks::new(&db)).unwrap();
 
                 // create transaction object

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -49,7 +49,7 @@ async fn tic_toc<T>(f: impl core::future::Future<Output = T>) -> (T, Option<f64>
 
 fn get_parallel_levels() -> Option<u8> {
     #[cfg(not(feature = "parallel_insert"))]
-    None;
+    return None;
 
     #[cfg(feature = "parallel_insert")]
     {

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -54,7 +54,7 @@ fn get_parallel_levels() -> Option<u8> {
     #[cfg(feature = "parallel_insert")]
     {
         // Based on profiling results, the best performance is achieved when the
-        // number of spawned tasks is equal to the number of available cores.
+        // number of spawned tasks is equal to the number of available threads.
         // We therefore get the number of available threads and calculate the
         // number of levels that should be executed in parallel to give the
         // number of tasks closest to the number of threads. While there might
@@ -62,6 +62,10 @@ fn get_parallel_levels() -> Option<u8> {
         // approximation that should yield good performance in most cases.
         let available_parallelism = std::thread::available_parallelism()
             .map_or(DEFAULT_AVAILABLE_PARALLELISM, |v| v.into());
+        // The number of tasks spawned at a level is the number of leaves at
+        // the level. As we are using a binary tree, the number of leaves at a
+        // level is 2^level. Therefore, the number of levels that should be
+        // executed in parallel is the log2 of the number of available threads.
         let levels = (available_parallelism as f32).log2().ceil() as u8;
         Some(levels)
     }

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -357,7 +357,7 @@ impl Azks {
 
         // if parallel: spawn a tokio task for the left child
         #[cfg(feature = "parallel_insert")]
-        let maybe_future = (!left_node_set.is_empty()).then_some({
+        let maybe_future = (!left_node_set.is_empty()).then(|| {
             let storage_clone = storage.clone();
             let left_child_label = current_node.get_child_label(Direction::Left)?;
             tokio::task::spawn(async move {

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -376,14 +376,14 @@ impl Azks {
 
         // else handle the left child in the current task
         #[cfg(not(feature = "parallel_insert"))]
-        if !left_insertion_set.is_empty() {
+        if !left_node_set.is_empty() {
             let left_child_label = current_node.get_child_label(Direction::Left)?;
-            let (mut left_node, left_num_inserted) = Azks::recursive_batch_insert_leaves(
+            let (mut left_node, left_num_inserted) = Azks::recursive_batch_insert_nodes(
                 storage,
                 left_child_label,
-                left_insertion_set,
+                left_node_set,
                 epoch,
-                append_only_exclude_usage,
+                insert_mode,
             )
             .await?;
 

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -210,7 +210,7 @@ impl<S: Database + 'static, V: VRFKeyStorage> Directory<S, V> {
             return Ok(EpochHash(current_epoch, root_hash));
         }
 
-        if let false = self.storage.begin_transaction().await {
+        if let false = self.storage.begin_transaction() {
             error!("Transaction is already active");
             return Err(AkdError::Storage(StorageError::Transaction(
                 "Transaction is already active".to_string(),
@@ -224,7 +224,7 @@ impl<S: Database + 'static, V: VRFKeyStorage> Directory<S, V> {
         {
             // If we fail to do the batch-leaf insert, we should rollback the transaction so we can try again cleanly.
             // Only fails if transaction is not currently active.
-            let _ = self.storage.rollback_transaction().await;
+            let _ = self.storage.rollback_transaction();
             // bubble up the err
             return Err(err);
         }
@@ -239,7 +239,7 @@ impl<S: Database + 'static, V: VRFKeyStorage> Directory<S, V> {
         // Commit the transaction
         info!("Committing transaction");
         if let Err(err) = self.storage.commit_transaction().await {
-            let _ = self.storage.rollback_transaction().await;
+            let _ = self.storage.rollback_transaction();
             return Err(AkdError::Storage(err));
         } else {
             info!("Transaction committed");
@@ -939,7 +939,7 @@ impl<S: Database + 'static, V: VRFKeyStorage> Directory<S, V> {
             return Ok(EpochHash(current_epoch, root_hash));
         }
 
-        if let false = self.storage.begin_transaction().await {
+        if let false = self.storage.begin_transaction() {
             error!("Transaction is already active");
             return Err(AkdError::Storage(StorageError::Transaction(
                 "Transaction is already active".to_string(),

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -52,7 +52,7 @@ impl<S: Database, V: VRFKeyStorage> Clone for Directory<S, V> {
     }
 }
 
-impl<S: Database, V: VRFKeyStorage> Directory<S, V> {
+impl<S: Database + 'static, V: VRFKeyStorage> Directory<S, V> {
     /// Creates a new (stateless) instance of a auditable key directory.
     /// Takes as input a pointer to the storage being used for this instance.
     /// The state is stored in the storage.
@@ -776,7 +776,7 @@ pub(crate) fn get_marker_version(version: u64) -> u64 {
 }
 
 /// Gets the azks root hash at the current epoch.
-pub async fn get_directory_root_hash_and_ep<S: Database, V: VRFKeyStorage>(
+pub async fn get_directory_root_hash_and_ep<S: Database + 'static, V: VRFKeyStorage>(
     akd_dir: &Directory<S, V>,
 ) -> Result<(Digest, u64), AkdError> {
     let current_azks = akd_dir.retrieve_current_azks().await?;
@@ -797,7 +797,7 @@ pub enum PublishCorruption {
 }
 
 #[cfg(test)]
-impl<S: Database, V: VRFKeyStorage> Directory<S, V> {
+impl<S: Database + 'static, V: VRFKeyStorage> Directory<S, V> {
     /// Updates the directory to include the updated key-value pairs with possible issues.
     pub(crate) async fn publish_malicious_update(
         &self,

--- a/akd/src/errors.rs
+++ b/akd/src/errors.rs
@@ -27,6 +27,8 @@ pub enum AkdError {
     Storage(StorageError),
     /// Audit verification error thrown
     AuditErr(AuditorError),
+    /// Parallelism/concurrency related errors
+    Parallelism(ParallelismError),
     /// Test error
     TestErr(String),
 }
@@ -69,6 +71,12 @@ impl From<AuditorError> for AkdError {
     }
 }
 
+impl From<ParallelismError> for AkdError {
+    fn from(error: ParallelismError) -> Self {
+        Self::Parallelism(error)
+    }
+}
+
 impl From<akd_core::verify::VerificationError> for AkdError {
     fn from(err: akd_core::verify::VerificationError) -> Self {
         Self::Directory(err.into())
@@ -95,6 +103,9 @@ impl std::fmt::Display for AkdError {
             }
             AkdError::AuditErr(err) => {
                 writeln!(f, "AKD Auditor Error {}", err)
+            }
+            AkdError::Parallelism(err) => {
+                writeln!(f, "AKD Parallelism Error: {}", err)
             }
             AkdError::TestErr(err) => {
                 writeln!(f, "{}", err)
@@ -296,6 +307,26 @@ impl fmt::Display for AuditorError {
         match self {
             Self::VerifyAuditProof(err_string) => {
                 write!(f, "Failed to verify audit {}", err_string)
+            }
+        }
+    }
+}
+
+/// The errors thrown by parallel code
+#[cfg_attr(test, derive(PartialEq, Eq))]
+#[derive(Debug)]
+pub enum ParallelismError {
+    /// A tokio task join error
+    JoinErr(String),
+}
+
+impl std::error::Error for ParallelismError {}
+
+impl fmt::Display for ParallelismError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::JoinErr(err_string) => {
+                write!(f, "Failed to join tokio task {}", err_string)
             }
         }
     }

--- a/akd/src/storage/manager/mod.rs
+++ b/akd/src/storage/manager/mod.rs
@@ -51,6 +51,7 @@ mod tests;
 
 /// Represents the manager of the storage mediums, including caching
 /// and transactional operations (creating the transaction, committing it, etc)
+#[derive(Clone)]
 pub struct StorageManager<Db: Database> {
     cache: Option<TimedCache>,
     transaction: Transaction,
@@ -58,17 +59,6 @@ pub struct StorageManager<Db: Database> {
     pub db: Db,
 
     metrics: [Arc<AtomicU64>; NUM_METRICS],
-}
-
-impl<Db: Database> Clone for StorageManager<Db> {
-    fn clone(&self) -> Self {
-        Self {
-            cache: self.cache.clone(),
-            transaction: Transaction::new(),
-            db: self.db.clone(),
-            metrics: self.metrics.clone(),
-        }
-    }
 }
 
 unsafe impl<Db: Database> Sync for StorageManager<Db> {}

--- a/akd/src/storage/manager/mod.rs
+++ b/akd/src/storage/manager/mod.rs
@@ -105,7 +105,7 @@ impl<Db: Database> StorageManager<Db> {
             cache.log_metrics(level)
         }
 
-        self.transaction.log_metrics(level).await;
+        self.transaction.log_metrics(level);
 
         let snapshot = self
             .metrics
@@ -155,8 +155,8 @@ impl<Db: Database> StorageManager<Db> {
     }
 
     /// Start an in-memory transaction of changes
-    pub async fn begin_transaction(&self) -> bool {
-        let started = self.transaction.begin_transaction().await;
+    pub fn begin_transaction(&self) -> bool {
+        let started = self.transaction.begin_transaction();
 
         // disable the cache cleaning since we're in a write transaction
         // and will want to keep cache'd objects for the life of the transaction
@@ -170,7 +170,7 @@ impl<Db: Database> StorageManager<Db> {
     /// Commit a transaction in the database
     pub async fn commit_transaction(&self) -> Result<(), StorageError> {
         // this retrieves all the trans operations, and "de-activates" the transaction flag
-        let records = self.transaction.commit_transaction().await?;
+        let records = self.transaction.commit_transaction()?;
 
         // The transaction is now complete (or reverted) and therefore we can re-enable
         // the cache cleaning status
@@ -207,8 +207,8 @@ impl<Db: Database> StorageManager<Db> {
     }
 
     /// Rollback a transaction
-    pub async fn rollback_transaction(&self) -> Result<(), StorageError> {
-        self.transaction.rollback_transaction().await?;
+    pub fn rollback_transaction(&self) -> Result<(), StorageError> {
+        self.transaction.rollback_transaction()?;
         // The transaction is being reverted and therefore we can re-enable
         // the cache cleaning status
         if let Some(cache) = &self.cache {
@@ -218,15 +218,15 @@ impl<Db: Database> StorageManager<Db> {
     }
 
     /// Retrieve a flag determining if there is a transaction active
-    pub async fn is_transaction_active(&self) -> bool {
-        self.transaction.is_transaction_active().await
+    pub fn is_transaction_active(&self) -> bool {
+        self.transaction.is_transaction_active()
     }
 
     /// Store a record in the database
     pub async fn set(&self, record: DbRecord) -> Result<(), StorageError> {
         // we're in a transaction, set the item in the transaction
-        if self.is_transaction_active().await {
-            self.transaction.set(&record).await;
+        if self.is_transaction_active() {
+            self.transaction.set(&record);
             return Ok(());
         }
 
@@ -249,8 +249,8 @@ impl<Db: Database> StorageManager<Db> {
         }
 
         // we're in a transaction, set the items in the transaction
-        if self.is_transaction_active().await {
-            self.transaction.batch_set(&records).await;
+        if self.is_transaction_active() {
+            self.transaction.batch_set(&records);
             return Ok(());
         }
 
@@ -286,8 +286,8 @@ impl<Db: Database> StorageManager<Db> {
     pub async fn get<St: Storable>(&self, id: &St::StorageKey) -> Result<DbRecord, StorageError> {
         // we're in a transaction, meaning the object _might_ be newer and therefore we should try and read if from the transaction
         // log instead of the raw storage layer
-        if self.is_transaction_active().await {
-            if let Some(result) = self.transaction.get::<St>(id).await {
+        if self.is_transaction_active() {
+            if let Some(result) = self.transaction.get::<St>(id) {
                 return Ok(result);
             }
         }
@@ -325,13 +325,13 @@ impl<Db: Database> StorageManager<Db> {
 
         let mut key_set: HashSet<St::StorageKey> = ids.iter().cloned().collect();
 
-        let trans_active = self.is_transaction_active().await;
+        let trans_active = self.is_transaction_active();
         // first check the transaction log & cache records
         for id in ids.iter() {
             if trans_active {
                 // we're in a transaction, meaning the object _might_ be newer and therefore we should try and read if from the transaction
                 // log instead of the raw storage layer
-                if let Some(result) = self.transaction.get::<St>(id).await {
+                if let Some(result) = self.transaction.get::<St>(id) {
                     records.push(result);
                     key_set.remove(id);
                     continue;
@@ -421,8 +421,8 @@ impl<Db: Database> StorageManager<Db> {
         // in the event we are in a transaction, there may be an updated object in the
         // transactional storage. Therefore we should update the db retrieved value if
         // we can with what's in the transaction log
-        if self.is_transaction_active().await {
-            if let Some(transaction_value) = self.transaction.get_user_state(username, flag).await {
+        if self.is_transaction_active() {
+            if let Some(transaction_value) = self.transaction.get_user_state(username, flag) {
                 if let Some(db_value) = &maybe_db_state {
                     if let Some(record) = Self::compare_db_and_transaction_records(
                         db_value.epoch,
@@ -462,7 +462,7 @@ impl<Db: Database> StorageManager<Db> {
         }?;
         self.increment_metric(METRIC_GET_USER_DATA);
 
-        if self.is_transaction_active().await {
+        if self.is_transaction_active() {
             // there are transaction-based values in the current transaction, they should override database-retrieved values
             let mut map = maybe_db_data
                 .map(|data| {
@@ -476,7 +476,6 @@ impl<Db: Database> StorageManager<Db> {
             let transaction_records = self
                 .transaction
                 .get_users_data(&[username.clone()])
-                .await
                 .remove(username)
                 .unwrap_or_default();
             for transaction_record in transaction_records.into_iter() {
@@ -515,8 +514,8 @@ impl<Db: Database> StorageManager<Db> {
         // in the event we are in a transaction, there may be an updated object in the
         // transactional storage. Therefore we should update the db retrieved value if
         // we can with what's in the transaction log
-        if self.is_transaction_active().await {
-            let transaction_records = self.transaction.get_users_states(usernames, flag).await;
+        if self.is_transaction_active() {
+            let transaction_records = self.transaction.get_users_states(usernames, flag);
             for (label, value_state) in transaction_records.into_iter() {
                 if let Some((epoch, _)) = data.get(&label) {
                     // there is an existing DB record, check if we should updated it from the transaction log

--- a/akd/src/storage/manager/tests.rs
+++ b/akd/src/storage/manager/tests.rs
@@ -21,7 +21,7 @@ async fn test_storage_manager_transaction() {
     let storage_manager = StorageManager::new_no_cache(db.clone());
 
     assert!(
-        storage_manager.begin_transaction().await,
+        storage_manager.begin_transaction(),
         "Failed to start transaction"
     );
 
@@ -69,7 +69,7 @@ async fn test_storage_manager_transaction() {
         Ok(0),
         db.batch_get_all_direct().await.map(|items| items.len())
     );
-    assert_eq!(11, storage_manager.transaction.count().await);
+    assert_eq!(11, storage_manager.transaction.count());
 
     // test a retrieval doesn't go to the database. Since we know the db is empty, it should be retrieved from the transaction log
     let key = NodeKey(NodeLabel {
@@ -103,7 +103,7 @@ async fn test_storage_manager_transaction() {
         Ok(11),
         db.batch_get_all_direct().await.map(|items| items.len())
     );
-    assert_eq!(0, storage_manager.transaction.count().await);
+    assert_eq!(0, storage_manager.transaction.count());
 }
 
 #[tokio::test]

--- a/akd/src/storage/tests.rs
+++ b/akd/src/storage/tests.rs
@@ -380,7 +380,7 @@ async fn test_transactions<S: Database>(db: &S) {
     }
 
     let tic = Instant::now();
-    assert!(storage.begin_transaction().await);
+    assert!(storage.begin_transaction());
     assert_eq!(Ok(()), storage.batch_set(new_data).await);
     assert_eq!(Ok(()), storage.commit_transaction().await);
     let toc: Duration = Instant::now() - tic;

--- a/akd/src/tests.rs
+++ b/akd/src/tests.rs
@@ -937,6 +937,9 @@ async fn test_directory_polling_azks_change() -> Result<(), AkdError> {
             .await
     });
 
+    // wait for a second to make sure the poller has started
+    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
     // verify a lookup proof, which will populate the cache
     async_poll_helper_proof(&reader, AkdValue::from_utf8_str("world")).await?;
 

--- a/akd/src/tests.rs
+++ b/akd/src/tests.rs
@@ -1173,7 +1173,7 @@ async fn test_simple_lookup_for_small_tree_sha256() -> Result<(), AkdError> {
 =========== Test Helpers ===========
 */
 
-async fn async_poll_helper_proof<T: Database, V: VRFKeyStorage>(
+async fn async_poll_helper_proof<T: Database + 'static, V: VRFKeyStorage>(
     reader: &Directory<T, V>,
     value: AkdValue,
 ) -> Result<(), AkdError> {

--- a/akd/src/utils.rs
+++ b/akd/src/utils.rs
@@ -34,11 +34,3 @@ pub(crate) fn random_label(rng: &mut impl rand::Rng) -> crate::NodeLabel {
         label_len: 256,
     }
 }
-
-/// "Swap" values in a RwLock, reading the current value and writing a new value into the lock
-pub(crate) async fn rwlock_swap<T: Clone>(lock: &tokio::sync::RwLock<T>, new_value: T) -> T {
-    let mut guard = lock.write().await;
-    let old = guard.clone();
-    *guard = new_value;
-    old
-}

--- a/akd_test_tools/src/test_suites.rs
+++ b/akd_test_tools/src/test_suites.rs
@@ -8,6 +8,7 @@ extern crate thread_id;
 // of this source tree.
 
 use akd::ecvrf::VRFKeyStorage;
+use akd::storage::Database;
 use akd::Directory;
 use akd::HistoryParams;
 use akd::{AkdLabel, AkdValue};
@@ -18,7 +19,7 @@ use rand::{thread_rng, Rng};
 /// The suite of tests to run against a fully-instantated and storage-backed directory.
 /// This will publish 3 epochs of ```num_users``` records and
 /// perform 10 random lookup proofs + 2 random history proofs + and audit proof from epochs 1u64 -> 2u64
-pub async fn directory_test_suite<S: akd::storage::Database, V: VRFKeyStorage>(
+pub async fn directory_test_suite<S: Database + 'static, V: VRFKeyStorage>(
     mysql_db: &akd::storage::StorageManager<S>,
     num_users: usize,
     vrf: &V,

--- a/integration_tests/src/test_util.rs
+++ b/integration_tests/src/test_util.rs
@@ -8,7 +8,7 @@ extern crate thread_id;
 // of this source tree.
 
 use akd::ecvrf::VRFKeyStorage;
-use akd::storage::StorageManager;
+use akd::storage::{Database, StorageManager};
 use akd::Directory;
 use akd::{AkdLabel, AkdValue};
 use log::{info, Level, Metadata, Record};
@@ -120,7 +120,7 @@ impl log::Log for FileLogger {
 
 // ================== Test Helpers ================== //
 
-pub(crate) async fn test_lookups<S: akd::storage::Database, V: VRFKeyStorage>(
+pub(crate) async fn test_lookups<S: Database + 'static, V: VRFKeyStorage>(
     mysql_db: &StorageManager<S>,
     vrf: &V,
     num_users: u64,
@@ -241,7 +241,7 @@ pub(crate) async fn test_lookups<S: akd::storage::Database, V: VRFKeyStorage>(
 // Reset MySQL database by logging metrics which resets the metrics, and flushing cache.
 // These allow us to accurately assess the additional efficiency of
 // bulk lookup proofs.
-async fn reset_mysql_db<S: akd::storage::Database>(mysql_db: &StorageManager<S>) {
+async fn reset_mysql_db<S: Database>(mysql_db: &StorageManager<S>) {
     mysql_db.log_metrics(Level::Trace).await;
     mysql_db.flush_cache().await;
 }

--- a/poc/src/directory_host.rs
+++ b/poc/src/directory_host.rs
@@ -35,7 +35,7 @@ pub enum DirectoryCommand {
 
 async fn get_root_hash<S, V>(directory: &mut Directory<S, V>) -> Option<Result<Digest, AkdError>>
 where
-    S: Database,
+    S: Database + 'static,
     V: VRFKeyStorage,
 {
     if let Ok(azks) = directory.retrieve_current_azks().await {
@@ -47,7 +47,7 @@ where
 
 pub(crate) async fn init_host<S, V>(rx: &mut Receiver<Rpc>, directory: &mut Directory<S, V>)
 where
-    S: Database,
+    S: Database + 'static,
     V: VRFKeyStorage,
 {
     info!("Starting the verifiable directory host");


### PR DESCRIPTION
# Overview
This PR builds upon #301 to finally parallelize leaf insertion and hashing. A tokio task is spawned for every recursive call on the left child, while the right child's work is executed in the current task. 

While tokio tasks are [lightweight](https://docs.rs/tokio/latest/tokio/task/#what-are-tasks), benchmarking has revealed that the best performance is had when the number of spawned tasks approximately equals the number of available CPU cores. To restrict the number of tasks spawned, I get the available number of threads and calculate the level by which we have to stop spawning new tasks. This is a rough measure that might not yield the ideal parallelism in all circumstances, but will be reasonably close to it. 

# Benchmark
Ran the `azks.rs` benchmark, which inserts 100K leaves into a tree with 10K leaves.

## Sequential
```console
$ cargo bench -p akd --bench azks --no-default-features -F bench
```
<img width="397" alt="image" src="https://user-images.githubusercontent.com/20502803/210122970-be665f16-1729-4be5-8ad8-fa8b3d669d83.png">


## Parallel
```console
$ cargo bench -p akd --bench azks --no-default-features -F bench -F parallel_insert
```
<img width="482" alt="image" src="https://user-images.githubusercontent.com/20502803/210122991-333b1ec2-57df-43bf-acea-f39ee842fed5.png">

A whopping 80% improvement in execution time 🏎💨


# Progress
- [x] Parallelize recursive insert
- [x] Gate parallelism behind feature flag
- [x] Convert transaction to use dashmap
- [x] Restrict tasks spawned
- [x] Benchmark 
- [x] Update GH actions to run tests without feature flag

