### PR TITLE
Add abstraction for insertion sets and optimize recursive insert

### DIFF
--- a/akd/benches/azks.rs
+++ b/akd/benches/azks.rs
@@ -8,6 +8,7 @@
 #[macro_use]
 extern crate criterion;
 
+use akd::append_only_zks::InsertMode;
 use akd::storage::manager::StorageManager;
 use akd::storage::memory::AsyncInMemoryDatabase;
 use akd::{Azks, Node, NodeLabel};
@@ -56,13 +57,17 @@ fn batch_insertion(c: &mut Criterion) {
 
                 // insert initial leaves as part of setup
                 runtime
-                    .block_on(azks.batch_insert_leaves(&db, initial_insertion_set.clone(), false))
+                    .block_on(azks.batch_insert_nodes(
+                        &db,
+                        initial_insertion_set.clone(),
+                        InsertMode::Directory,
+                    ))
                     .unwrap();
                 (azks, db, insertion_set.clone())
             },
             |(mut azks, db, insertion_set)| {
                 runtime
-                    .block_on(azks.batch_insert_leaves(&db, insertion_set, false))
+                    .block_on(azks.batch_insert_nodes(&db, insertion_set, InsertMode::Directory))
                     .unwrap();
             },
             BatchSize::PerIteration,

--- a/akd/benches/azks.rs
+++ b/akd/benches/azks.rs
@@ -24,13 +24,13 @@ fn batch_insertion(c: &mut Criterion) {
     let runtime = tokio::runtime::Builder::new_multi_thread().build().unwrap();
 
     // prepare node set for initial leaves
-    let mut initial_insertion_set = vec![];
+    let mut initial_node_set = vec![];
     for _ in 0..num_initial_leaves {
         let label = random_label(&mut rng);
         let mut input = [0u8; 32];
         rng.fill_bytes(&mut input);
         let hash = akd_core::hash::hash(&input);
-        initial_insertion_set.push(Node { label, hash });
+        initial_node_set.push(Node { label, hash });
     }
 
     // prepare node set for batch insertion
@@ -59,7 +59,7 @@ fn batch_insertion(c: &mut Criterion) {
                 runtime
                     .block_on(azks.batch_insert_nodes(
                         &db,
-                        initial_insertion_set.clone(),
+                        initial_node_set.clone(),
                         InsertMode::Directory,
                     ))
                     .unwrap();

--- a/akd/benches/azks.rs
+++ b/akd/benches/azks.rs
@@ -18,12 +18,12 @@ use rand::{RngCore, SeedableRng};
 
 fn batch_insertion(c: &mut Criterion) {
     let num_initial_leaves = 10000;
-    let num_inserted_leaves = 1000;
+    let num_inserted_leaves = 100000;
 
     let mut rng = StdRng::seed_from_u64(42);
     let runtime = tokio::runtime::Builder::new_multi_thread().build().unwrap();
 
-    // prepare insertion set for initial leaves
+    // prepare node set for initial leaves
     let mut initial_insertion_set = vec![];
     for _ in 0..num_initial_leaves {
         let label = random_label(&mut rng);
@@ -33,14 +33,14 @@ fn batch_insertion(c: &mut Criterion) {
         initial_insertion_set.push(Node { label, hash });
     }
 
-    // prepare insertion set for batch insertion
-    let mut insertion_set = vec![];
+    // prepare node set for batch insertion
+    let mut node_set = vec![];
     for _ in 0..num_inserted_leaves {
         let label = random_label(&mut rng);
         let mut input = [0u8; 32];
         rng.fill_bytes(&mut input);
         let hash = akd_core::hash::hash(&input);
-        insertion_set.push(Node { label, hash });
+        node_set.push(Node { label, hash });
     }
 
     // benchmark batch insertion
@@ -63,11 +63,11 @@ fn batch_insertion(c: &mut Criterion) {
                         InsertMode::Directory,
                     ))
                     .unwrap();
-                (azks, db, insertion_set.clone())
+                (azks, db, node_set.clone())
             },
-            |(mut azks, db, insertion_set)| {
+            |(mut azks, db, node_set)| {
                 runtime
-                    .block_on(azks.batch_insert_nodes(&db, insertion_set, InsertMode::Directory))
+                    .block_on(azks.batch_insert_nodes(&db, node_set, InsertMode::Directory))
                     .unwrap();
             },
             BatchSize::PerIteration,

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -135,15 +135,10 @@ impl InsertionSet {
 
     pub(crate) fn get_longest_common_prefix(&self) -> NodeLabel {
         match self {
-            InsertionSet::BinarySearchable(nodes) => {
-                // TODO: Implement binary search
-                if nodes.is_empty() {
-                    return EMPTY_LABEL;
-                }
-                nodes.iter().skip(1).fold(nodes[0].label, |acc, node| {
-                    node.label.get_longest_common_prefix(acc)
-                })
-            }
+            InsertionSet::BinarySearchable(nodes) => match (nodes.first(), nodes.last()) {
+                (Some(first), Some(last)) => first.label.get_longest_common_prefix(last.label),
+                _ => EMPTY_LABEL,
+            },
             InsertionSet::Unsorted(nodes) => {
                 if nodes.is_empty() {
                     return EMPTY_LABEL;

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -98,15 +98,17 @@ impl From<Vec<Node>> for InsertionSet {
 impl InsertionSet {
     pub(crate) fn partition(self, lcp_label: NodeLabel) -> (InsertionSet, InsertionSet) {
         match self {
-            InsertionSet::BinarySearchable(nodes) => {
+            InsertionSet::BinarySearchable(mut nodes) => {
                 // binary search for partition point
-                let (mut left, right): (Vec<Node>, Vec<Node>) =
-                    nodes.into_iter().partition(|candidate| {
-                        match lcp_label.get_dir(candidate.label) {
-                            Direction::Left | Direction::None => true,
-                            Direction::Right => false,
-                        }
+                let partition_point =
+                    nodes.partition_point(|candidate| match lcp_label.get_dir(candidate.label) {
+                        Direction::Left | Direction::None => true,
+                        Direction::Right => false,
                     });
+
+                // split nodes vector at partition point
+                let right = nodes.split_off(partition_point);
+                let mut left = nodes;
 
                 // drop nodes with direction None
                 while left.last().map(|node| lcp_label.get_dir(node.label)) == Some(Direction::None)

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -87,7 +87,7 @@ impl From<Vec<Node>> for InsertionSet {
                 .iter()
                 .all(|node| node.label.label_len == nodes[0].label.label_len)
         {
-            nodes.sort();
+            nodes.sort_unstable();
             InsertionSet::BinarySearchable(nodes)
         } else {
             InsertionSet::Unsorted(nodes)
@@ -1017,10 +1017,11 @@ mod tests {
         let unsorted_set = InsertionSet::Unsorted(nodes.clone());
         let bin_searchable_set = {
             let mut nodes = nodes.clone();
-            nodes.sort();
+            nodes.sort_unstable();
             InsertionSet::BinarySearchable(nodes)
         };
 
+        // assert that insertion sets always return the same partitions
         let assert_fun = |prefix_label: NodeLabel| match (
             unsorted_set.clone().partition(prefix_label),
             bin_searchable_set.clone().partition(prefix_label),
@@ -1035,15 +1036,14 @@ mod tests {
                     InsertionSet::BinarySearchable(right_bin_searchable),
                 ),
             ) => {
-                left_unsorted.sort();
-                right_unsorted.sort();
+                left_unsorted.sort_unstable();
+                right_unsorted.sort_unstable();
                 assert_eq!(left_unsorted, *left_bin_searchable);
                 assert_eq!(right_unsorted, *right_bin_searchable);
             }
             _ => panic!("Unexpected enum variant returned from partition call"),
         };
 
-        // assert that insertion sets always return the same partitions
         let lcp_label = bin_searchable_set[0]
             .label
             .get_longest_common_prefix(bin_searchable_set[num_nodes - 1].label);
@@ -1067,14 +1067,14 @@ mod tests {
         let unsorted_set = InsertionSet::Unsorted(nodes.clone());
         let bin_searchable_set = {
             let mut nodes = nodes.clone();
-            nodes.sort();
+            nodes.sort_unstable();
             InsertionSet::BinarySearchable(nodes)
         };
 
         // assert that insertion sets always return the same LCP
         assert_eq!(
-            unsorted_set.clone().get_longest_common_prefix(),
-            bin_searchable_set.clone().get_longest_common_prefix()
+            unsorted_set.get_longest_common_prefix(),
+            bin_searchable_set.get_longest_common_prefix()
         );
 
         Ok(())

--- a/akd/src/auditor.rs
+++ b/akd/src/auditor.rs
@@ -56,7 +56,7 @@ pub async fn verify_consecutive_append_only(
     let manager = StorageManager::new_no_cache(&db);
 
     let mut azks = Azks::new::<_>(&manager).await?;
-    azks.batch_insert_leaves::<_>(&manager, unchanged_nodes, InsertMode::Auditor)
+    azks.batch_insert_nodes::<_>(&manager, unchanged_nodes, InsertMode::Auditor)
         .await?;
     let computed_start_root_hash: Digest = azks.get_root_hash::<_>(&manager).await?;
     let mut verified = computed_start_root_hash == start_hash;
@@ -69,7 +69,7 @@ pub async fn verify_consecutive_append_only(
             y
         })
         .collect();
-    azks.batch_insert_leaves::<_>(&manager, updated_inserted, InsertMode::Auditor)
+    azks.batch_insert_nodes::<_>(&manager, updated_inserted, InsertMode::Auditor)
         .await?;
     let computed_end_root_hash: Digest = azks.get_root_hash::<_>(&manager).await?;
     verified = verified && (computed_end_root_hash == end_hash);

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -209,7 +209,7 @@ impl<S: Database + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
         info!("Starting inserting new leaves");
 
         if let Err(err) = current_azks
-            .batch_insert_leaves::<_>(&self.storage, sorted_insertion_set, InsertMode::Directory)
+            .batch_insert_nodes::<_>(&self.storage, sorted_insertion_set, InsertMode::Directory)
             .await
         {
             // If we fail to do the batch-leaf insert, we should rollback the transaction so we can try again cleanly.
@@ -345,7 +345,7 @@ impl<S: Database + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
 
         // Load nodes.
         current_azks
-            .bfs_preload_nodes_sorted::<_>(&self.storage, &sorted_lookup_labels)
+            .bfs_preload_nodes_bin_search::<_>(&self.storage, &sorted_lookup_labels)
             .await?;
 
         // Ensure we have got all lookup infos needed.
@@ -918,7 +918,7 @@ impl<S: Database + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
         info!("Starting database insertion");
 
         current_azks
-            .batch_insert_leaves::<_>(&self.storage, insertion_set, InsertMode::Directory)
+            .batch_insert_nodes::<_>(&self.storage, insertion_set, InsertMode::Directory)
             .await?;
 
         // batch all the inserts into a single transactional write to storage

--- a/akd/src/storage/cache/high_parallelism.rs
+++ b/akd/src/storage/cache/high_parallelism.rs
@@ -19,7 +19,9 @@ use log::info;
 #[cfg(feature = "runtime_metrics")]
 use log::{debug, error, warn};
 
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+#[cfg(feature = "runtime_metrics")]
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
@@ -34,10 +36,10 @@ pub struct TimedCache {
     can_clean: Arc<AtomicBool>,
     item_lifetime: Duration,
     memory_limit_bytes: Option<usize>,
+    clean_frequency: Duration,
 
     #[cfg(feature = "runtime_metrics")]
     hit_count: Arc<AtomicU64>,
-    clean_frequency: Duration,
 }
 
 impl TimedCache {
@@ -154,8 +156,10 @@ impl TimedCache {
             can_clean: Arc::new(AtomicBool::new(true)),
             item_lifetime: lifetime,
             memory_limit_bytes: o_memory_limit_bytes,
-            hit_count: Arc::new(AtomicU64::new(0u64)),
             clean_frequency,
+
+            #[cfg(feature = "runtime_metrics")]
+            hit_count: Arc::new(AtomicU64::new(0u64)),
         }
     }
 

--- a/akd/src/storage/cache/high_parallelism.rs
+++ b/akd/src/storage/cache/high_parallelism.rs
@@ -34,6 +34,8 @@ pub struct TimedCache {
     can_clean: Arc<AtomicBool>,
     item_lifetime: Duration,
     memory_limit_bytes: Option<usize>,
+
+    #[cfg(feature = "runtime_metrics")]
     hit_count: Arc<AtomicU64>,
     clean_frequency: Duration,
 }

--- a/akd/src/tree_node.rs
+++ b/akd/src/tree_node.rs
@@ -12,7 +12,6 @@ use crate::storage::manager::StorageManager;
 use crate::storage::types::{DbRecord, StorageType};
 use crate::storage::{Database, Storable};
 use crate::Digest;
-use crate::Node;
 use crate::{node_label::*, Direction, EMPTY_LABEL};
 use akd_core::hash::EMPTY_DIGEST;
 #[cfg(feature = "serde_serialization")]
@@ -521,28 +520,6 @@ impl TreeNode {
 }
 
 /////// Helpers //////
-
-pub(crate) fn get_longest_common_prefix(nodes: &[Node]) -> NodeLabel {
-    nodes.iter().skip(1).fold(nodes[0].label, |acc, node| {
-        node.label.get_longest_common_prefix(acc)
-    })
-}
-
-pub(crate) fn partition_longest_common_prefix(
-    nodes: Vec<Node>,
-    lcp_label: NodeLabel,
-) -> (Vec<crate::Node>, Vec<Node>) {
-    nodes
-        .into_iter()
-        .fold((vec![], vec![]), |(mut left, mut right), node| {
-            match lcp_label.get_dir(node.label) {
-                Direction::Left => left.push(node),
-                Direction::Right => right.push(node),
-                Direction::None => (),
-            };
-            (left, right)
-        })
-}
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum NodeHashingMode {

--- a/akd/src/utils.rs
+++ b/akd/src/utils.rs
@@ -5,7 +5,7 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree.
 
-// 1. Create a hashmap of all prefixes of all elements of the insertion set
+// 1. Create a hashmap of all prefixes of all elements of the node set
 // 2. For each node in current_nodes set, check if each child is in prefix hashmap
 // 3. If so, add child label to batch set
 

--- a/akd_core/src/types/node_label/mod.rs
+++ b/akd_core/src/types/node_label/mod.rs
@@ -92,9 +92,9 @@ impl NodeLabel {
         if self.label_len > other.label_len {
             return false;
         }
-        !(0..self.label_len)
+        (0..self.label_len)
             .into_iter()
-            .any(|i| self.get_bit_at(i) != other.get_bit_at(i))
+            .all(|i| self.get_bit_at(i) == other.get_bit_at(i))
     }
 
     /// Takes as input a pointer to the caller and another [NodeLabel],

--- a/akd_core/src/types/node_label/tests.rs
+++ b/akd_core/src/types/node_label/tests.rs
@@ -590,9 +590,9 @@ pub fn test_is_prefix_of() {
 
     // valid prefixes
     assert_eq!(label_1.is_prefix_of(&label_2), true);
-    assert_eq!(label_1.is_prefix_of(&label_3), false);
 
     // invalid prefixes
+    assert_eq!(label_1.is_prefix_of(&label_3), false);
     assert_eq!(label_2.is_prefix_of(&label_1), false);
     assert_eq!(label_2.is_prefix_of(&label_3), false);
     assert_eq!(label_3.is_prefix_of(&label_1), false);

--- a/akd_core/src/types/node_label/tests.rs
+++ b/akd_core/src/types/node_label/tests.rs
@@ -571,3 +571,30 @@ pub fn test_get_sibling_prefix() {
 
     assert!(label_rand_len_256.get_sibling_prefix(256) == label_rand_len_256_prefix_256_sibling);
 }
+
+#[test]
+pub fn test_is_prefix_of() {
+    let label_1 = NodeLabel::new(byte_arr_from_u64(0b01u64 << 62), 4u32);
+    let label_2 = NodeLabel::new(byte_arr_from_u64(0b010u64 << 61), 5u32);
+    let label_3 = NodeLabel::new(byte_arr_from_u64(0b0u64), 4u32);
+
+    // empty label is prefix of all labels
+    assert_eq!(EMPTY_LABEL.is_prefix_of(&label_1), true);
+    assert_eq!(EMPTY_LABEL.is_prefix_of(&label_2), true);
+    assert_eq!(EMPTY_LABEL.is_prefix_of(&label_3), true);
+
+    // every label is a prefix of itself
+    assert_eq!(label_1.is_prefix_of(&label_1), true);
+    assert_eq!(label_2.is_prefix_of(&label_2), true);
+    assert_eq!(label_3.is_prefix_of(&label_3), true);
+
+    // valid prefixes
+    assert_eq!(label_1.is_prefix_of(&label_2), true);
+    assert_eq!(label_1.is_prefix_of(&label_3), false);
+
+    // invalid prefixes
+    assert_eq!(label_2.is_prefix_of(&label_1), false);
+    assert_eq!(label_2.is_prefix_of(&label_3), false);
+    assert_eq!(label_3.is_prefix_of(&label_1), false);
+    assert_eq!(label_3.is_prefix_of(&label_2), false);
+}


### PR DESCRIPTION
# Overview
1. Adding a `NodeSet` enum that encodes information about whether a vector of nodes is binary searchable (i.e. nodes have the same label length AND are sorted). Our functions can then decide whether to apply binary search based on the enum variant.
    - This addresses the [minor issue in #306](https://github.com/facebook/akd/pull/306/files#r1057887531) where insertion sets are assumed to be binary searchable when they may not necessarily be.

2. Adding binary search to the partitioning of insertion sets + more efficient computation of LCP in an insertion set, as [suggested in #301](https://github.com/facebook/akd/pull/301#issuecomment-1365706006)

# Benchmark
Used 5fdad25 to represent main branch (it includes the fix for the benchmark I am running). Ran:
```console
$ cargo bench -p akd --bench azks -F bench
```


## Inserting 10K Nodes

Main:
![image](https://user-images.githubusercontent.com/20502803/209892339-66f0edf2-4958-47c3-b85c-6ec7f3d9ad4c.png)



This PR:
![image](https://user-images.githubusercontent.com/20502803/209892380-9fa8da78-e923-43c8-8688-f38a8a8c5975.png)

No improvements observed at this scale.


## Inserting 100K Nodes
Main:
![image](https://user-images.githubusercontent.com/20502803/209892467-2c5a966f-9661-4f9c-9b46-608e931f3f65.png)

This PR:
![image](https://user-images.githubusercontent.com/20502803/209892447-485058e7-01e6-42dd-8994-8d1287f219e6.png)

Minor perf improvements observed.