### PR TITLE
Fixing VRF map for already-existing labels and introducing VersionFreshness enum

### DIFF
--- a/akd_core/src/types/mod.rs
+++ b/akd_core/src/types/mod.rs
@@ -50,6 +50,18 @@ pub trait SizeOf {
 // Typedefs and constants
 // ============================================
 
+/// Whether or not a node is marked as stale or fresh
+/// Stale nodes are no longer active because a newer
+/// version exists to replace them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum VersionFreshness {
+    /// Represents not being the most recent version
+    Stale = 0u8,
+    /// Corresponds to the most recent version
+    Fresh = 1u8,
+}
+
 /// This type is used to indicate a direction for a
 /// particular node relative to its parent. We use
 /// 0 to represent "left" and 1 to represent "right".

--- a/akd_core/src/verify/base.rs
+++ b/akd_core/src/verify/base.rs
@@ -11,7 +11,9 @@ use super::VerificationError;
 
 use crate::ecvrf::{Proof, VrfError};
 use crate::hash::{build_and_hash_layer, merge, Digest};
-use crate::{AkdLabel, MembershipProof, NodeLabel, NonMembershipProof, ARITY, EMPTY_LABEL};
+use crate::{
+    AkdLabel, MembershipProof, NodeLabel, NonMembershipProof, VersionFreshness, ARITY, EMPTY_LABEL,
+};
 
 #[cfg(feature = "nostd")]
 use alloc::format;
@@ -104,13 +106,13 @@ pub fn verify_nonmembership(
 pub(crate) fn verify_label(
     vrf_public_key: &[u8],
     akd_label: &AkdLabel,
-    stale: bool,
+    freshness: VersionFreshness,
     version: u64,
     vrf_proof: &[u8],
     node_label: NodeLabel,
 ) -> Result<(), VerificationError> {
     let vrf_pk = crate::ecvrf::VRFPublicKey::try_from(vrf_public_key)?;
-    let hashed_label = crate::utils::get_hash_from_label_input(akd_label, stale, version);
+    let hashed_label = crate::utils::get_hash_from_label_input(akd_label, freshness, version);
 
     // VRF proof verification (returns VRF hash output)
     let proof = Proof::try_from(vrf_proof)?;

--- a/akd_core/src/verify/history.rs
+++ b/akd_core/src/verify/history.rs
@@ -12,7 +12,7 @@ use super::VerificationError;
 use crate::utils::hash_leaf_with_value;
 
 use crate::hash::{hash, merge_with_int, Digest};
-use crate::{AkdLabel, HistoryProof, UpdateProof, VerifyResult};
+use crate::{AkdLabel, HistoryProof, UpdateProof, VerifyResult, VersionFreshness};
 #[cfg(feature = "nostd")]
 use alloc::format;
 #[cfg(feature = "nostd")]
@@ -111,7 +111,14 @@ pub fn key_history_verify(
         let pf = &proof.non_existence_of_next_few[i];
         let vrf_pf = &proof.next_few_vrf_proofs[i];
         let ver_label = pf.label;
-        verify_label(vrf_public_key, &akd_key, false, ver, vrf_pf, ver_label)?;
+        verify_label(
+            vrf_public_key,
+            &akd_key,
+            VersionFreshness::Fresh,
+            ver,
+            vrf_pf,
+            ver_label,
+        )?;
         if verify_nonmembership(root_hash, pf).is_err() {
             return Err(VerificationError::HistoryProof(format!("Non-existence of next few proof of user {:?}'s version {:?} at epoch {:?} does not verify",
             &akd_key, ver, current_epoch)));
@@ -124,7 +131,14 @@ pub fn key_history_verify(
         let pf = &proof.non_existence_of_future_markers[i];
         let vrf_pf = &proof.future_marker_vrf_proofs[i];
         let ver_label = pf.label;
-        verify_label(vrf_public_key, &akd_key, false, ver, vrf_pf, ver_label)?;
+        verify_label(
+            vrf_public_key,
+            &akd_key,
+            VersionFreshness::Fresh,
+            ver,
+            vrf_pf,
+            ver_label,
+        )?;
         if verify_nonmembership(root_hash, pf).is_err() {
             return Err(VerificationError::HistoryProof(format!("Non-existence of future marker proof of user {:?}'s version {:?} at epoch {:?} does not verify",
             akd_key, ver, current_epoch)));
@@ -170,7 +184,7 @@ fn verify_single_update_proof(
     verify_label(
         vrf_public_key,
         uname,
-        false,
+        VersionFreshness::Fresh,
         version,
         &proof.existence_vrf_proof,
         existence_at_ep.label,
@@ -215,7 +229,7 @@ fn verify_single_update_proof(
         verify_label(
             vrf_public_key,
             uname,
-            true,
+            VersionFreshness::Stale,
             version - 1,
             previous_version_vrf_proof,
             previous_version_stale_at_ep.label,

--- a/akd_core/src/verify/lookup.rs
+++ b/akd_core/src/verify/lookup.rs
@@ -12,7 +12,7 @@ use super::VerificationError;
 use crate::utils::hash_leaf_with_value;
 
 use crate::hash::Digest;
-use crate::{AkdLabel, LookupProof, VerifyResult};
+use crate::{AkdLabel, LookupProof, VerifyResult, VersionFreshness};
 #[cfg(feature = "nostd")]
 use alloc::string::ToString;
 
@@ -43,7 +43,7 @@ pub fn lookup_verify(
     verify_label(
         vrf_public_key,
         &akd_label,
-        false,
+        VersionFreshness::Fresh,
         version,
         &proof.existence_vrf_proof,
         fresh_label,
@@ -54,7 +54,7 @@ pub fn lookup_verify(
     verify_label(
         vrf_public_key,
         &akd_label,
-        false,
+        VersionFreshness::Fresh,
         marker_version,
         &proof.marker_vrf_proof,
         marker_label,
@@ -66,7 +66,7 @@ pub fn lookup_verify(
     verify_label(
         vrf_public_key,
         &akd_label,
-        true,
+        VersionFreshness::Stale,
         version,
         &proof.freshness_vrf_proof,
         stale_label,


### PR DESCRIPTION
Closes #304 by using a flat_map in publish when computing the VRF map.

Also, instead of using a boolean stale value passed around, I am introducing a `VersionFreshness` enum to track whether or not a node is marked as stale or fresh.