### PR TITLE
Add TODO for Issue 314

### DIFF
--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -240,6 +240,8 @@ impl Azks {
                     DIRECTIONS
                         .iter()
                         .filter_map(|dir| {
+                            // TODO (Issue #314): Migrate away from a panic in favor of a compile-time
+                            // error for an invalid directional state.
                             node.get_child_label(*dir)
                                 .unwrap_or_else(|_| {
                                     panic!("Attempted to load an invalid direction: {:?}", dir)


### PR DESCRIPTION
- Add a TODO linking a panic that we'd like to convert into a compile-time error instead. For more information, please see: https://github.com/facebook/akd/issues/314.