### PR TITLE
Invert Filter on Preload to Ensure Appropriate Nodes are Preloaded

### DIFF
--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -861,6 +861,7 @@ type AppendOnlyHelper = (Vec<Node>, Vec<Node>);
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::storage::types::DbRecord;
     use crate::utils::byte_arr_from_u64;
     use crate::{
         auditor::audit_verify,
@@ -869,6 +870,7 @@ mod tests {
         EMPTY_VALUE,
     };
     use rand::{rngs::OsRng, seq::SliceRandom, RngCore};
+    use std::time::Duration;
 
     #[tokio::test]
     async fn test_batch_insert_basic() -> Result<(), AkdError> {
@@ -1023,6 +1025,86 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_preload_nodes_accuracy() {
+        let database = AsyncInMemoryDatabase::new();
+        let storage_manager =
+            StorageManager::new(&database, Some(Duration::from_secs(180u64)), None, None);
+        let mut azks = Azks::new::<_>(&storage_manager)
+            .await
+            .expect("Failed to create azks!");
+        azks.increment_epoch();
+
+        // Construct our tree
+        let root_label = NodeLabel::root();
+
+        let left_label = NodeLabel::new(byte_arr_from_u64(1), 1);
+        let left = DbRecord::TreeNode(TreeNodeWithPreviousValue::from_tree_node(TreeNode {
+            label: left_label,
+            last_epoch: 1,
+            min_descendant_epoch: 1,
+            parent: root_label,
+            node_type: NodeType::Leaf,
+            left_child: None,
+            right_child: None,
+            hash: crate::hash::EMPTY_DIGEST,
+        }));
+        let right_label = NodeLabel::new(byte_arr_from_u64(2), 2);
+        let right = DbRecord::TreeNode(TreeNodeWithPreviousValue::from_tree_node(TreeNode {
+            label: right_label,
+            last_epoch: 1,
+            min_descendant_epoch: 1,
+            parent: root_label,
+            node_type: NodeType::Leaf,
+            left_child: None,
+            right_child: None,
+            hash: crate::hash::EMPTY_DIGEST,
+        }));
+        let root = DbRecord::TreeNode(TreeNodeWithPreviousValue::from_tree_node(TreeNode {
+            label: root_label,
+            last_epoch: 1,
+            min_descendant_epoch: 1,
+            parent: root_label,
+            node_type: NodeType::Root,
+            left_child: Some(left_label),
+            right_child: Some(right_label),
+            hash: crate::hash::EMPTY_DIGEST,
+        }));
+
+        // Seed the database and cache with our tree
+        storage_manager
+            .batch_set(vec![root, left, right])
+            .await
+            .expect("Failed to seed database for preload test");
+
+        // Preload nodes to populate storage manager cache
+        let node_set = NodeSet::from(vec![
+            Node {
+                label: root_label,
+                hash: crate::hash::EMPTY_DIGEST,
+            },
+            Node {
+                label: left_label,
+                hash: crate::hash::EMPTY_DIGEST,
+            },
+            Node {
+                label: right_label,
+                hash: crate::hash::EMPTY_DIGEST,
+            },
+        ]);
+        let expected_preload_count = 3u64;
+        let actual_preload_count = azks
+            .preload_nodes(&storage_manager, &node_set)
+            .await
+            .expect("Failed to preload nodes");
+
+        assert_eq!(
+            expected_preload_count, actual_preload_count,
+            "Preload count returned unexpected value!"
+        );
     }
 
     #[tokio::test]

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -435,7 +435,7 @@ impl Azks {
             // individually for each node's state.
             current_nodes = nodes
                 .iter()
-                .filter(|node| !node_set.contains_prefix(&node.label))
+                .filter(|node| node_set.contains_prefix(&node.label))
                 .flat_map(|node| {
                     DIRECTIONS
                         .iter()
@@ -1028,7 +1028,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_preload_nodes_accuracy() {
         let database = AsyncInMemoryDatabase::new();
         let storage_manager =

--- a/akd/src/storage/memory.rs
+++ b/akd/src/storage/memory.rs
@@ -160,14 +160,14 @@ impl Database for AsyncInMemoryDatabase {
         &self,
         ids: &[St::StorageKey],
     ) -> Result<Vec<DbRecord>, StorageError> {
-        let mut map = Vec::new();
+        let mut records = Vec::new();
         for key in ids.iter() {
             if let Ok(result) = self.get::<St>(key).await {
-                map.push(result);
+                records.push(result);
             }
             // swallow errors (i.e. not found)
         }
-        Ok(map)
+        Ok(records)
     }
 
     /// Retrieve the user data for a given user

--- a/akd/src/storage/transaction.rs
+++ b/akd/src/storage/transaction.rs
@@ -5,7 +5,7 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree.
 
-//! A simple in-memory transaction object to minize data-layer operations
+//! A simple in-memory transaction object to minimize data-layer operations
 
 use crate::errors::StorageError;
 use crate::storage::types::DbRecord;

--- a/akd/src/tree_node.rs
+++ b/akd/src/tree_node.rs
@@ -228,7 +228,7 @@ pub struct TreeNode {
     pub label: NodeLabel,
     /// The last epoch this node was updated in.
     pub last_epoch: u64,
-    /// The minumum last_epoch across all descendants of this node.
+    /// The minimum last_epoch across all descendants of this node.
     pub min_descendant_epoch: u64,
     /// The label of this node's parent. where the root node is marked its own parent.
     pub parent: NodeLabel,


### PR DESCRIPTION
- Prior to a more functional approach to preloading being adopted in #312, the "filter" that was being applied was used to continue within a loop. However, now that we're filtering in an iterator, the check should be inverted such that we continue iterating over the appropriate nodes.


- [x] Manually test to verify that preload is preloading more than one value
- [x] Add unit tests to catch this case