### PR TITLE
Add Send and Sync trait bounds to Database trait

### DIFF
--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -21,7 +21,7 @@ use akd_core::SizeOf;
 use async_recursion::async_recursion;
 use log::info;
 use std::cmp::Ordering;
-use std::marker::{Send, Sync};
+use std::marker::Sync;
 use std::ops::Deref;
 
 /// The default azks key
@@ -232,9 +232,7 @@ unsafe impl Sync for Azks {}
 
 impl Azks {
     /// Creates a new azks
-    pub async fn new<S: Database + Sync + Send>(
-        storage: &StorageManager<S>,
-    ) -> Result<Self, AkdError> {
+    pub async fn new<S: Database>(storage: &StorageManager<S>) -> Result<Self, AkdError> {
         create_empty_root::<S>(storage, Option::Some(0), Option::Some(0)).await?;
         let azks = Azks {
             latest_epoch: 0,
@@ -245,7 +243,7 @@ impl Azks {
     }
 
     /// Insert a batch of new leaves.
-    pub async fn batch_insert_nodes<S: Database + Sync + Send>(
+    pub async fn batch_insert_nodes<S: Database>(
         &mut self,
         storage: &StorageManager<S>,
         nodes: Vec<Node>,
@@ -290,7 +288,7 @@ impl Azks {
     }
 
     /// Preloads given nodes using breadth-first search.
-    pub(crate) async fn preload_nodes<S: Database + Send + Sync>(
+    pub(crate) async fn preload_nodes<S: Database>(
         &self,
         storage: &StorageManager<S>,
         node_set: &NodeSet,
@@ -332,7 +330,7 @@ impl Azks {
 
     /// Inserts a batch of leaves recursively from a given node label.
     #[async_recursion]
-    pub(crate) async fn recursive_batch_insert_nodes<S: Database + Sync + Send>(
+    pub(crate) async fn recursive_batch_insert_nodes<S: Database>(
         storage: &StorageManager<S>,
         node_label: Option<NodeLabel>,
         node_set: NodeSet,
@@ -440,7 +438,7 @@ impl Azks {
 
     /// Returns the Merkle membership proof for the trie as it stood at epoch
     // Assumes the verifier has access to the root at epoch
-    pub async fn get_membership_proof<S: Database + Sync + Send>(
+    pub async fn get_membership_proof<S: Database>(
         &self,
         storage: &StorageManager<S>,
         label: NodeLabel,
@@ -457,7 +455,7 @@ impl Azks {
     /// In a compressed trie, the proof consists of the longest prefix
     /// of the label that is included in the trie, as well as its children, to show that
     /// none of the children is equal to the given label.
-    pub async fn get_non_membership_proof<S: Database + Sync + Send>(
+    pub async fn get_non_membership_proof<S: Database>(
         &self,
         storage: &StorageManager<S>,
         label: NodeLabel,
@@ -514,7 +512,7 @@ impl Azks {
     /// **RESTRICTIONS**: Note that `start_epoch` and `end_epoch` are valid only when the following are true
     /// * `start_epoch` <= `end_epoch`
     /// * `start_epoch` and `end_epoch` are both existing epochs of this AZKS
-    pub async fn get_append_only_proof<S: Database + Sync + Send>(
+    pub async fn get_append_only_proof<S: Database>(
         &self,
         storage: &StorageManager<S>,
         start_epoch: u64,
@@ -593,7 +591,7 @@ impl Azks {
         }
     }
 
-    async fn gather_audit_proof_nodes<S: Database + Sync + Send>(
+    async fn gather_audit_proof_nodes<S: Database>(
         &self,
         nodes: Vec<TreeNode>,
         storage: &StorageManager<S>,
@@ -625,7 +623,7 @@ impl Azks {
     }
 
     #[async_recursion]
-    async fn get_append_only_proof_helper<S: Database + Sync + Send>(
+    async fn get_append_only_proof_helper<S: Database>(
         &self,
         storage: &StorageManager<S>,
         node: TreeNode,
@@ -689,7 +687,7 @@ impl Azks {
 
     // FIXME: these functions below should be moved into higher-level API
     /// Gets the root hash for this azks
-    pub async fn get_root_hash<S: Database + Sync + Send>(
+    pub async fn get_root_hash<S: Database>(
         &self,
         storage: &StorageManager<S>,
     ) -> Result<Digest, AkdError> {
@@ -699,7 +697,7 @@ impl Azks {
 
     /// Gets the root hash of the tree at the latest epoch if the passed epoch
     /// is equal to the latest epoch. Will return an error otherwise.
-    pub async fn get_root_hash_safe<S: Database + Sync + Send>(
+    pub async fn get_root_hash_safe<S: Database>(
         &self,
         storage: &StorageManager<S>,
         epoch: u64,
@@ -732,7 +730,7 @@ impl Azks {
     }
 
     /// Gets the sibling node of the passed node's child in the "opposite" of the passed direction.
-    async fn get_sibling_node<S: Database + Sync + Send>(
+    async fn get_sibling_node<S: Database>(
         &self,
         storage: &StorageManager<S>,
         curr_node: &TreeNode,
@@ -766,7 +764,7 @@ impl Azks {
     /// This function returns the node label for the node whose label is the longest common
     /// prefix for the queried label. It also returns a membership proof for said label.
     /// This is meant to be used in both getting membership proofs and getting non-membership proofs.
-    pub async fn get_membership_proof_and_node<S: Database + Sync + Send>(
+    pub async fn get_membership_proof_and_node<S: Database>(
         &self,
         storage: &StorageManager<S>,
         label: NodeLabel,

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -24,12 +24,11 @@ use akd_core::utils::{commit_value, get_commitment_nonce};
 use akd_core::VersionFreshness;
 use log::{error, info};
 use std::collections::HashMap;
-use std::marker::{Send, Sync};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
 /// The representation of a auditable key directory
-pub struct Directory<S: Database + Sync + Send, V> {
+pub struct Directory<S: Database, V> {
     storage: StorageManager<S>,
     vrf: V,
     read_only: bool,
@@ -43,7 +42,7 @@ pub struct Directory<S: Database + Sync + Send, V> {
 }
 
 // Manual implementation of Clone, see: https://github.com/rust-lang/rust/issues/41481
-impl<S: Database + Sync + Send, V: VRFKeyStorage> Clone for Directory<S, V> {
+impl<S: Database, V: VRFKeyStorage> Clone for Directory<S, V> {
     fn clone(&self) -> Self {
         Self {
             storage: self.storage.clone(),
@@ -54,7 +53,7 @@ impl<S: Database + Sync + Send, V: VRFKeyStorage> Clone for Directory<S, V> {
     }
 }
 
-impl<S: Database + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
+impl<S: Database, V: VRFKeyStorage> Directory<S, V> {
     /// Creates a new (stateless) instance of a auditable key directory.
     /// Takes as input a pointer to the storage being used for this instance.
     /// The state is stored in the storage.
@@ -788,7 +787,7 @@ pub(crate) fn get_marker_version(version: u64) -> u64 {
 }
 
 /// Gets the azks root hash at the current epoch.
-pub async fn get_directory_root_hash_and_ep<S: Database + Sync + Send, V: VRFKeyStorage>(
+pub async fn get_directory_root_hash_and_ep<S: Database, V: VRFKeyStorage>(
     akd_dir: &Directory<S, V>,
 ) -> Result<(Digest, u64), AkdError> {
     let current_azks = akd_dir.retrieve_current_azks().await?;
@@ -809,7 +808,7 @@ pub enum PublishCorruption {
 }
 
 #[cfg(test)]
-impl<S: Database + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
+impl<S: Database, V: VRFKeyStorage> Directory<S, V> {
     /// Updates the directory to include the updated key-value pairs with possible issues.
     pub(crate) async fn publish_malicious_update(
         &self,

--- a/akd/src/storage/manager/mod.rs
+++ b/akd/src/storage/manager/mod.rs
@@ -51,7 +51,7 @@ mod tests;
 
 /// Represents the manager of the storage mediums, including caching
 /// and transactional operations (creating the transaction, commiting it, etc)
-pub struct StorageManager<Db: Database + Sync + Send> {
+pub struct StorageManager<Db: Database> {
     cache: Option<TimedCache>,
     transaction: Transaction,
     /// The underlying database managed by this storage manager
@@ -60,7 +60,7 @@ pub struct StorageManager<Db: Database + Sync + Send> {
     metrics: [Arc<AtomicU64>; NUM_METRICS],
 }
 
-impl<Db: Database + Sync + Send> Clone for StorageManager<Db> {
+impl<Db: Database> Clone for StorageManager<Db> {
     fn clone(&self) -> Self {
         Self {
             cache: self.cache.clone(),
@@ -71,10 +71,10 @@ impl<Db: Database + Sync + Send> Clone for StorageManager<Db> {
     }
 }
 
-unsafe impl<Db: Database + Sync + Send> Sync for StorageManager<Db> {}
-unsafe impl<Db: Database + Sync + Send> Send for StorageManager<Db> {}
+unsafe impl<Db: Database> Sync for StorageManager<Db> {}
+unsafe impl<Db: Database> Send for StorageManager<Db> {}
 
-impl<Db: Database + Sync + Send> StorageManager<Db> {
+impl<Db: Database> StorageManager<Db> {
     /// Create a new storage manager with NO CACHE
     pub fn new_no_cache(db: &Db) -> Self {
         Self {

--- a/akd/src/storage/mod.rs
+++ b/akd/src/storage/mod.rs
@@ -16,7 +16,7 @@ use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
 use std::collections::HashMap;
 use std::hash::Hash;
-use std::marker::Send;
+use std::marker::{Send, Sync};
 
 pub mod cache;
 pub mod transaction;
@@ -93,7 +93,7 @@ pub trait Storable: Clone + Sync {
 
 /// A database implementation backing storage for the AKD
 #[async_trait]
-pub trait Database: Clone {
+pub trait Database: Clone + Send + Sync {
     /// Set a record in the database
     async fn set(&self, record: DbRecord) -> Result<(), StorageError>;
 

--- a/akd/src/storage/tests.rs
+++ b/akd/src/storage/tests.rs
@@ -43,7 +43,7 @@ mod memory_storage_tests {
 /// Run the storage-layer test suite for a given storage implementation.
 /// This is public because it can be used by other implemented storage layers
 /// for consistency checks (e.g. mysql, memcached, etc)
-pub async fn run_test_cases_for_storage_impl<S: Database + Sync + Send>(db: &S) {
+pub async fn run_test_cases_for_storage_impl<S: Database>(db: &S) {
     test_get_and_set_item(db).await;
     test_user_data(db).await;
     test_transactions(db).await;
@@ -312,7 +312,7 @@ async fn test_batch_get_items<Ns: Database>(storage: &Ns) {
     }
 }
 
-async fn test_transactions<S: Database + Sync + Send>(db: &S) {
+async fn test_transactions<S: Database>(db: &S) {
     let storage = crate::storage::manager::StorageManager::new_no_cache(db);
 
     let mut rand_users: Vec<Vec<u8>> = vec![];
@@ -394,7 +394,7 @@ async fn test_transactions<S: Database + Sync + Send>(db: &S) {
     }
 }
 
-async fn test_user_data<S: Database + Sync + Send>(storage: &S) {
+async fn test_user_data<S: Database>(storage: &S) {
     let rand_user = thread_rng()
         .sample_iter(&Alphanumeric)
         .take(30)
@@ -593,7 +593,7 @@ async fn test_user_data<S: Database + Sync + Send>(storage: &S) {
     assert_eq!(4, data.unwrap().states.len());
 }
 
-async fn test_tombstoning_data<S: Database + Sync + Send>(
+async fn test_tombstoning_data<S: Database>(
     storage: &StorageManager<S>,
 ) -> Result<(), crate::errors::AkdError> {
     let rand_user = thread_rng()

--- a/akd/src/tests.rs
+++ b/akd/src/tests.rs
@@ -1173,7 +1173,7 @@ async fn test_simple_lookup_for_small_tree_sha256() -> Result<(), AkdError> {
 =========== Test Helpers ===========
 */
 
-async fn async_poll_helper_proof<T: Database + Sync + Send, V: VRFKeyStorage>(
+async fn async_poll_helper_proof<T: Database, V: VRFKeyStorage>(
     reader: &Directory<T, V>,
     value: AkdValue,
 ) -> Result<(), AkdError> {

--- a/akd/src/tree_node.rs
+++ b/akd/src/tree_node.rs
@@ -18,7 +18,7 @@ use akd_core::hash::EMPTY_DIGEST;
 use akd_core::utils::serde_helpers::{bytes_deserialize_hex, bytes_serialize_hex};
 use std::cmp::{max, min};
 use std::convert::TryInto;
-use std::marker::{Send, Sync};
+use std::marker::Sync;
 
 /// There are three types of nodes: root, leaf and interior.
 /// This enum is used to mark the type of a [TreeNode].
@@ -165,14 +165,14 @@ impl TreeNodeWithPreviousValue {
         }
     }
 
-    pub(crate) async fn write_to_storage<S: Database + Send + Sync>(
+    pub(crate) async fn write_to_storage<S: Database>(
         &self,
         storage: &StorageManager<S>,
     ) -> Result<(), StorageError> {
         storage.set(DbRecord::TreeNode(self.clone())).await
     }
 
-    pub(crate) async fn get_appropriate_tree_node_from_storage<S: Database + Send + Sync>(
+    pub(crate) async fn get_appropriate_tree_node_from_storage<S: Database>(
         storage: &StorageManager<S>,
         key: &NodeKey,
         target_epoch: u64,
@@ -186,7 +186,7 @@ impl TreeNodeWithPreviousValue {
         }
     }
 
-    pub(crate) async fn batch_get_appropriate_tree_node_from_storage<S: Database + Send + Sync>(
+    pub(crate) async fn batch_get_appropriate_tree_node_from_storage<S: Database>(
         storage: &StorageManager<S>,
         keys: &[NodeKey],
         target_epoch: u64,
@@ -264,7 +264,7 @@ impl akd_core::SizeOf for TreeNode {
 
 impl TreeNode {
     // Storage operations
-    pub(crate) async fn write_to_storage<S: Database + Send + Sync>(
+    pub(crate) async fn write_to_storage<S: Database>(
         &self,
         storage: &StorageManager<S>,
     ) -> Result<(), StorageError> {
@@ -273,7 +273,7 @@ impl TreeNode {
 
     /// Internal function to be used for storage operations. If a node is new (i.e., is_new_node=true), the node's previous version
     /// will be used as None without the cost of finding this information in the cache or worse yet in the database.
-    async fn write_to_storage_impl<S: Database + Send + Sync>(
+    async fn write_to_storage_impl<S: Database>(
         &self,
         storage: &StorageManager<S>,
         is_new_node: bool,
@@ -321,7 +321,7 @@ impl TreeNode {
         left_shifted.write_to_storage(storage).await
     }
 
-    pub(crate) async fn get_from_storage<S: Database + Send + Sync>(
+    pub(crate) async fn get_from_storage<S: Database>(
         storage: &StorageManager<S>,
         key: &NodeKey,
         target_epoch: u64,
@@ -334,7 +334,7 @@ impl TreeNode {
         .await
     }
 
-    pub(crate) async fn batch_get_from_storage<S: Database + Send + Sync>(
+    pub(crate) async fn batch_get_from_storage<S: Database>(
         storage: &StorageManager<S>,
         keys: &[NodeKey],
         target_epoch: u64,
@@ -362,7 +362,7 @@ impl TreeNode {
     // FIXME: Figure out how to better group arguments.
     #[allow(clippy::too_many_arguments)]
     /// Creates a new TreeNode and writes it to the storage.
-    async fn new<S: Database + Send + Sync>(
+    async fn new<S: Database>(
         storage: &StorageManager<S>,
         label: NodeLabel,
         parent: NodeLabel,
@@ -388,7 +388,7 @@ impl TreeNode {
     }
 
     /// Updates the node hash and saves it in storage.
-    pub(crate) async fn update_node_hash<S: Database + Sync + Send>(
+    pub(crate) async fn update_node_hash<S: Database>(
         &mut self,
         storage: &StorageManager<S>,
         hash_mode: NodeHashingMode,
@@ -428,7 +428,7 @@ impl TreeNode {
 
     /// Inserts a child into this node, adding the state to the state at this epoch,
     /// without updating its own hash.
-    pub(crate) async fn set_child<S: Database + Sync + Send>(
+    pub(crate) async fn set_child<S: Database>(
         &mut self,
         storage: &StorageManager<S>,
         child_node: &mut TreeNode,
@@ -470,7 +470,7 @@ impl TreeNode {
     ///// getrs for child nodes ////
 
     /// Loads (from storage) the left or right child of a node using given direction and epoch
-    pub(crate) async fn get_child_node<S: Database + Sync + Send>(
+    pub(crate) async fn get_child_node<S: Database>(
         &self,
         storage: &StorageManager<S>,
         direction: Direction,
@@ -569,7 +569,7 @@ pub(crate) fn optional_child_state_hash(input: &Option<TreeNode>) -> Digest {
 }
 
 /// Create an empty root node.
-pub(crate) async fn create_empty_root<S: Database + Sync + Send>(
+pub(crate) async fn create_empty_root<S: Database>(
     storage: &StorageManager<S>,
     ep: Option<u64>,
     smallest_descendant_ep: Option<u64>,
@@ -600,7 +600,7 @@ pub(crate) async fn create_empty_root<S: Database + Sync + Send>(
 
 /// Create an interior node by splitting off from an existing node, pushing the
 /// existing node down and setting it as a child of the new node.
-pub(crate) async fn create_interior_node_from_existing_node<S: Database + Sync + Send>(
+pub(crate) async fn create_interior_node_from_existing_node<S: Database>(
     storage: &StorageManager<S>,
     existing_node: &mut TreeNode,
     new_label: NodeLabel,
@@ -626,7 +626,7 @@ pub(crate) async fn create_interior_node_from_existing_node<S: Database + Sync +
 }
 
 /// Create an interior node with an empty hash.
-pub(crate) async fn create_interior_node<S: Database + Sync + Send>(
+pub(crate) async fn create_interior_node<S: Database>(
     storage: &StorageManager<S>,
     label: NodeLabel,
     birth_epoch: u64,
@@ -647,7 +647,7 @@ pub(crate) async fn create_interior_node<S: Database + Sync + Send>(
 }
 
 /// Create a specific leaf node.
-pub(crate) async fn create_leaf_node<S: Database + Sync + Send>(
+pub(crate) async fn create_leaf_node<S: Database>(
     storage: &StorageManager<S>,
     label: NodeLabel,
     value: &Digest,

--- a/akd_test_tools/src/test_suites.rs
+++ b/akd_test_tools/src/test_suites.rs
@@ -18,7 +18,7 @@ use rand::{thread_rng, Rng};
 /// The suite of tests to run against a fully-instantated and storage-backed directory.
 /// This will publish 3 epochs of ```num_users``` records and
 /// perform 10 random lookup proofs + 2 random history proofs + and audit proof from epochs 1u64 -> 2u64
-pub async fn directory_test_suite<S: akd::storage::Database + Sync + Send, V: VRFKeyStorage>(
+pub async fn directory_test_suite<S: akd::storage::Database, V: VRFKeyStorage>(
     mysql_db: &akd::storage::StorageManager<S>,
     num_users: usize,
     vrf: &V,

--- a/integration_tests/src/test_util.rs
+++ b/integration_tests/src/test_util.rs
@@ -120,7 +120,7 @@ impl log::Log for FileLogger {
 
 // ================== Test Helpers ================== //
 
-pub(crate) async fn test_lookups<S: akd::storage::Database + Sync + Send, V: VRFKeyStorage>(
+pub(crate) async fn test_lookups<S: akd::storage::Database, V: VRFKeyStorage>(
     mysql_db: &StorageManager<S>,
     vrf: &V,
     num_users: u64,
@@ -241,7 +241,7 @@ pub(crate) async fn test_lookups<S: akd::storage::Database + Sync + Send, V: VRF
 // Reset MySQL database by logging metrics which resets the metrics, and flushing cache.
 // These allow us to accurately assess the additional efficiency of
 // bulk lookup proofs.
-async fn reset_mysql_db<S: akd::storage::Database + Sync + Send>(mysql_db: &StorageManager<S>) {
+async fn reset_mysql_db<S: akd::storage::Database>(mysql_db: &StorageManager<S>) {
     mysql_db.log_metrics(Level::Trace).await;
     mysql_db.flush_cache().await;
 }

--- a/poc/src/directory_host.rs
+++ b/poc/src/directory_host.rs
@@ -35,7 +35,7 @@ pub enum DirectoryCommand {
 
 async fn get_root_hash<S, V>(directory: &mut Directory<S, V>) -> Option<Result<Digest, AkdError>>
 where
-    S: Database + Sync + Send,
+    S: Database,
     V: VRFKeyStorage,
 {
     if let Ok(azks) = directory.retrieve_current_azks().await {
@@ -47,7 +47,7 @@ where
 
 pub(crate) async fn init_host<S, V>(rx: &mut Receiver<Rpc>, directory: &mut Directory<S, V>)
 where
-    S: Database + Sync + Send,
+    S: Database,
     V: VRFKeyStorage,
 {
     info!("Starting the verifiable directory host");


### PR DESCRIPTION
Per suggestion in https://github.com/facebook/akd/pull/302#discussion_r1057996150, this simplifies the use of the `Database` trait. It seems reasonable to expect that all implementors of the trait will be thread-safe.