### PR TITLE
Preload nodes in lookups

### DIFF
--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 
 use akd_core::SizeOf;
+use akd_core::hash::EMPTY_DIGEST;
 use async_recursion::async_recursion;
 use log::info;
 use std::cmp::Ordering;
@@ -287,6 +288,22 @@ impl Azks {
         }
 
         Ok(())
+    }
+
+    pub(crate) async fn preload_lookup_nodes<S: Database + Send + Sync>(&self, storage: &StorageManager<S>, lookup_labels: &[NodeLabel]) -> Result<u64, AkdError> {
+        // Create nodes for labels.
+        let lookup_nodes: Vec<Node> = lookup_labels
+            .into_iter()
+            .map(|&l| Node {
+                label: l,
+                hash: EMPTY_DIGEST,
+            })
+            .collect();
+
+        // Load nodes. Note NodeSet will sort these nodes for efficient preloading.
+        self
+            .preload_nodes(storage, &NodeSet::from(lookup_nodes))
+            .await
     }
 
     /// Preloads given nodes using breadth-first search.

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -7,6 +7,7 @@
 
 //! An implementation of an append-only zero knowledge set
 use crate::errors::TreeNodeError;
+use crate::helper_structs::LookupInfo;
 use crate::storage::manager::StorageManager;
 use crate::storage::types::StorageType;
 use crate::{
@@ -290,11 +291,14 @@ impl Azks {
         Ok(())
     }
 
-    pub(crate) async fn preload_lookup_nodes<S: Database + Send + Sync>(&self, storage: &StorageManager<S>, lookup_labels: &[NodeLabel]) -> Result<u64, AkdError> {
-        // Create nodes for labels.
-        let lookup_nodes: Vec<Node> = lookup_labels
+    pub(crate) async fn preload_lookup_nodes<S: Database + Send + Sync>(&self, storage: &StorageManager<S>, lookup_infos: &[LookupInfo]) -> Result<u64, AkdError> {
+        // Collect lookup labels needed and convert them into Nodes for preloading.
+        let lookup_nodes: Vec<Node> = lookup_infos
             .into_iter()
-            .map(|&l| Node {
+            .flat_map(|li| {
+               vec![li.existent_label, li.marker_label, li.non_existent_label] 
+            })
+            .map(|l| Node {
                 label: l,
                 hash: EMPTY_DIGEST,
             })

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -306,7 +306,7 @@ impl Azks {
             })
             .collect();
 
-        // Load nodes. Note NodeSet will sort these nodes for efficient preloading.
+        // Load nodes.
         self.preload_nodes(storage, &NodeSet::from(lookup_nodes))
             .await
     }

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -298,7 +298,7 @@ impl Azks {
     ) -> Result<u64, AkdError> {
         // Collect lookup labels needed and convert them into Nodes for preloading.
         let lookup_nodes: Vec<Node> = lookup_infos
-            .into_iter()
+            .iter()
             .flat_map(|li| vec![li.existent_label, li.marker_label, li.non_existent_label])
             .map(|l| Node {
                 label: l,
@@ -1039,7 +1039,7 @@ mod tests {
         let nodes = gen_nodes(num_nodes);
         let unsorted_set = NodeSet::Unsorted(nodes.clone());
         let bin_searchable_set = {
-            let mut nodes = nodes.clone();
+            let mut nodes = nodes;
             nodes.sort_unstable();
             NodeSet::BinarySearchable(nodes)
         };
@@ -1086,7 +1086,7 @@ mod tests {
         let nodes = gen_nodes(num_nodes);
         let unsorted_set = NodeSet::Unsorted(nodes.clone());
         let bin_searchable_set = {
-            let mut nodes = nodes.clone();
+            let mut nodes = nodes;
             nodes.sort_unstable();
             NodeSet::BinarySearchable(nodes)
         };

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -18,8 +18,8 @@ use crate::{
     NonMembershipProof, SingleAppendOnlyProof, ARITY, DIRECTIONS, EMPTY_LABEL,
 };
 
-use akd_core::SizeOf;
 use akd_core::hash::EMPTY_DIGEST;
+use akd_core::SizeOf;
 use async_recursion::async_recursion;
 use log::info;
 use std::cmp::Ordering;
@@ -291,13 +291,15 @@ impl Azks {
         Ok(())
     }
 
-    pub(crate) async fn preload_lookup_nodes<S: Database + Send + Sync>(&self, storage: &StorageManager<S>, lookup_infos: &[LookupInfo]) -> Result<u64, AkdError> {
+    pub(crate) async fn preload_lookup_nodes<S: Database + Send + Sync>(
+        &self,
+        storage: &StorageManager<S>,
+        lookup_infos: &[LookupInfo],
+    ) -> Result<u64, AkdError> {
         // Collect lookup labels needed and convert them into Nodes for preloading.
         let lookup_nodes: Vec<Node> = lookup_infos
             .into_iter()
-            .flat_map(|li| {
-               vec![li.existent_label, li.marker_label, li.non_existent_label] 
-            })
+            .flat_map(|li| vec![li.existent_label, li.marker_label, li.non_existent_label])
             .map(|l| Node {
                 label: l,
                 hash: EMPTY_DIGEST,
@@ -305,8 +307,7 @@ impl Azks {
             .collect();
 
         // Load nodes. Note NodeSet will sort these nodes for efficient preloading.
-        self
-            .preload_nodes(storage, &NodeSet::from(lookup_nodes))
+        self.preload_nodes(storage, &NodeSet::from(lookup_nodes))
             .await
     }
 

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -280,7 +280,9 @@ impl<S: Database + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
         lookup_info: LookupInfo,
     ) -> Result<LookupProof, AkdError> {
         // Preload nodes needed for lookup.
-        current_azks.preload_lookup_nodes(&self.storage, &vec![lookup_info.clone()]).await?;
+        current_azks
+            .preload_lookup_nodes(&self.storage, &vec![lookup_info.clone()])
+            .await?;
 
         let current_version = lookup_info.value_state.version;
         let commitment_key = self.derive_commitment_key().await?;
@@ -349,7 +351,9 @@ impl<S: Database + Sync + Send, V: VRFKeyStorage> Directory<S, V> {
         }
 
         // Load nodes needed using the lookup infos.
-        current_azks.preload_lookup_nodes(&self.storage, &lookup_infos).await?;
+        current_azks
+            .preload_lookup_nodes(&self.storage, &lookup_infos)
+            .await?;
 
         // Ensure we have got all lookup infos needed.
         assert_eq!(unames.len(), lookup_infos.len());

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -16,7 +16,7 @@ use crate::storage::types::{DbRecord, ValueState, ValueStateRetrievalFlag};
 use crate::storage::Database;
 use crate::{
     AkdLabel, AkdValue, AppendOnlyProof, Digest, EpochHash, HistoryProof, LookupProof, Node,
-    NodeLabel, NonMembershipProof, UpdateProof,
+    NonMembershipProof, UpdateProof,
 };
 
 use akd_core::utils::{commit_value, get_commitment_nonce};


### PR DESCRIPTION
In `batch_lookups` we utilize node preloading to minimize individual `GET` operations. We can do the same optimization for regular lookups -- which this PR adds. Performance results are shown below. 

In summary, instead of 40 individual `GET` operations, with this PR, we only have 2 `GET` + 8 `BATCH GET` operations which gives a total of 10 compared to 40. This should improve the performance of lookups quite a bit considering database access delays.

---
Without this PR:

```
Post look-up metrics:
Cache hit since last: 47, cached size: 40 items

===================================================
============ Database operation counts ============
===================================================
    SET 2, 
    BATCH SET 3, 
    GET 40, 
    BATCH GET 0
    TOMBSTONE 0
    GET USER STATE 1
    GET USER DATA 0
    GET USER STATE VERSIONS 3
===================================================
============ Database operation timing ============
===================================================
    TIME READ 98 ms
    TIME WRITE 1380 ms
```


With this PR:
```
Post look-up metrics:
Cache hit since last: 80, cached size: 40 items

===================================================
============ Database operation counts ============
===================================================
    SET 2, 
    BATCH SET 3, 
    GET 2, 
    BATCH GET 8
    TOMBSTONE 0
    GET USER STATE 1
    GET USER DATA 0
    GET USER STATE VERSIONS 3
===================================================
============ Database operation timing ============
===================================================
    TIME READ 143 ms
    TIME WRITE 1379 ms
 ```
  
 ---
> **NOTE:** Tests done after patching #320. A single lookup operation costs are shown only for post-lookup. Generated with the diff below:
 
 ```diff
+            mysql_db.flush_cache().await;
+            println!("Pre look-up metrics:");
+            mysql_db.log_metrics(log::Level::Trace).await;
             // Perform 10 random lookup proofs on the published users
             for user in users.iter().choose_multiple(&mut rng, 10) {
                 let key = AkdLabel::from_utf8_str(user);
                 match dir.lookup(key.clone()).await {
                     Err(error) => panic!("Error looking up user information {:?}", error),
                     Ok((proof, root_hash)) => {
+                        println!("Post look-up metrics:");
+                        mysql_db.log_metrics(log::Level::Trace).await;
+                        return;
```
---