### PR TITLE
Remove reference passing in CTORs

### DIFF
--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -877,7 +877,7 @@ mod tests {
         let mut rng = OsRng;
         let num_nodes = 10;
         let database = AsyncInMemoryDatabase::new();
-        let db = StorageManager::new_no_cache(&database);
+        let db = StorageManager::new_no_cache(database);
         let mut azks1 = Azks::new::<_>(&db).await?;
         azks1.increment_epoch();
 
@@ -901,7 +901,7 @@ mod tests {
         }
 
         let database2 = AsyncInMemoryDatabase::new();
-        let db2 = StorageManager::new_no_cache(&database2);
+        let db2 = StorageManager::new_no_cache(database2);
         let mut azks2 = Azks::new::<_>(&db2).await?;
 
         azks2
@@ -920,7 +920,7 @@ mod tests {
     #[tokio::test]
     async fn test_batch_insert_root_hash() -> Result<(), AkdError> {
         let database = AsyncInMemoryDatabase::new();
-        let db = StorageManager::new_no_cache(&database);
+        let db = StorageManager::new_no_cache(database);
 
         // manually construct a 3-layer tree and compute the root hash
         let mut nodes = Vec::<Node>::new();
@@ -986,7 +986,7 @@ mod tests {
         let num_nodes = 10;
         let mut rng = OsRng;
         let database = AsyncInMemoryDatabase::new();
-        let db = StorageManager::new_no_cache(&database);
+        let db = StorageManager::new_no_cache(database);
         let mut azks1 = Azks::new::<_>(&db).await?;
         azks1.increment_epoch();
         let mut node_set: Vec<Node> = vec![];
@@ -1011,7 +1011,7 @@ mod tests {
         node_set.shuffle(&mut rng);
 
         let database2 = AsyncInMemoryDatabase::new();
-        let db2 = StorageManager::new_no_cache(&database2);
+        let db2 = StorageManager::new_no_cache(database2);
         let mut azks2 = Azks::new(&db2).await?;
 
         azks2
@@ -1031,7 +1031,7 @@ mod tests {
     async fn test_preload_nodes_accuracy() {
         let database = AsyncInMemoryDatabase::new();
         let storage_manager =
-            StorageManager::new(&database, Some(Duration::from_secs(180u64)), None, None);
+            StorageManager::new(database, Some(Duration::from_secs(180u64)), None, None);
         let mut azks = Azks::new::<_>(&storage_manager)
             .await
             .expect("Failed to create azks!");
@@ -1110,7 +1110,7 @@ mod tests {
     async fn test_node_set_partition() -> Result<(), AkdError> {
         let num_nodes = 5;
         let database = AsyncInMemoryDatabase::new();
-        let db = StorageManager::new_no_cache(&database);
+        let db = StorageManager::new_no_cache(database);
         let mut azks1 = Azks::new::<_>(&db).await?;
         azks1.increment_epoch();
 
@@ -1157,7 +1157,7 @@ mod tests {
     async fn test_node_set_get_longest_common_prefix() -> Result<(), AkdError> {
         let num_nodes = 10;
         let database = AsyncInMemoryDatabase::new();
-        let db = StorageManager::new_no_cache(&database);
+        let db = StorageManager::new_no_cache(database);
         let mut azks1 = Azks::new::<_>(&db).await?;
         azks1.increment_epoch();
 
@@ -1197,7 +1197,7 @@ mod tests {
         // Try randomly permuting
         node_set.shuffle(&mut rng);
         let database = AsyncInMemoryDatabase::new();
-        let db = StorageManager::new_no_cache(&database);
+        let db = StorageManager::new_no_cache(database);
         let mut azks = Azks::new::<_>(&db).await?;
         azks.batch_insert_nodes::<_>(&db, node_set.clone(), InsertMode::Directory)
             .await?;
@@ -1213,30 +1213,24 @@ mod tests {
                 .get_child_node(&db, Direction::Right, 1)
                 .await?;
 
-            match left_child {
-                Some(left_child) => {
-                    let sibling_label = azks
-                        .get_sibling_node(&db, &current_node, Direction::Right, 1)
-                        .await?
-                        .unwrap()
-                        .label;
-                    assert_eq!(left_child.label, sibling_label);
-                    nodes.push(left_child);
-                }
-                None => {}
+            if let Some(left_child) = left_child {
+                let sibling_label = azks
+                    .get_sibling_node(&db, &current_node, Direction::Right, 1)
+                    .await?
+                    .unwrap()
+                    .label;
+                assert_eq!(left_child.label, sibling_label);
+                nodes.push(left_child);
             }
 
-            match right_child {
-                Some(right_child) => {
-                    let sibling_label = azks
-                        .get_sibling_node(&db, &current_node, Direction::Left, 1)
-                        .await?
-                        .unwrap()
-                        .label;
-                    assert_eq!(right_child.label, sibling_label);
-                    nodes.push(right_child);
-                }
-                None => {}
+            if let Some(right_child) = right_child {
+                let sibling_label = azks
+                    .get_sibling_node(&db, &current_node, Direction::Left, 1)
+                    .await?
+                    .unwrap()
+                    .label;
+                assert_eq!(right_child.label, sibling_label);
+                nodes.push(right_child);
             }
         }
 
@@ -1253,7 +1247,7 @@ mod tests {
         // Try randomly permuting
         node_set.shuffle(&mut rng);
         let database = AsyncInMemoryDatabase::new();
-        let db = StorageManager::new_no_cache(&database);
+        let db = StorageManager::new_no_cache(database);
         let mut azks = Azks::new::<_>(&db).await?;
         azks.batch_insert_nodes::<_>(&db, node_set.clone(), InsertMode::Directory)
             .await?;
@@ -1282,7 +1276,7 @@ mod tests {
             }
 
             let database = AsyncInMemoryDatabase::new();
-            let db = StorageManager::new_no_cache(&database);
+            let db = StorageManager::new_no_cache(database);
             let mut azks = Azks::new::<_>(&db).await?;
             azks.batch_insert_nodes::<_>(&db, node_set.clone(), InsertMode::Directory)
                 .await?;
@@ -1304,7 +1298,7 @@ mod tests {
         // Try randomly permuting
         node_set.shuffle(&mut rng);
         let database = AsyncInMemoryDatabase::new();
-        let db = StorageManager::new_no_cache(&database);
+        let db = StorageManager::new_no_cache(database);
         let mut azks = Azks::new::<_>(&db).await?;
         azks.batch_insert_nodes::<_>(&db, node_set.clone(), InsertMode::Directory)
             .await?;
@@ -1327,7 +1321,7 @@ mod tests {
     #[tokio::test]
     async fn test_membership_proof_intermediate() -> Result<(), AkdError> {
         let database = AsyncInMemoryDatabase::new();
-        let db = StorageManager::new_no_cache(&database);
+        let db = StorageManager::new_no_cache(database);
 
         let node_set: Vec<Node> = vec![
             Node {
@@ -1381,7 +1375,7 @@ mod tests {
             node_set.push(node);
         }
         let database = AsyncInMemoryDatabase::new();
-        let db = StorageManager::new_no_cache(&database);
+        let db = StorageManager::new_no_cache(database);
         let mut azks = Azks::new::<_>(&db).await?;
         let search_label = node_set[0].label;
         azks.batch_insert_nodes::<_>(&db, node_set.clone()[1..2].to_vec(), InsertMode::Directory)
@@ -1401,7 +1395,7 @@ mod tests {
 
         let node_set = gen_nodes(num_nodes);
         let database = AsyncInMemoryDatabase::new();
-        let db = StorageManager::new_no_cache(&database);
+        let db = StorageManager::new_no_cache(database);
         let mut azks = Azks::new::<_>(&db).await?;
         let search_label = node_set[num_nodes - 1].label;
         azks.batch_insert_nodes::<_>(
@@ -1423,7 +1417,7 @@ mod tests {
 
         let node_set = gen_nodes(num_nodes);
         let database = AsyncInMemoryDatabase::new();
-        let db = StorageManager::new_no_cache(&database);
+        let db = StorageManager::new_no_cache(database);
         let mut azks = Azks::new::<_>(&db).await?;
         let search_label = node_set[num_nodes - 1].label;
         azks.batch_insert_nodes::<_>(
@@ -1442,7 +1436,7 @@ mod tests {
     #[tokio::test]
     async fn test_append_only_proof_very_tiny() -> Result<(), AkdError> {
         let database = AsyncInMemoryDatabase::new();
-        let db = StorageManager::new_no_cache(&database);
+        let db = StorageManager::new_no_cache(database);
         let mut azks = Azks::new::<_>(&db).await?;
 
         let node_set_1: Vec<Node> = vec![Node {
@@ -1471,7 +1465,7 @@ mod tests {
     #[tokio::test]
     async fn test_append_only_proof_tiny() -> Result<(), AkdError> {
         let database = AsyncInMemoryDatabase::new();
-        let db = StorageManager::new_no_cache(&database);
+        let db = StorageManager::new_no_cache(database);
         let mut azks = Azks::new::<_>(&db).await?;
 
         let node_set_1: Vec<Node> = vec![
@@ -1516,7 +1510,7 @@ mod tests {
         let node_set_1 = gen_nodes(num_nodes);
 
         let database = AsyncInMemoryDatabase::new();
-        let db = StorageManager::new_no_cache(&database);
+        let db = StorageManager::new_no_cache(database);
         let mut azks = Azks::new::<_>(&db).await?;
         azks.batch_insert_nodes::<_>(&db, node_set_1.clone(), InsertMode::Directory)
             .await?;
@@ -1546,7 +1540,7 @@ mod tests {
     async fn future_epoch_throws_error() -> Result<(), AkdError> {
         let database = AsyncInMemoryDatabase::new();
 
-        let db = StorageManager::new_no_cache(&database);
+        let db = StorageManager::new_no_cache(database);
         let azks = Azks::new::<_>(&db).await?;
 
         let out = azks.get_root_hash_safe::<_>(&db, 123).await;

--- a/akd/src/auditor.rs
+++ b/akd/src/auditor.rs
@@ -53,7 +53,7 @@ pub async fn verify_consecutive_append_only(
     let inserted = proof.inserted.clone();
 
     let db = AsyncInMemoryDatabase::new();
-    let manager = StorageManager::new_no_cache(&db);
+    let manager = StorageManager::new_no_cache(db);
 
     let mut azks = Azks::new::<_>(&manager).await?;
     azks.batch_insert_nodes::<_>(&manager, unchanged_nodes, InsertMode::Auditor)

--- a/akd/src/lib.rs
+++ b/akd/src/lib.rs
@@ -58,7 +58,7 @@
 //! let vrf = HardCodedAkdVRF{};
 //!
 //! # tokio_test::block_on(async {
-//! let mut akd = Directory::<_, _>::new(&storage_manager, &vrf, false)
+//! let mut akd = Directory::<_, _>::new(storage_manager, vrf, false)
 //!     .await
 //!     .expect("Could not create a new directory");
 //! # });
@@ -90,7 +90,7 @@
 //!
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<_, _>::new(&storage_manager, &vrf, false).await.unwrap();
+//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, false).await.unwrap();
 //! let EpochHash(epoch, root_hash) = akd.publish(entries)
 //!     .await.expect("Error with publishing");
 //! println!("Published epoch {} with root hash: {}", epoch, hex::encode(root_hash));
@@ -124,7 +124,7 @@
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<_, _>::new(&storage_manager, &vrf, false).await.unwrap();
+//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, false).await.unwrap();
 //! #     let EpochHash(epoch, root_hash) = akd.publish(entries)
 //! #         .await.expect("Error with publishing");
 //! let (lookup_proof, _) = akd.lookup(
@@ -157,7 +157,7 @@
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<_, _>::new(&storage_manager, &vrf, false).await.unwrap();
+//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, false).await.unwrap();
 //! #     let _ = akd.publish(entries)
 //! #         .await.expect("Error with publishing");
 //! #     let (lookup_proof, epoch_hash) = akd.lookup(
@@ -211,7 +211,7 @@
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<_, _>::new(&storage_manager, &vrf, false).await.unwrap();
+//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, false).await.unwrap();
 //! #     let EpochHash(epoch, root_hash) = akd.publish(entries)
 //! #         .await.expect("Error with publishing");
 //! use akd::HistoryParams;
@@ -252,7 +252,7 @@
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<_, _>::new(&storage_manager, &vrf, false).await.unwrap();
+//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, false).await.unwrap();
 //! #     let _ = akd.publish(entries)
 //! #         .await.expect("Error with publishing");
 //! #     let _ = akd.publish(
@@ -315,7 +315,7 @@
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<_, _>::new(&storage_manager, &vrf, false).await.unwrap();
+//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, false).await.unwrap();
 //! #     let EpochHash(epoch, root_hash) = akd.publish(entries)
 //! #         .await.expect("Error with publishing");
 //! // Publish new entries into a second epoch
@@ -354,7 +354,7 @@
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<_, _>::new(&storage_manager, &vrf, false).await.unwrap();
+//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, false).await.unwrap();
 //! #     let EpochHash(epoch, root_hash) = akd.publish(entries)
 //! #         .await.expect("Error with publishing");
 //! #     // Publish new entries into a second epoch

--- a/akd/src/lib.rs
+++ b/akd/src/lib.rs
@@ -54,7 +54,7 @@
 //! use akd::directory::Directory;
 //!
 //! let db = AsyncInMemoryDatabase::new();
-//! let storage_manager = StorageManager::new_no_cache(&db);
+//! let storage_manager = StorageManager::new_no_cache(db);
 //! let vrf = HardCodedAkdVRF{};
 //!
 //! # tokio_test::block_on(async {
@@ -75,7 +75,7 @@
 //! # use akd::directory::Directory;
 //! #
 //! # let db = AsyncInMemoryDatabase::new();
-//! # let storage_manager = StorageManager::new_no_cache(&db);
+//! # let storage_manager = StorageManager::new_no_cache(db);
 //! # let vrf = HardCodedAkdVRF{};
 //! use akd::EpochHash;
 //! use akd::{AkdLabel, AkdValue};
@@ -86,7 +86,7 @@
 //!     (AkdLabel::from_utf8_str("second entry"), AkdValue::from_utf8_str("second value")),
 //! ];
 //! # let db = AsyncInMemoryDatabase::new();
-//! # let storage_manager = StorageManager::new_no_cache(&db);
+//! # let storage_manager = StorageManager::new_no_cache(db);
 //!
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
@@ -109,7 +109,7 @@
 //! # use akd::directory::Directory;
 //! #
 //! # let db = AsyncInMemoryDatabase::new();
-//! # let storage_manager = StorageManager::new_no_cache(&db);
+//! # let storage_manager = StorageManager::new_no_cache(db);
 //! # let vrf = HardCodedAkdVRF{};
 //! # use akd::EpochHash;
 //! # use akd::{AkdLabel, AkdValue};
@@ -120,7 +120,7 @@
 //! #     (AkdLabel::from_utf8_str("second entry"), AkdValue::from_utf8_str("second value")),
 //! # ];
 //! # let db = AsyncInMemoryDatabase::new();
-//! # let storage_manager = StorageManager::new_no_cache(&db);
+//! # let storage_manager = StorageManager::new_no_cache(db);
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
@@ -142,7 +142,7 @@
 //! # use akd::directory::Directory;
 //! #
 //! # let db = AsyncInMemoryDatabase::new();
-//! # let storage_manager = StorageManager::new_no_cache(&db);
+//! # let storage_manager = StorageManager::new_no_cache(db);
 //! # let vrf = HardCodedAkdVRF{};
 //! # use akd::EpochHash;
 //! # use akd::{AkdLabel, AkdValue};
@@ -153,7 +153,7 @@
 //! #     (AkdLabel::from_utf8_str("second entry"), AkdValue::from_utf8_str("second value")),
 //! # ];
 //! # let db = AsyncInMemoryDatabase::new();
-//! # let storage_manager = StorageManager::new_no_cache(&db);
+//! # let storage_manager = StorageManager::new_no_cache(db);
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
@@ -196,7 +196,7 @@
 //! # use akd::directory::Directory;
 //! #
 //! # let db = AsyncInMemoryDatabase::new();
-//! # let storage_manager = StorageManager::new_no_cache(&db);
+//! # let storage_manager = StorageManager::new_no_cache(db);
 //! # let vrf = HardCodedAkdVRF{};
 //! # use akd::EpochHash;
 //! # use akd::{AkdLabel, AkdValue};
@@ -207,7 +207,7 @@
 //! #     (AkdLabel::from_utf8_str("second entry"), AkdValue::from_utf8_str("second value")),
 //! # ];
 //! # let db = AsyncInMemoryDatabase::new();
-//! # let storage_manager = StorageManager::new_no_cache(&db);
+//! # let storage_manager = StorageManager::new_no_cache(db);
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
@@ -236,7 +236,7 @@
 //! # use akd::directory::Directory;
 //! #
 //! # let db = AsyncInMemoryDatabase::new();
-//! # let storage_manager = StorageManager::new_no_cache(&db);
+//! # let storage_manager = StorageManager::new_no_cache(db);
 //! # let vrf = HardCodedAkdVRF{};
 //! # use akd::EpochHash;
 //! # use akd::HistoryParams;
@@ -248,7 +248,7 @@
 //! #     (AkdLabel::from_utf8_str("second entry"), AkdValue::from_utf8_str("second value")),
 //! # ];
 //! # let db = AsyncInMemoryDatabase::new();
-//! # let storage_manager = StorageManager::new_no_cache(&db);
+//! # let storage_manager = StorageManager::new_no_cache(db);
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
@@ -300,7 +300,7 @@
 //! # use akd::directory::Directory;
 //! #
 //! # let db = AsyncInMemoryDatabase::new();
-//! # let storage_manager = StorageManager::new_no_cache(&db);
+//! # let storage_manager = StorageManager::new_no_cache(db);
 //! # let vrf = HardCodedAkdVRF{};
 //! # use akd::EpochHash;
 //! # use akd::{AkdLabel, AkdValue};
@@ -311,7 +311,7 @@
 //! #     (AkdLabel::from_utf8_str("second entry"), AkdValue::from_utf8_str("second value")),
 //! # ];
 //! # let db = AsyncInMemoryDatabase::new();
-//! # let storage_manager = StorageManager::new_no_cache(&db);
+//! # let storage_manager = StorageManager::new_no_cache(db);
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
@@ -339,7 +339,7 @@
 //! # use akd::directory::Directory;
 //! #
 //! # let db = AsyncInMemoryDatabase::new();
-//! # let storage_manager = StorageManager::new_no_cache(&db);
+//! # let storage_manager = StorageManager::new_no_cache(db);
 //! # let vrf = HardCodedAkdVRF{};
 //! # use akd::EpochHash;
 //! # use akd::{AkdLabel, AkdValue};
@@ -350,7 +350,7 @@
 //! #     (AkdLabel::from_utf8_str("second entry"), AkdValue::from_utf8_str("second value")),
 //! # ];
 //! # let db = AsyncInMemoryDatabase::new();
-//! # let storage_manager = StorageManager::new_no_cache(&db);
+//! # let storage_manager = StorageManager::new_no_cache(db);
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};

--- a/akd/src/storage/manager/mod.rs
+++ b/akd/src/storage/manager/mod.rs
@@ -76,18 +76,18 @@ unsafe impl<Db: Database> Send for StorageManager<Db> {}
 
 impl<Db: Database> StorageManager<Db> {
     /// Create a new storage manager with NO CACHE
-    pub fn new_no_cache(db: &Db) -> Self {
+    pub fn new_no_cache(db: Db) -> Self {
         Self {
             cache: None,
             transaction: Transaction::new(),
-            db: db.clone(),
+            db,
             metrics: [0; NUM_METRICS].map(|_| Arc::new(AtomicU64::new(0))),
         }
     }
 
     /// Create a new storage manager with a cache utilizing the options provided (or defaults)
     pub fn new(
-        db: &Db,
+        db: Db,
         cache_item_lifetime: Option<Duration>,
         cache_limit_bytes: Option<usize>,
         cache_clean_frequency: Option<Duration>,
@@ -99,7 +99,7 @@ impl<Db: Database> StorageManager<Db> {
                 cache_clean_frequency,
             )),
             transaction: Transaction::new(),
-            db: db.clone(),
+            db,
             metrics: [0; NUM_METRICS].map(|_| Arc::new(AtomicU64::new(0))),
         }
     }

--- a/akd/src/storage/manager/tests.rs
+++ b/akd/src/storage/manager/tests.rs
@@ -18,7 +18,7 @@ use crate::*;
 #[tokio::test]
 async fn test_storage_manager_transaction() {
     let db = AsyncInMemoryDatabase::new();
-    let storage_manager = StorageManager::new_no_cache(&db);
+    let storage_manager = StorageManager::new_no_cache(db.clone());
 
     assert!(
         storage_manager.begin_transaction().await,
@@ -109,7 +109,7 @@ async fn test_storage_manager_transaction() {
 #[tokio::test]
 async fn test_storage_manager_cache_populated_by_batch_set() {
     let db = AsyncInMemoryDatabase::new();
-    let storage_manager = StorageManager::new(&db, None, None, None);
+    let storage_manager = StorageManager::new(db.clone(), None, None, None);
 
     let mut records = (0..10)
         .into_iter()
@@ -190,7 +190,7 @@ async fn test_storage_manager_cache_populated_by_batch_set() {
 #[tokio::test]
 async fn test_storage_manager_cache_populated_by_batch_get() {
     let db = AsyncInMemoryDatabase::new();
-    let storage_manager = StorageManager::new(&db, None, None, None);
+    let storage_manager = StorageManager::new(db.clone(), None, None, None);
 
     let mut keys = vec![];
     let mut records = (0..10)
@@ -239,8 +239,12 @@ async fn test_storage_manager_cache_populated_by_batch_get() {
     drop(storage_manager);
 
     // re-create the storage manager, and run a batch_get of the same data keys to populate the cache
-    let storage_manager =
-        StorageManager::new(&db, Some(std::time::Duration::from_secs(1000)), None, None);
+    let storage_manager = StorageManager::new(
+        db.clone(),
+        Some(std::time::Duration::from_secs(1000)),
+        None,
+        None,
+    );
 
     let _ = storage_manager
         .batch_get::<TreeNodeWithPreviousValue>(&keys)

--- a/akd/src/storage/tests.rs
+++ b/akd/src/storage/tests.rs
@@ -49,7 +49,7 @@ pub async fn run_test_cases_for_storage_impl<S: Database>(db: &S) {
     test_transactions(db).await;
     test_batch_get_items(db).await;
 
-    let manager = StorageManager::new_no_cache(db);
+    let manager = StorageManager::new_no_cache(db.clone());
     test_tombstoning_data(&manager).await.unwrap();
 }
 
@@ -313,7 +313,7 @@ async fn test_batch_get_items<Ns: Database>(storage: &Ns) {
 }
 
 async fn test_transactions<S: Database>(db: &S) {
-    let storage = crate::storage::manager::StorageManager::new_no_cache(db);
+    let storage = crate::storage::manager::StorageManager::new_no_cache(db.clone());
 
     let mut rand_users: Vec<Vec<u8>> = vec![];
     for _ in 0..20 {

--- a/akd/src/tests.rs
+++ b/akd/src/tests.rs
@@ -22,7 +22,7 @@ use crate::{
 #[tokio::test]
 async fn test_empty_tree_root_hash() -> Result<(), AkdError> {
     let db = AsyncInMemoryDatabase::new();
-    let storage = StorageManager::new_no_cache(&db);
+    let storage = StorageManager::new_no_cache(db);
     let vrf = HardCodedAkdVRF {};
     let akd = Directory::<_, _>::new(storage, vrf, false).await?;
 
@@ -79,7 +79,7 @@ async fn test_empty_tree_root_hash() -> Result<(), AkdError> {
 #[tokio::test]
 async fn test_simple_publish() -> Result<(), AkdError> {
     let db = AsyncInMemoryDatabase::new();
-    let storage = StorageManager::new_no_cache(&db);
+    let storage = StorageManager::new_no_cache(db);
     let vrf = HardCodedAkdVRF {};
     let akd = Directory::<_, _>::new(storage, vrf, false).await?;
     // Make sure you can publish and that something so simple
@@ -98,7 +98,7 @@ async fn test_simple_publish() -> Result<(), AkdError> {
 #[tokio::test]
 async fn test_simple_lookup() -> Result<(), AkdError> {
     let db = AsyncInMemoryDatabase::new();
-    let storage = StorageManager::new_no_cache(&db);
+    let storage = StorageManager::new_no_cache(db);
     let vrf = HardCodedAkdVRF {};
     let akd = Directory::<_, _>::new(storage, vrf, false).await?;
     // Add two labels and corresponding values to the akd
@@ -136,7 +136,7 @@ async fn test_small_key_history() -> Result<(), AkdError> {
     // The value of this label is updated two times.
     // Then the test verifies the key history.
     let db = AsyncInMemoryDatabase::new();
-    let storage = StorageManager::new_no_cache(&db);
+    let storage = StorageManager::new_no_cache(db);
     let vrf = HardCodedAkdVRF {};
     let akd = Directory::<_, _>::new(storage, vrf, false).await?;
     // Publish the first value for the label "hello"
@@ -195,7 +195,7 @@ async fn test_small_key_history() -> Result<(), AkdError> {
 #[tokio::test]
 async fn test_simple_key_history() -> Result<(), AkdError> {
     let db = AsyncInMemoryDatabase::new();
-    let storage = StorageManager::new_no_cache(&db);
+    let storage = StorageManager::new_no_cache(db);
     let vrf = HardCodedAkdVRF {};
     let akd = Directory::<_, _>::new(storage, vrf, false).await?;
     // Epoch 1: Add labels "hello" and "hello2"
@@ -372,7 +372,7 @@ async fn test_simple_key_history() -> Result<(), AkdError> {
 #[tokio::test]
 async fn test_limited_key_history() -> Result<(), AkdError> {
     let db = AsyncInMemoryDatabase::new();
-    let storage_manager = StorageManager::new_no_cache(&db);
+    let storage_manager = StorageManager::new_no_cache(db);
     let vrf = HardCodedAkdVRF {};
     // epoch 0
     let akd = Directory::<_, _>::new(storage_manager, vrf, false).await?;
@@ -544,7 +544,7 @@ async fn test_malicious_key_history() -> Result<(), AkdError> {
     // delay in marking the first version for "hello" as stale, which should
     // be caught by key history verifications for "hello".
     let db = AsyncInMemoryDatabase::new();
-    let storage = StorageManager::new_no_cache(&db);
+    let storage = StorageManager::new_no_cache(db);
     let vrf = HardCodedAkdVRF {};
     let akd = Directory::<_, _>::new(storage, vrf, false).await?;
     // Publish the first value for the label "hello"
@@ -619,7 +619,7 @@ async fn test_malicious_key_history() -> Result<(), AkdError> {
 #[tokio::test]
 async fn test_simple_audit() -> Result<(), AkdError> {
     let db = AsyncInMemoryDatabase::new();
-    let storage = StorageManager::new_no_cache(&db);
+    let storage = StorageManager::new_no_cache(db);
     let vrf = HardCodedAkdVRF {};
     let akd = Directory::<_, _>::new(storage, vrf, false).await?;
 
@@ -779,7 +779,7 @@ async fn test_simple_audit() -> Result<(), AkdError> {
 #[tokio::test]
 async fn test_read_during_publish() -> Result<(), AkdError> {
     let db = AsyncInMemoryDatabase::new();
-    let storage = StorageManager::new_no_cache(&db);
+    let storage = StorageManager::new_no_cache(db.clone());
     let vrf = HardCodedAkdVRF {};
     let akd = Directory::<_, _>::new(storage, vrf, false).await?;
 
@@ -884,7 +884,7 @@ async fn test_read_during_publish() -> Result<(), AkdError> {
 #[tokio::test]
 async fn test_directory_read_only_mode() -> Result<(), AkdError> {
     let db = AsyncInMemoryDatabase::new();
-    let storage = StorageManager::new_no_cache(&db);
+    let storage = StorageManager::new_no_cache(db);
     let vrf = HardCodedAkdVRF {};
     // There is no AZKS object in the storage layer, directory construction should fail
     let akd = Directory::<_, _>::new(storage.clone(), vrf.clone(), true).await;
@@ -907,7 +907,7 @@ async fn test_directory_read_only_mode() -> Result<(), AkdError> {
 #[tokio::test]
 async fn test_directory_polling_azks_change() -> Result<(), AkdError> {
     let db = AsyncInMemoryDatabase::new();
-    let storage = StorageManager::new(&db, None, None, None);
+    let storage = StorageManager::new(db, None, None, None);
     let vrf = HardCodedAkdVRF {};
     // writer will write the AZKS record
     let writer = Directory::<_, _>::new(storage.clone(), vrf.clone(), false).await?;
@@ -966,7 +966,7 @@ async fn test_directory_polling_azks_change() -> Result<(), AkdError> {
 #[tokio::test]
 async fn test_tombstoned_key_history() -> Result<(), AkdError> {
     let db = AsyncInMemoryDatabase::new();
-    let storage = StorageManager::new_no_cache(&db);
+    let storage = StorageManager::new_no_cache(db);
     let vrf = HardCodedAkdVRF {};
     // epoch 0
     let akd = Directory::<_, _>::new(storage.clone(), vrf, false).await?;
@@ -1064,7 +1064,7 @@ async fn test_tombstoned_key_history() -> Result<(), AkdError> {
 #[tokio::test]
 async fn test_simple_lookup_for_small_tree_blake() -> Result<(), AkdError> {
     let db = AsyncInMemoryDatabase::new();
-    let storage = StorageManager::new_no_cache(&db);
+    let storage = StorageManager::new_no_cache(db);
     let vrf = HardCodedAkdVRF {};
     // epoch 0
     let akd = Directory::<_, _>::new(storage, vrf.clone(), false).await?;
@@ -1117,7 +1117,7 @@ async fn test_simple_lookup_for_small_tree_blake() -> Result<(), AkdError> {
 #[tokio::test]
 async fn test_simple_lookup_for_small_tree_sha256() -> Result<(), AkdError> {
     let db = AsyncInMemoryDatabase::new();
-    let storage = StorageManager::new_no_cache(&db);
+    let storage = StorageManager::new_no_cache(db);
     let vrf = HardCodedAkdVRF {};
     // epoch 0
     let akd = Directory::<_, _>::new(storage, vrf, false).await?;

--- a/akd/src/tree_node.rs
+++ b/akd/src/tree_node.rs
@@ -683,7 +683,7 @@ mod tests {
     #[tokio::test]
     async fn test_smallest_descendant_ep() -> Result<(), AkdError> {
         let database = InMemoryDb::new();
-        let db = StorageManager::new_no_cache(&database);
+        let db = StorageManager::new_no_cache(database);
         let mut root =
             create_empty_root::<InMemoryDb>(&db, Option::Some(0u64), Option::Some(0u64)).await?;
 
@@ -782,7 +782,7 @@ mod tests {
     #[tokio::test]
     async fn test_insert_single_leaf_root() -> Result<(), AkdError> {
         let database = InMemoryDb::new();
-        let db = StorageManager::new_no_cache(&database);
+        let db = StorageManager::new_no_cache(database);
 
         let mut root =
             create_empty_root::<InMemoryDb>(&db, Option::Some(0u64), Option::Some(0u64)).await?;
@@ -845,7 +845,7 @@ mod tests {
     #[tokio::test]
     async fn test_insert_single_leaf_below_root() -> Result<(), AkdError> {
         let database = InMemoryDb::new();
-        let db = StorageManager::new_no_cache(&database);
+        let db = StorageManager::new_no_cache(database);
         let mut root =
             create_empty_root::<InMemoryDb>(&db, Option::Some(0u64), Option::Some(0u64)).await?;
 
@@ -932,7 +932,7 @@ mod tests {
     #[tokio::test]
     async fn test_insert_single_leaf_below_root_both_sides() -> Result<(), AkdError> {
         let database = InMemoryDb::new();
-        let db = StorageManager::new_no_cache(&database);
+        let db = StorageManager::new_no_cache(database);
         let mut root =
             create_empty_root::<InMemoryDb>(&db, Option::Some(0u64), Option::Some(0u64)).await?;
 
@@ -1053,7 +1053,7 @@ mod tests {
     #[tokio::test]
     async fn test_insert_single_leaf_full_tree() -> Result<(), AkdError> {
         let database = InMemoryDb::new();
-        let db = StorageManager::new_no_cache(&database);
+        let db = StorageManager::new_no_cache(database);
         let mut root =
             create_empty_root::<InMemoryDb>(&db, Option::Some(0u64), Option::Some(0u64)).await?;
 

--- a/akd_client/src/wasm.rs
+++ b/akd_client/src/wasm.rs
@@ -153,9 +153,9 @@ pub mod tests {
     #[wasm_bindgen_test]
     async fn test_simple_wasm_lookup() {
         let db = AsyncInMemoryDatabase::new();
-        let storage = StorageManager::new_no_cache(&db);
+        let storage = StorageManager::new_no_cache(db);
         let vrf = HardCodedAkdVRF {};
-        let akd = Directory::<_, _>::new(&storage, &vrf, false)
+        let akd = Directory::<_, _>::new(storage, vrf, false)
             .await
             .expect("Failed to construct directory");
 

--- a/akd_local_auditor/src/common_test.rs
+++ b/akd_local_auditor/src/common_test.rs
@@ -63,7 +63,7 @@ pub async fn generate_audit_proofs(
     let db = AsyncInMemoryDatabase::new();
     let storage_manager = StorageManager::new_no_cache(&db);
     let vrf = HardCodedAkdVRF {};
-    let akd = Directory::<_, _>::new(&storage_manager, &vrf, false).await?;
+    let akd = Directory::<_, _>::new(storage_manager, vrf, false).await?;
     let mut proofs = vec![];
     // gather the hash + azks for epoch "0" (init)
     let mut azks = akd.retrieve_current_azks().await?;

--- a/akd_local_auditor/src/common_test.rs
+++ b/akd_local_auditor/src/common_test.rs
@@ -61,7 +61,7 @@ pub async fn generate_audit_proofs(
     expensive: bool,
 ) -> Result<Vec<AuditInformation>, akd::errors::AkdError> {
     let db = AsyncInMemoryDatabase::new();
-    let storage_manager = StorageManager::new_no_cache(&db);
+    let storage_manager = StorageManager::new_no_cache(db);
     let vrf = HardCodedAkdVRF {};
     let akd = Directory::<_, _>::new(storage_manager, vrf, false).await?;
     let mut proofs = vec![];

--- a/akd_test_tools/src/fixture_generator/examples/example_tests.rs
+++ b/akd_test_tools/src/fixture_generator/examples/example_tests.rs
@@ -35,7 +35,7 @@ async fn test_use_fixture() {
         .await
         .unwrap();
     let vrf = HardCodedAkdVRF {};
-    let storage_manager = StorageManager::new_no_cache(&db);
+    let storage_manager = StorageManager::new_no_cache(db.clone());
     let akd = Directory::<_, _>::new(storage_manager, vrf, false)
         .await
         .unwrap();

--- a/akd_test_tools/src/fixture_generator/examples/example_tests.rs
+++ b/akd_test_tools/src/fixture_generator/examples/example_tests.rs
@@ -36,7 +36,7 @@ async fn test_use_fixture() {
         .unwrap();
     let vrf = HardCodedAkdVRF {};
     let storage_manager = StorageManager::new_no_cache(&db);
-    let akd = Directory::<_, _>::new(&storage_manager, &vrf, false)
+    let akd = Directory::<_, _>::new(storage_manager, vrf, false)
         .await
         .unwrap();
 

--- a/akd_test_tools/src/fixture_generator/generator.rs
+++ b/akd_test_tools/src/fixture_generator/generator.rs
@@ -121,7 +121,7 @@ pub(crate) async fn generate(args: Args) {
     // initialize directory
     let db = akd::storage::memory::AsyncInMemoryDatabase::new();
     let vrf = akd::ecvrf::HardCodedAkdVRF {};
-    let storage_manager = StorageManager::new_no_cache(&db);
+    let storage_manager = StorageManager::new_no_cache(db.clone());
     let akd = Directory::<_, _>::new(storage_manager, vrf, false)
         .await
         .unwrap();

--- a/akd_test_tools/src/fixture_generator/generator.rs
+++ b/akd_test_tools/src/fixture_generator/generator.rs
@@ -122,7 +122,7 @@ pub(crate) async fn generate(args: Args) {
     let db = akd::storage::memory::AsyncInMemoryDatabase::new();
     let vrf = akd::ecvrf::HardCodedAkdVRF {};
     let storage_manager = StorageManager::new_no_cache(&db);
-    let akd = Directory::<_, _>::new(&storage_manager, &vrf, false)
+    let akd = Directory::<_, _>::new(storage_manager, vrf, false)
         .await
         .unwrap();
 

--- a/akd_test_tools/src/test_suites.rs
+++ b/akd_test_tools/src/test_suites.rs
@@ -38,7 +38,7 @@ pub async fn directory_test_suite<S: akd::storage::Database, V: VRFKeyStorage>(
     }
     let mut root_hashes = vec![];
     // create & test the directory
-    let maybe_dir = Directory::<_, _>::new(mysql_db, vrf, false).await;
+    let maybe_dir = Directory::<_, _>::new(mysql_db.clone(), vrf.clone(), false).await;
     match maybe_dir {
         Err(akd_error) => panic!("Error initializing directory: {:?}", akd_error),
         Ok(dir) => {

--- a/integration_tests/src/memory_tests.rs
+++ b/integration_tests/src/memory_tests.rs
@@ -19,7 +19,7 @@ async fn test_directory_operations() {
     let db = InMemoryDb::new();
 
     let vrf = HardCodedAkdVRF {};
-    let storage_manager = StorageManager::new_no_cache(&db);
+    let storage_manager = StorageManager::new_no_cache(db);
     akd_test_tools::test_suites::directory_test_suite::<_, HardCodedAkdVRF>(
         &storage_manager,
         500,
@@ -39,7 +39,7 @@ async fn test_directory_operations_with_caching() {
     let db = InMemoryDb::new();
 
     let vrf = HardCodedAkdVRF {};
-    let storage_manager = StorageManager::new(&db, None, None, None);
+    let storage_manager = StorageManager::new(db, None, None, None);
     akd_test_tools::test_suites::directory_test_suite::<_, HardCodedAkdVRF>(
         &storage_manager,
         500,

--- a/integration_tests/src/mysql_tests.rs
+++ b/integration_tests/src/mysql_tests.rs
@@ -47,7 +47,7 @@ async fn test_directory_operations() {
         }
 
         let vrf = HardCodedAkdVRF {};
-        let storage_manager = StorageManager::new_no_cache(&mysql_db);
+        let storage_manager = StorageManager::new_no_cache(mysql_db.clone());
         akd_test_tools::test_suites::directory_test_suite::<_, HardCodedAkdVRF>(
             &storage_manager,
             50,
@@ -108,7 +108,7 @@ async fn test_directory_operations_with_caching() {
         }
 
         let vrf = HardCodedAkdVRF {};
-        let storage_manager = StorageManager::new(&mysql_db, None, None, None);
+        let storage_manager = StorageManager::new(mysql_db.clone(), None, None, None);
         akd_test_tools::test_suites::directory_test_suite::<_, HardCodedAkdVRF>(
             &storage_manager,
             50,
@@ -169,7 +169,7 @@ async fn test_lookups() {
         }
 
         let vrf = HardCodedAkdVRF {};
-        let storage_manager = StorageManager::new(&mysql_db, None, None, None);
+        let storage_manager = StorageManager::new(mysql_db.clone(), None, None, None);
         crate::test_util::test_lookups::<_, HardCodedAkdVRF>(&storage_manager, &vrf, 50, 5, 100)
             .await;
 

--- a/integration_tests/src/test_util.rs
+++ b/integration_tests/src/test_util.rs
@@ -142,7 +142,7 @@ pub(crate) async fn test_lookups<S: akd::storage::Database, V: VRFKeyStorage>(
     }
 
     // create & test the directory
-    let maybe_dir = Directory::<_, _>::new(mysql_db, vrf, false).await;
+    let maybe_dir = Directory::<_, _>::new(mysql_db.clone(), vrf.clone(), false).await;
     match maybe_dir {
         Err(akd_error) => panic!("Error initializing directory: {:?}", akd_error),
         Ok(dir) => {

--- a/poc/src/main.rs
+++ b/poc/src/main.rs
@@ -139,7 +139,7 @@ async fn main() {
     let vrf = HardCodedAkdVRF {};
     if cli.memory_db {
         let db = akd::storage::memory::AsyncInMemoryDatabase::new();
-        let storage_manager = StorageManager::new_no_cache(&db);
+        let storage_manager = StorageManager::new_no_cache(db);
         let mut directory = Directory::<_, _>::new(storage_manager, vrf, false)
             .await
             .unwrap();
@@ -165,7 +165,7 @@ async fn main() {
             return;
         }
         let storage_manager = StorageManager::new(
-            &mysql_db,
+            mysql_db,
             Some(Duration::from_secs(10 * 60)),
             None,
             Some(Duration::from_secs(15)),

--- a/poc/src/main.rs
+++ b/poc/src/main.rs
@@ -140,7 +140,7 @@ async fn main() {
     if cli.memory_db {
         let db = akd::storage::memory::AsyncInMemoryDatabase::new();
         let storage_manager = StorageManager::new_no_cache(&db);
-        let mut directory = Directory::<_, _>::new(&storage_manager, &vrf, false)
+        let mut directory = Directory::<_, _>::new(storage_manager, vrf, false)
             .await
             .unwrap();
         if let Some(()) = pre_process_input(&cli, &tx, None).await {
@@ -170,13 +170,13 @@ async fn main() {
             None,
             Some(Duration::from_secs(15)),
         );
-        let mut directory = Directory::<_, _>::new(&storage_manager, &vrf, false)
+        let mut directory = Directory::<_, _>::new(storage_manager.clone(), vrf, false)
             .await
             .unwrap();
         tokio::spawn(async move {
             directory_host::init_host::<_, HardCodedAkdVRF>(&mut rx, &mut directory).await
         });
-        process_input(&cli, &tx, Some(&storage_manager)).await;
+        process_input(&cli, &tx, Some(storage_manager)).await;
     }
 }
 
@@ -205,7 +205,7 @@ async fn pre_process_input(
 async fn process_input(
     cli: &Cli,
     tx: &Sender<directory_host::Rpc>,
-    db: Option<&StorageManager<AsyncMySqlDatabase>>,
+    db: Option<StorageManager<AsyncMySqlDatabase>>,
 ) {
     if let Some(other_mode) = &cli.other_mode {
         match other_mode {
@@ -447,7 +447,7 @@ async fn process_input(
                 }
                 Command::Flush => {
                     println!("Flushing the database...");
-                    if let Some(mysql_db) = db {
+                    if let Some(mysql_db) = &db {
                         if let Err(error) = mysql_db.db.delete_data().await {
                             println!("Error flushing database: {}", error);
                         } else {
@@ -463,7 +463,7 @@ async fn process_input(
                         println!("\t**** DEBUG mode ACTIVE ****");
                     }
                     println!("===== Auditable Key Directory Information =====");
-                    if let Some(mysql) = db {
+                    if let Some(mysql) = &db {
                         println!("      Database properties ({})", mysql.db);
                     } else {
                         println!("      Connected to an in-memory database");


### PR DESCRIPTION
There's a few instances where we take a reference to a struct an nearly immediately clone it. This should be left to the caller, since if they are only say constructing a database to pass it to the storage manager, we may be inducing a clone for no real reason.