### PR TITLE
Upgrade tokio from 1.10 to 1.21

### DIFF
--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -40,7 +40,7 @@ dashmap = { version = "5" }
 ed25519-dalek = "1"
 hex = "0.4"
 log = { version = "0.4.8", features = ["kv_unstable"] }
-tokio = { version = "1.10", features = ["sync", "time", "rt"] }
+tokio = { version = "1.21", features = ["sync", "time", "rt"] }
 
 ## Optional dependencies ##
 bincode = { version = "1", optional = true }
@@ -59,7 +59,7 @@ colored = { version = "2" }
 once_cell = { version = "1" }
 ctor = "0.1"
 tokio-test = "0.4"
-tokio = { version = "1.10", features = ["rt", "sync", "time", "macros"] }
+tokio = { version = "1.21", features = ["rt", "sync", "time", "macros"] }
 akd = { path = ".", features = ["public-tests"], version = "0.8.0", default-features = false }
 
 [[bench]]

--- a/akd_core/Cargo.toml
+++ b/akd_core/Cargo.toml
@@ -51,7 +51,7 @@ sha2 = { version = "0.10", optional = true, default-features = false }
 sha3 = { version = "0.10", optional = true, default-features = false }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_bytes = { version = "0.11", optional = true }
-tokio = { version = "1.10", features = ["rt"], optional = true }
+tokio = { version = "1.21", features = ["rt"], optional = true }
 
 [dev-dependencies]
 bincode = "1"

--- a/akd_local_auditor/Cargo.toml
+++ b/akd_local_auditor/Cargo.toml
@@ -26,7 +26,7 @@ qr2term = "0.3"
 rand = "0.8"
 rustyrepl = { version = "0.1", features = ["async"] }
 thread-id = "3"
-tokio = { version = "1.10", features = ["full"] }
+tokio = { version = "1.21", features = ["full"] }
 tokio-stream = "0.1"
 
 akd = { path = "../akd", features = ["public-tests", "public_auditing"] }

--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -20,7 +20,7 @@ winter-math = "0.2"
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 async-trait = "0.1"
-tokio = { version = "1.10", features = ["full"] }
+tokio = { version = "1.21", features = ["full"] }
 async-recursion = "0.3"
 mysql_async = "0.31"
 mysql_common = "0.29.1"

--- a/akd_test_tools/Cargo.toml
+++ b/akd_test_tools/Cargo.toml
@@ -14,7 +14,7 @@ winter-crypto = "0.2"
 winter-math = "0.2"
 clap = { version="3", features = ["derive"]}
 log = { version = "0.4.8", features = ["kv_unstable"] }
-tokio = { version = "1.10", features = ["full"] }
+tokio = { version = "1.21", features = ["full"] }
 regex = "1.5"
 rand = "0.7"
 serde_yaml = "0.8"

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -12,7 +12,7 @@ akd = { path = "../akd", features = ["public-tests", "rand", "serde_serializatio
 
 [dev-dependencies]
 log = { version = "0.4.8", features = ["kv_unstable"] }
-tokio = { version = "1.10", features = ["full"] }
+tokio = { version = "1.21", features = ["full"] }
 serial_test = "*"
 mysql_async = "0.31"
 rand = "0.7"

--- a/poc/Cargo.toml
+++ b/poc/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-tokio = { version = "1.10", features = ["full"] }
+tokio = { version = "1.21", features = ["full"] }
 colored = "2.0.0"
 hex = "0.4.3"
 rand = "0.8"


### PR DESCRIPTION
As title, so as to use more recent API and features. I made sure to check all `Cargo.toml` files, and verified that existing feature flags are still valid.