### PR TITLE
Remove Pub Modifier on StorageManager DB

### DIFF
--- a/akd/src/storage/manager/mod.rs
+++ b/akd/src/storage/manager/mod.rs
@@ -55,7 +55,7 @@ pub struct StorageManager<Db: Database> {
     cache: Option<TimedCache>,
     transaction: Transaction,
     /// The underlying database managed by this storage manager
-    pub db: Db,
+    db: Db,
 
     metrics: [Arc<AtomicU64>; NUM_METRICS],
 }


### PR DESCRIPTION
- Remove the pub access modifier to the Database impl field in the `StorageManager` struct. Database access should only be performed through an instance of `StorageManager`.