### PR TITLE
Reduce and cleanup writes to storage during insertion

### DIFF
--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -265,7 +265,7 @@ unsafe impl Sync for Azks {}
 impl Azks {
     /// Creates a new azks
     pub async fn new<S: Database>(storage: &StorageManager<S>) -> Result<Self, AkdError> {
-        let root_node = create_empty_root().await?;
+        let root_node = new_root_node().await?;
         root_node.write_to_storage(storage).await?;
 
         let azks = Azks {
@@ -347,7 +347,7 @@ impl Azks {
                     // pushing it down one level (away from root) in the tree
                     // and replacing it with a new node whose label is equal to
                     // the longest common prefix.
-                    current_node = create_interior_node(lcp_label, epoch).await?;
+                    current_node = new_interior_node(lcp_label, epoch).await?;
                     current_node.set_child(storage, &mut existing_node).await?;
                     num_inserted = 1;
                 } else {
@@ -362,7 +362,7 @@ impl Azks {
                 // Case 2: The node label is None and the node set has a
                 // single element, meaning that a new leaf node should be
                 // created to represent the element.
-                current_node = create_leaf_node(node.label, &node.hash, epoch).await?;
+                current_node = new_leaf_node(node.label, &node.hash, epoch).await?;
                 num_inserted = 1;
             }
             (None, _) => {
@@ -371,7 +371,7 @@ impl Azks {
                 // created with a label equal to the longest common prefix of
                 // the node set.
                 let lcp_label = node_set.get_longest_common_prefix();
-                current_node = create_interior_node(lcp_label, epoch).await?;
+                current_node = new_interior_node(lcp_label, epoch).await?;
                 num_inserted = 1;
             }
         }
@@ -996,7 +996,7 @@ mod tests {
             let hash = &crate::hash::hash(&leaf_u64.to_be_bytes());
             nodes.push(Node { label, hash: *hash });
 
-            let new_leaf = create_leaf_node(label, hash, 7 - i + 1).await?;
+            let new_leaf = new_leaf_node(label, hash, 7 - i + 1).await?;
             leaf_hashes.push(crate::hash::merge(&[
                 crate::hash::merge_with_int(crate::hash::hash(&leaf_u64.to_be_bytes()), 7 - i + 1),
                 new_leaf.label.hash(),

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -265,7 +265,7 @@ unsafe impl Sync for Azks {}
 impl Azks {
     /// Creates a new azks
     pub async fn new<S: Database>(storage: &StorageManager<S>) -> Result<Self, AkdError> {
-        let root_node = new_root_node().await?;
+        let root_node = new_root_node();
         root_node.write_to_storage(storage).await?;
 
         let azks = Azks {
@@ -347,7 +347,7 @@ impl Azks {
                     // pushing it down one level (away from root) in the tree
                     // and replacing it with a new node whose label is equal to
                     // the longest common prefix.
-                    current_node = new_interior_node(lcp_label, epoch).await?;
+                    current_node = new_interior_node(lcp_label, epoch);
                     current_node.set_child(storage, &mut existing_node).await?;
                     num_inserted = 1;
                 } else {
@@ -362,7 +362,7 @@ impl Azks {
                 // Case 2: The node label is None and the node set has a
                 // single element, meaning that a new leaf node should be
                 // created to represent the element.
-                current_node = new_leaf_node(node.label, &node.hash, epoch).await?;
+                current_node = new_leaf_node(node.label, &node.hash, epoch);
                 num_inserted = 1;
             }
             (None, _) => {
@@ -371,7 +371,7 @@ impl Azks {
                 // created with a label equal to the longest common prefix of
                 // the node set.
                 let lcp_label = node_set.get_longest_common_prefix();
-                current_node = new_interior_node(lcp_label, epoch).await?;
+                current_node = new_interior_node(lcp_label, epoch);
                 num_inserted = 1;
             }
         }
@@ -996,7 +996,7 @@ mod tests {
             let hash = &crate::hash::hash(&leaf_u64.to_be_bytes());
             nodes.push(Node { label, hash: *hash });
 
-            let new_leaf = new_leaf_node(label, hash, 7 - i + 1).await?;
+            let new_leaf = new_leaf_node(label, hash, 7 - i + 1);
             leaf_hashes.push(crate::hash::merge(&[
                 crate::hash::merge_with_int(crate::hash::hash(&leaf_u64.to_be_bytes()), 7 - i + 1),
                 new_leaf.label.hash(),

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -318,8 +318,8 @@ impl Azks {
 
     /// Inserts a batch of leaves recursively from a given node label. Note: it
     /// is the caller's responsibility to write the returned node to storage.
-    /// This is done so that the caller may set the 'parent' field of nodes
-    /// before writing nodes to storage.
+    /// This is done so that the caller may set the 'parent' field of a node
+    /// before it is written to storage.
     #[async_recursion]
     pub(crate) async fn recursive_batch_insert_nodes<S: Database + 'static>(
         storage: &StorageManager<S>,

--- a/akd/src/tree_node.rs
+++ b/akd/src/tree_node.rs
@@ -344,15 +344,15 @@ impl TreeNode {
     // FIXME: Figure out how to better group arguments.
     #[allow(clippy::too_many_arguments)]
     /// Creates a new TreeNode and writes it to the storage.
-    async fn new(
+    fn new(
         label: NodeLabel,
         parent: NodeLabel,
         node_type: NodeType,
         birth_epoch: u64,
         min_descendant_epoch: u64,
         hash: crate::Digest,
-    ) -> Result<Self, StorageError> {
-        Ok(TreeNode {
+    ) -> Self {
+        TreeNode {
             label,
             last_epoch: birth_epoch,
             min_descendant_epoch,
@@ -361,7 +361,7 @@ impl TreeNode {
             left_child: None,
             right_child: None,
             hash,
-        })
+        }
     }
 
     /// Updates the node hash and saves it in storage.
@@ -542,10 +542,10 @@ pub(crate) fn optional_child_state_hash(input: &Option<TreeNode>) -> Digest {
 }
 
 /// Create an empty root node.
-pub(crate) async fn new_root_node() -> Result<TreeNode, StorageError> {
+pub(crate) fn new_root_node() -> TreeNode {
     // Empty root hash is the same as empty node hash with no label
     let empty_root_hash = crate::hash::hash(&crate::EMPTY_VALUE);
-    let node = TreeNode::new(
+    TreeNode::new(
         NodeLabel::root(),
         NodeLabel::root(),
         NodeType::Root,
@@ -553,16 +553,11 @@ pub(crate) async fn new_root_node() -> Result<TreeNode, StorageError> {
         0u64,
         empty_root_hash,
     )
-    .await?;
-    Ok(node)
 }
 
 /// Create an interior node with an empty hash.
-pub(crate) async fn new_interior_node(
-    label: NodeLabel,
-    birth_epoch: u64,
-) -> Result<TreeNode, StorageError> {
-    let new_node = TreeNode::new(
+pub(crate) fn new_interior_node(label: NodeLabel, birth_epoch: u64) -> TreeNode {
+    TreeNode::new(
         label,
         EMPTY_LABEL,
         NodeType::Interior,
@@ -570,17 +565,11 @@ pub(crate) async fn new_interior_node(
         birth_epoch,
         EMPTY_DIGEST,
     )
-    .await?;
-    Ok(new_node)
 }
 
 /// Create a specific leaf node.
-pub(crate) async fn new_leaf_node(
-    label: NodeLabel,
-    value: &Digest,
-    birth_epoch: u64,
-) -> Result<TreeNode, StorageError> {
-    let new_node = TreeNode::new(
+pub(crate) fn new_leaf_node(label: NodeLabel, value: &Digest, birth_epoch: u64) -> TreeNode {
+    TreeNode::new(
         label,
         EMPTY_LABEL,
         NodeType::Leaf,
@@ -588,8 +577,6 @@ pub(crate) async fn new_leaf_node(
         birth_epoch,
         *value,
     )
-    .await?;
-    Ok(new_node)
 }
 
 #[cfg(test)]
@@ -608,31 +595,28 @@ mod tests {
     async fn test_smallest_descendant_ep() -> Result<(), AkdError> {
         let database = InMemoryDb::new();
         let db = StorageManager::new_no_cache(database);
-        let mut root = new_root_node().await?;
+        let mut root = new_root_node();
 
         let mut right_child =
-            new_interior_node(NodeLabel::new(byte_arr_from_u64(0b1u64 << 63), 1u32), 3).await?;
+            new_interior_node(NodeLabel::new(byte_arr_from_u64(0b1u64 << 63), 1u32), 3);
 
         let mut new_leaf = new_leaf_node(
             NodeLabel::new(byte_arr_from_u64(0b00u64), 2u32),
             &crate::hash::hash(&EMPTY_VALUE),
             1,
-        )
-        .await?;
+        );
 
         let mut leaf_1 = new_leaf_node(
             NodeLabel::new(byte_arr_from_u64(0b11u64 << 62), 2u32),
             &crate::hash::hash(&[1u8]),
             2,
-        )
-        .await?;
+        );
 
         let mut leaf_2 = new_leaf_node(
             NodeLabel::new(byte_arr_from_u64(0b10u64 << 62), 2u32),
             &crate::hash::hash(&[1u8, 1u8]),
             3,
-        )
-        .await?;
+        );
 
         right_child.set_child(&db, &mut leaf_2).await?;
         right_child.set_child(&db, &mut leaf_1).await?;
@@ -702,23 +686,21 @@ mod tests {
         let database = InMemoryDb::new();
         let db = StorageManager::new_no_cache(database);
 
-        let mut root = new_root_node().await?;
+        let mut root = new_root_node();
 
         // Prepare the leaf to be inserted with label 0.
         let mut leaf_0 = new_leaf_node(
             NodeLabel::new(byte_arr_from_u64(0b0u64), 1u32),
             &crate::hash::hash(&EMPTY_VALUE),
             0,
-        )
-        .await?;
+        );
 
         // Prepare another leaf to insert with label 1.
         let mut leaf_1 = new_leaf_node(
             NodeLabel::new(byte_arr_from_u64(0b1u64 << 63), 1u32),
             &crate::hash::hash(&[1u8]),
             0,
-        )
-        .await?;
+        );
 
         // Insert leaves.
         root.set_child(&db, &mut leaf_0).await?;
@@ -762,31 +744,28 @@ mod tests {
     async fn test_insert_single_leaf_below_root() -> Result<(), AkdError> {
         let database = InMemoryDb::new();
         let db = StorageManager::new_no_cache(database);
-        let mut root = new_root_node().await?;
+        let mut root = new_root_node();
 
         let mut right_child =
-            new_interior_node(NodeLabel::new(byte_arr_from_u64(0b1u64 << 63), 1u32), 3).await?;
+            new_interior_node(NodeLabel::new(byte_arr_from_u64(0b1u64 << 63), 1u32), 3);
 
         let mut leaf_0 = new_leaf_node(
             NodeLabel::new(byte_arr_from_u64(0b00u64), 2u32),
             &crate::hash::hash(&EMPTY_VALUE),
             1,
-        )
-        .await?;
+        );
 
         let mut leaf_1 = new_leaf_node(
             NodeLabel::new(byte_arr_from_u64(0b11u64 << 62), 2u32),
             &crate::hash::hash(&[1u8]),
             2,
-        )
-        .await?;
+        );
 
         let mut leaf_2 = new_leaf_node(
             NodeLabel::new(byte_arr_from_u64(0b10u64 << 62), 2u32),
             &crate::hash::hash(&[1u8, 1u8]),
             3,
-        )
-        .await?;
+        );
 
         right_child.set_child(&db, &mut leaf_2).await?;
         right_child.set_child(&db, &mut leaf_1).await?;
@@ -843,41 +822,36 @@ mod tests {
     async fn test_insert_single_leaf_below_root_both_sides() -> Result<(), AkdError> {
         let database = InMemoryDb::new();
         let db = StorageManager::new_no_cache(database);
-        let mut root = new_root_node().await?;
+        let mut root = new_root_node();
 
-        let mut left_child =
-            new_interior_node(NodeLabel::new(byte_arr_from_u64(0b0u64), 1u32), 4).await?;
+        let mut left_child = new_interior_node(NodeLabel::new(byte_arr_from_u64(0b0u64), 1u32), 4);
 
         let mut right_child =
-            new_interior_node(NodeLabel::new(byte_arr_from_u64(0b1u64 << 63), 1u32), 3).await?;
+            new_interior_node(NodeLabel::new(byte_arr_from_u64(0b1u64 << 63), 1u32), 3);
 
         let mut leaf_0 = new_leaf_node(
             NodeLabel::new(byte_arr_from_u64(0b000u64), 3u32),
             &crate::hash::hash(&EMPTY_VALUE),
             1,
-        )
-        .await?;
+        );
 
         let mut leaf_1 = new_leaf_node(
             NodeLabel::new(byte_arr_from_u64(0b111u64 << 61), 3u32),
             &crate::hash::hash(&[1u8]),
             2,
-        )
-        .await?;
+        );
 
         let mut leaf_2 = new_leaf_node(
             NodeLabel::new(byte_arr_from_u64(0b100u64 << 61), 3u32),
             &crate::hash::hash(&[1u8, 1u8]),
             3,
-        )
-        .await?;
+        );
 
         let mut leaf_3 = new_leaf_node(
             NodeLabel::new(byte_arr_from_u64(0b010u64 << 61), 3u32),
             &crate::hash::hash(&[0u8, 1u8]),
             4,
-        )
-        .await?;
+        );
 
         // Insert nodes.
         left_child.set_child(&db, &mut leaf_0).await?;
@@ -954,7 +928,7 @@ mod tests {
     async fn test_insert_single_leaf_full_tree() -> Result<(), AkdError> {
         let database = InMemoryDb::new();
         let db = StorageManager::new_no_cache(database);
-        let mut root = new_root_node().await?;
+        let mut root = new_root_node();
 
         let mut leaves = Vec::<TreeNode>::new();
         let mut leaf_hashes = Vec::new();
@@ -964,8 +938,7 @@ mod tests {
                 NodeLabel::new(byte_arr_from_u64(leaf_u64), 3u32),
                 &crate::hash::hash(&leaf_u64.to_be_bytes()),
                 7 - i,
-            )
-            .await?;
+            );
             leaf_hashes.push(crate::hash::merge(&[
                 crate::hash::merge_with_int(crate::hash::hash(&leaf_u64.to_be_bytes()), 7 - i),
                 hash_label(new_leaf.label),
@@ -977,13 +950,10 @@ mod tests {
         let mut layer_1_hashes = Vec::new();
         for (i, j) in (0u64..4).enumerate() {
             let interior_u64 = j << 62;
-            layer_1_interior.push(
-                new_interior_node(
-                    NodeLabel::new(byte_arr_from_u64(interior_u64), 2u32),
-                    7 - (2 * j),
-                )
-                .await?,
-            );
+            layer_1_interior.push(new_interior_node(
+                NodeLabel::new(byte_arr_from_u64(interior_u64), 2u32),
+                7 - (2 * j),
+            ));
 
             let left_child_hash = leaf_hashes[2 * i];
             let right_child_hash = leaf_hashes[2 * i + 1];
@@ -997,13 +967,10 @@ mod tests {
         let mut layer_2_hashes = Vec::new();
         for (i, j) in (0u64..2).enumerate() {
             let interior_u64 = j << 63;
-            layer_2_interior.push(
-                new_interior_node(
-                    NodeLabel::new(byte_arr_from_u64(interior_u64), 1u32),
-                    7 - (4 * j),
-                )
-                .await?,
-            );
+            layer_2_interior.push(new_interior_node(
+                NodeLabel::new(byte_arr_from_u64(interior_u64), 1u32),
+                7 - (4 * j),
+            ));
 
             let left_child_hash = layer_1_hashes[2 * i];
             let right_child_hash = layer_1_hashes[2 * i + 1];

--- a/akd/src/tree_node.rs
+++ b/akd/src/tree_node.rs
@@ -413,7 +413,8 @@ impl TreeNode {
                 self.right_child = Some(child_node.label);
             }
         }
-        // Uparent of the child.
+
+        // Update parent of the child.
         child_node.parent = self.label;
 
         // Update last updated epoch.

--- a/akd/src/tree_node.rs
+++ b/akd/src/tree_node.rs
@@ -438,7 +438,6 @@ impl TreeNode {
                 min(self.min_descendant_epoch, child_node.min_descendant_epoch);
         }
 
-        // self.write_to_storage(storage, false).await?;
         child_node.write_to_storage(storage).await?;
 
         Ok(())

--- a/akd/src/tree_node.rs
+++ b/akd/src/tree_node.rs
@@ -397,9 +397,6 @@ impl TreeNode {
             }
         }
 
-        // Update the node in storage.
-        self.write_to_storage(storage).await?;
-
         Ok(())
     }
 
@@ -642,11 +639,13 @@ mod tests {
         right_child
             .update_node_hash(&db, NodeHashingMode::WithLeafEpoch)
             .await?;
+        right_child.write_to_storage(&db).await?;
 
         root.set_child(&db, &mut new_leaf).await?;
         root.set_child(&db, &mut right_child).await?;
         root.update_node_hash(&db, NodeHashingMode::WithLeafEpoch)
             .await?;
+        root.write_to_storage(&db).await?;
 
         let stored_root = db
             .get::<TreeNodeWithPreviousValue>(&NodeKey(NodeLabel::root()))
@@ -726,6 +725,7 @@ mod tests {
         root.set_child(&db, &mut leaf_1).await?;
         root.update_node_hash(&db, NodeHashingMode::WithLeafEpoch)
             .await?;
+        root.write_to_storage(&db).await?;
 
         // Calculate expected root hash.
         let leaf_0_hash = crate::hash::merge(&[
@@ -793,11 +793,13 @@ mod tests {
         right_child
             .update_node_hash(&db, NodeHashingMode::WithLeafEpoch)
             .await?;
+        right_child.write_to_storage(&db).await?;
 
         root.set_child(&db, &mut leaf_0).await?;
         root.set_child(&db, &mut right_child).await?;
         root.update_node_hash(&db, NodeHashingMode::WithLeafEpoch)
             .await?;
+        root.write_to_storage(&db).await?;
 
         let leaf_0_hash = crate::hash::merge(&[
             crate::hash::merge_with_int(crate::hash::hash(&EMPTY_VALUE), 1),
@@ -883,17 +885,20 @@ mod tests {
         left_child
             .update_node_hash(&db, NodeHashingMode::WithLeafEpoch)
             .await?;
+        left_child.write_to_storage(&db).await?;
 
         right_child.set_child(&db, &mut leaf_2).await?;
         right_child.set_child(&db, &mut leaf_1).await?;
         right_child
             .update_node_hash(&db, NodeHashingMode::WithLeafEpoch)
             .await?;
+        right_child.write_to_storage(&db).await?;
 
         root.set_child(&db, &mut left_child).await?;
         root.set_child(&db, &mut right_child).await?;
         root.update_node_hash(&db, NodeHashingMode::WithLeafEpoch)
             .await?;
+        root.write_to_storage(&db).await?;
 
         let leaf_0_hash = crate::hash::merge(&[
             crate::hash::merge_with_int(crate::hash::hash(&EMPTY_VALUE), 1),
@@ -1021,6 +1026,7 @@ mod tests {
             node.set_child(&db, &mut right_child).await?;
             node.update_node_hash(&db, NodeHashingMode::WithLeafEpoch)
                 .await?;
+            node.write_to_storage(&db).await?;
         }
 
         for node in layer_2_interior.iter_mut() {
@@ -1031,6 +1037,7 @@ mod tests {
             node.set_child(&db, &mut right_child).await?;
             node.update_node_hash(&db, NodeHashingMode::WithLeafEpoch)
                 .await?;
+            node.write_to_storage(&db).await?;
         }
 
         let mut left_child = layer_2_interior.remove(0);
@@ -1040,6 +1047,7 @@ mod tests {
         root.set_child(&db, &mut right_child).await?;
         root.update_node_hash(&db, NodeHashingMode::WithLeafEpoch)
             .await?;
+        root.write_to_storage(&db).await?;
 
         let stored_root = db
             .get::<TreeNodeWithPreviousValue>(&NodeKey(NodeLabel::root()))

--- a/akd/src/tree_node.rs
+++ b/akd/src/tree_node.rs
@@ -545,7 +545,7 @@ pub(crate) fn optional_child_state_hash(input: &Option<TreeNode>) -> Digest {
 }
 
 /// Create an empty root node.
-pub(crate) async fn create_empty_root() -> Result<TreeNode, StorageError> {
+pub(crate) async fn new_root_node() -> Result<TreeNode, StorageError> {
     // Empty root hash is the same as empty node hash with no label
     let empty_root_hash = crate::hash::hash(&crate::EMPTY_VALUE);
     let node = TreeNode::new(
@@ -561,7 +561,7 @@ pub(crate) async fn create_empty_root() -> Result<TreeNode, StorageError> {
 }
 
 /// Create an interior node with an empty hash.
-pub(crate) async fn create_interior_node(
+pub(crate) async fn new_interior_node(
     label: NodeLabel,
     birth_epoch: u64,
 ) -> Result<TreeNode, StorageError> {
@@ -578,7 +578,7 @@ pub(crate) async fn create_interior_node(
 }
 
 /// Create a specific leaf node.
-pub(crate) async fn create_leaf_node(
+pub(crate) async fn new_leaf_node(
     label: NodeLabel,
     value: &Digest,
     birth_epoch: u64,
@@ -611,26 +611,26 @@ mod tests {
     async fn test_smallest_descendant_ep() -> Result<(), AkdError> {
         let database = InMemoryDb::new();
         let db = StorageManager::new_no_cache(database);
-        let mut root = create_empty_root().await?;
+        let mut root = new_root_node().await?;
 
         let mut right_child =
-            create_interior_node(NodeLabel::new(byte_arr_from_u64(0b1u64 << 63), 1u32), 3).await?;
+            new_interior_node(NodeLabel::new(byte_arr_from_u64(0b1u64 << 63), 1u32), 3).await?;
 
-        let mut new_leaf = create_leaf_node(
+        let mut new_leaf = new_leaf_node(
             NodeLabel::new(byte_arr_from_u64(0b00u64), 2u32),
             &crate::hash::hash(&EMPTY_VALUE),
             1,
         )
         .await?;
 
-        let mut leaf_1 = create_leaf_node(
+        let mut leaf_1 = new_leaf_node(
             NodeLabel::new(byte_arr_from_u64(0b11u64 << 62), 2u32),
             &crate::hash::hash(&[1u8]),
             2,
         )
         .await?;
 
-        let mut leaf_2 = create_leaf_node(
+        let mut leaf_2 = new_leaf_node(
             NodeLabel::new(byte_arr_from_u64(0b10u64 << 62), 2u32),
             &crate::hash::hash(&[1u8, 1u8]),
             3,
@@ -703,10 +703,10 @@ mod tests {
         let database = InMemoryDb::new();
         let db = StorageManager::new_no_cache(database);
 
-        let mut root = create_empty_root().await?;
+        let mut root = new_root_node().await?;
 
         // Prepare the leaf to be inserted with label 0.
-        let mut leaf_0 = create_leaf_node(
+        let mut leaf_0 = new_leaf_node(
             NodeLabel::new(byte_arr_from_u64(0b0u64), 1u32),
             &crate::hash::hash(&EMPTY_VALUE),
             0,
@@ -714,7 +714,7 @@ mod tests {
         .await?;
 
         // Prepare another leaf to insert with label 1.
-        let mut leaf_1 = create_leaf_node(
+        let mut leaf_1 = new_leaf_node(
             NodeLabel::new(byte_arr_from_u64(0b1u64 << 63), 1u32),
             &crate::hash::hash(&[1u8]),
             0,
@@ -762,26 +762,26 @@ mod tests {
     async fn test_insert_single_leaf_below_root() -> Result<(), AkdError> {
         let database = InMemoryDb::new();
         let db = StorageManager::new_no_cache(database);
-        let mut root = create_empty_root().await?;
+        let mut root = new_root_node().await?;
 
         let mut right_child =
-            create_interior_node(NodeLabel::new(byte_arr_from_u64(0b1u64 << 63), 1u32), 3).await?;
+            new_interior_node(NodeLabel::new(byte_arr_from_u64(0b1u64 << 63), 1u32), 3).await?;
 
-        let mut leaf_0 = create_leaf_node(
+        let mut leaf_0 = new_leaf_node(
             NodeLabel::new(byte_arr_from_u64(0b00u64), 2u32),
             &crate::hash::hash(&EMPTY_VALUE),
             1,
         )
         .await?;
 
-        let mut leaf_1 = create_leaf_node(
+        let mut leaf_1 = new_leaf_node(
             NodeLabel::new(byte_arr_from_u64(0b11u64 << 62), 2u32),
             &crate::hash::hash(&[1u8]),
             2,
         )
         .await?;
 
-        let mut leaf_2 = create_leaf_node(
+        let mut leaf_2 = new_leaf_node(
             NodeLabel::new(byte_arr_from_u64(0b10u64 << 62), 2u32),
             &crate::hash::hash(&[1u8, 1u8]),
             3,
@@ -841,36 +841,36 @@ mod tests {
     async fn test_insert_single_leaf_below_root_both_sides() -> Result<(), AkdError> {
         let database = InMemoryDb::new();
         let db = StorageManager::new_no_cache(database);
-        let mut root = create_empty_root().await?;
+        let mut root = new_root_node().await?;
 
         let mut left_child =
-            create_interior_node(NodeLabel::new(byte_arr_from_u64(0b0u64), 1u32), 4).await?;
+            new_interior_node(NodeLabel::new(byte_arr_from_u64(0b0u64), 1u32), 4).await?;
 
         let mut right_child =
-            create_interior_node(NodeLabel::new(byte_arr_from_u64(0b1u64 << 63), 1u32), 3).await?;
+            new_interior_node(NodeLabel::new(byte_arr_from_u64(0b1u64 << 63), 1u32), 3).await?;
 
-        let mut leaf_0 = create_leaf_node(
+        let mut leaf_0 = new_leaf_node(
             NodeLabel::new(byte_arr_from_u64(0b000u64), 3u32),
             &crate::hash::hash(&EMPTY_VALUE),
             1,
         )
         .await?;
 
-        let mut leaf_1 = create_leaf_node(
+        let mut leaf_1 = new_leaf_node(
             NodeLabel::new(byte_arr_from_u64(0b111u64 << 61), 3u32),
             &crate::hash::hash(&[1u8]),
             2,
         )
         .await?;
 
-        let mut leaf_2 = create_leaf_node(
+        let mut leaf_2 = new_leaf_node(
             NodeLabel::new(byte_arr_from_u64(0b100u64 << 61), 3u32),
             &crate::hash::hash(&[1u8, 1u8]),
             3,
         )
         .await?;
 
-        let mut leaf_3 = create_leaf_node(
+        let mut leaf_3 = new_leaf_node(
             NodeLabel::new(byte_arr_from_u64(0b010u64 << 61), 3u32),
             &crate::hash::hash(&[0u8, 1u8]),
             4,
@@ -949,13 +949,13 @@ mod tests {
     async fn test_insert_single_leaf_full_tree() -> Result<(), AkdError> {
         let database = InMemoryDb::new();
         let db = StorageManager::new_no_cache(database);
-        let mut root = create_empty_root().await?;
+        let mut root = new_root_node().await?;
 
         let mut leaves = Vec::<TreeNode>::new();
         let mut leaf_hashes = Vec::new();
         for i in 0u64..8u64 {
             let leaf_u64 = i << 61;
-            let new_leaf = create_leaf_node(
+            let new_leaf = new_leaf_node(
                 NodeLabel::new(byte_arr_from_u64(leaf_u64), 3u32),
                 &crate::hash::hash(&leaf_u64.to_be_bytes()),
                 7 - i,
@@ -973,7 +973,7 @@ mod tests {
         for (i, j) in (0u64..4).enumerate() {
             let interior_u64 = j << 62;
             layer_1_interior.push(
-                create_interior_node(
+                new_interior_node(
                     NodeLabel::new(byte_arr_from_u64(interior_u64), 2u32),
                     7 - (2 * j),
                 )
@@ -993,7 +993,7 @@ mod tests {
         for (i, j) in (0u64..2).enumerate() {
             let interior_u64 = j << 63;
             layer_2_interior.push(
-                create_interior_node(
+                new_interior_node(
                     NodeLabel::new(byte_arr_from_u64(interior_u64), 1u32),
                     7 - (4 * j),
                 )


### PR DESCRIPTION
# Overview
Now that node insertion is fully recursive, it's easy to identify the redundant calls writing nodes to storage. While we have a transaction object that make these writes fairly fast, they still result in some contention under parallelism. Furthermore, the inconsistent callsites make it unclear when objects have already been written to storage. This PR cuts out the unnecessary calls.

# Benchmark
Ran the `azks.rs` benchmark, which inserts 100K leaves into a tree with 10K leaves.:

```console
$ cargo bench -p akd --bench azks -F bench
```

Note that the benchmark does use a transaction object (as a write cache) as opposed to writing to the DB directly, which is reflective of real-world usage.

## Main

<img width="478" alt="image" src="https://user-images.githubusercontent.com/20502803/210159110-08defd21-d84b-431f-8192-cd883d77b82a.png">



## This PR

<img width="478" alt="image" src="https://user-images.githubusercontent.com/20502803/210159115-240dfc8a-1ac1-4b0b-b678-d80c28d49f1d.png">

That's... quite a huge improvement 😀

