### PR TITLE
Specify blake3 feature flag when publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,10 +24,10 @@ jobs:
         CRATES_IO_TOKEN: ${{ secrets.crates_io_token }}
 
     - name: Dry run publish AKD_CORE
-      run: cargo publish --dry-run --manifest-path Cargo.toml -p akd_core
+      run: cargo publish --dry-run --manifest-path Cargo.toml -p akd_core -F blake3
 
     - name: Publish crate AKD_CORE
-      run: cargo publish --manifest-path Cargo.toml -p akd_core
+      run: cargo publish --manifest-path Cargo.toml -p akd_core -F blake3
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}
 


### PR DESCRIPTION
The GH actions run to publish the v0.8.3 crate was failing: https://github.com/facebook/akd/actions/runs/3816632953

In #292 we dropped the `blake3` feature flag from the `akd_core` crate's default features. Therefore we now need to specify the feature flag when publishing so that a hash function is included in the build. 

Running the new command in dry-run mode succeeds locally:
```console
$ cargo publish --dry-run --manifest-path Cargo.toml -p akd_core -F blake3
```