### PR TITLE
Bump version to 0.8.4 to re-attempt publish

### DIFF
--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -62,7 +62,6 @@ once_cell = { version = "1" }
 ctor = "0.1"
 tokio-test = "0.4"
 tokio = { version = "1.21", features = ["rt", "sync", "time", "macros"] }
-akd = { path = ".", features = ["public-tests"], version = "0.8.3", default-features = false }
 
 [[bench]]
 name = "azks"

--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -63,6 +63,9 @@ ctor = "0.1"
 tokio-test = "0.4"
 tokio = { version = "1.21", features = ["rt", "sync", "time", "macros"] }
 
+# To enable the public-test feature in tests
+akd = { path = ".", features = ["public-tests"], default-features = false }
+
 [[bench]]
 name = "azks"
 harness = false

--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd"
-version = "0.8.3"
+version = "0.8.4"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "An implementation of an auditable key directory"
 license = "MIT OR Apache-2.0"
@@ -34,7 +34,7 @@ default = ["blake3", "public_auditing", "parallel_vrf", "parallel_insert"]
 
 [dependencies]
 ## Required dependencies ##
-akd_core = { path = "../akd_core", version = "0.8.3", default-features = false, features = ["vrf"] }
+akd_core = { path = "../akd_core", version = "0.8.4", default-features = false, features = ["vrf"] }
 async-recursion = "0.3"
 async-trait = "0.1"
 curve25519-dalek = "3"

--- a/akd_client/Cargo.toml
+++ b/akd_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_client"
-version = "0.8.3"
+version = "0.8.4"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Client verification companion for the auditable key directory with limited dependencies."
 license = "MIT OR Apache-2.0"

--- a/akd_core/Cargo.toml
+++ b/akd_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_core"
-version = "0.8.3"
+version = "0.8.4"
 authors = ["Sean Lawlor <seanlawlor@fb.com>"]
 description = "Core utilities for the auditable-key-directory suite of crates (akd and akd_client)"
 license = "MIT OR Apache-2.0"

--- a/akd_local_auditor/Cargo.toml
+++ b/akd_local_auditor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "akd_local_auditor"
 default-run = "akd_local_auditor"
-version = "0.8.3"
+version = "0.8.4"
 authors = ["Sean Lawlor <seanlawlor@fb.com>"]
 edition = "2018"
 publish = false

--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_mysql"
-version = "0.8.3"
+version = "0.8.4"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "A MySQL storage layer implementation for an auditable key directory (AKD)"
 license = "MIT OR Apache-2.0"

--- a/akd_test_tools/Cargo.toml
+++ b/akd_test_tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_test_tools"
-version = "0.8.3"
+version = "0.8.4"
 authors = ["Evan Au <evanau@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Test utilities and tooling"
 license = "MIT OR Apache-2.0"
@@ -22,9 +22,9 @@ serde = "1.0"
 async-trait = "0.1"
 thread-id = "3"
 
-akd = { path = "../akd", features = ["serde_serialization"], version = "0.8.3" }
+akd = { path = "../akd", features = ["serde_serialization"], version = "0.8.4" }
 
 [dev-dependencies]
 assert_fs="1"
 
-akd = { path = "../akd", features = ["public-tests", "rand", "serde_serialization"], version = "0.8.3" }
+akd = { path = "../akd", features = ["public-tests", "rand", "serde_serialization"], version = "0.8.4" }


### PR DESCRIPTION
Unfortunately, the workflow to publish the akd v0.8.3 failed after akd_core and akd_client v0.8.3 was published: https://github.com/facebook/akd/actions/runs/3817658498/jobs/6494059254

We also have to bump the version number for all crates to attempt a republish, since we cannot overwrite already published crates.
