### PR TITLE
Avoid looking up previous version of nodes that are new

### DIFF
--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd"
-version = "0.8.4"
+version = "0.8.5"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "An implementation of an auditable key directory"
 license = "MIT OR Apache-2.0"
@@ -34,7 +34,7 @@ default = ["blake3", "public_auditing", "parallel_vrf", "parallel_insert"]
 
 [dependencies]
 ## Required dependencies ##
-akd_core = { path = "../akd_core", version = "0.8.4", default-features = false, features = ["vrf"] }
+akd_core = { path = "../akd_core", version = "0.8.5", default-features = false, features = ["vrf"] }
 async-recursion = "0.3"
 async-trait = "0.1"
 curve25519-dalek = "3"

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -66,8 +66,13 @@ fn get_parallel_levels() -> Option<u8> {
         // the level. As we are using a binary tree, the number of leaves at a
         // level is 2^level. Therefore, the number of levels that should be
         // executed in parallel is the log2 of the number of available threads.
-        let levels = (available_parallelism as f32).log2().ceil() as u8;
-        Some(levels)
+        let parallel_levels = (available_parallelism as f32).log2().ceil() as u8;
+
+        info!(
+            "Insert will be performed in parallel (available parallelism: {}, parallel levels: {})",
+            available_parallelism, parallel_levels
+        );
+        Some(parallel_levels)
     }
 }
 

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -266,7 +266,7 @@ impl Azks {
     /// Creates a new azks
     pub async fn new<S: Database>(storage: &StorageManager<S>) -> Result<Self, AkdError> {
         let root_node = new_root_node();
-        root_node.write_to_storage(storage).await?;
+        root_node.write_to_storage(storage, true).await?;
 
         let azks = Azks {
             latest_epoch: 0,
@@ -296,7 +296,7 @@ impl Azks {
 
         if !node_set.is_empty() {
             // call recursive batch insert on the root
-            let (root_node, num_inserted) = Self::recursive_batch_insert_nodes(
+            let (root_node, is_new, num_inserted) = Self::recursive_batch_insert_nodes(
                 storage,
                 Some(NodeLabel::root()),
                 node_set,
@@ -305,7 +305,7 @@ impl Azks {
                 get_parallel_levels(),
             )
             .await?;
-            root_node.write_to_storage(storage).await?;
+            root_node.write_to_storage(storage, is_new).await?;
 
             // update the number of nodes
             self.num_nodes += num_inserted;
@@ -319,7 +319,8 @@ impl Azks {
     /// Inserts a batch of leaves recursively from a given node label. Note: it
     /// is the caller's responsibility to write the returned node to storage.
     /// This is done so that the caller may set the 'parent' field of a node
-    /// before it is written to storage.
+    /// before it is written to storage. The is_new flag indicates whether the
+    /// returned node is new or not.
     #[async_recursion]
     pub(crate) async fn recursive_batch_insert_nodes<S: Database + 'static>(
         storage: &StorageManager<S>,
@@ -328,10 +329,11 @@ impl Azks {
         epoch: u64,
         insert_mode: InsertMode,
         parallel_levels: Option<u8>,
-    ) -> Result<(TreeNode, u64), AkdError> {
-        // Phase 1: Obtain the current root node of this subtree and count if a
-        // node is inserted.
+    ) -> Result<(TreeNode, bool, u64), AkdError> {
+        // Phase 1: Obtain the current root node of this subtree. If the node is
+        // new, mark it as so and count it towards the number of inserted nodes.
         let mut current_node;
+        let is_new;
         let mut num_inserted;
 
         match (node_label, &node_set[..]) {
@@ -353,13 +355,15 @@ impl Azks {
                     // the longest common prefix.
                     current_node = new_interior_node(lcp_label, epoch);
                     current_node.set_child(&mut existing_node)?;
-                    existing_node.write_to_storage(storage).await?;
+                    existing_node.write_to_storage(storage, false).await?;
+                    is_new = true;
                     num_inserted = 1;
                 } else {
                     // Case 1b: The existing node does not need to be
                     // decompressed as its label is longer than or equal to the
                     // longest common prefix of the node set.
                     current_node = existing_node;
+                    is_new = false;
                     num_inserted = 0;
                 }
             }
@@ -368,6 +372,7 @@ impl Azks {
                 // single element, meaning that a new leaf node should be
                 // created to represent the element.
                 current_node = new_leaf_node(node.label, &node.hash, epoch);
+                is_new = true;
                 num_inserted = 1;
             }
             (None, _) => {
@@ -377,6 +382,7 @@ impl Azks {
                 // the node set.
                 let lcp_label = node_set.get_longest_common_prefix();
                 current_node = new_interior_node(lcp_label, epoch);
+                is_new = true;
                 num_inserted = 1;
             }
         }
@@ -411,10 +417,10 @@ impl Azks {
                 Some(tokio::task::spawn(left_future))
             } else {
                 // else handle the left child in the current task
-                let (mut left_node, left_num_inserted) = left_future.await?;
+                let (mut left_node, left_is_new, left_num_inserted) = left_future.await?;
 
                 current_node.set_child(&mut left_node)?;
-                left_node.write_to_storage(storage).await?;
+                left_node.write_to_storage(storage, left_is_new).await?;
                 num_inserted += left_num_inserted;
                 None
             }
@@ -425,28 +431,29 @@ impl Azks {
         // handle the right child in the current task
         if !right_node_set.is_empty() {
             let right_child_label = current_node.get_child_label(Direction::Right)?;
-            let (mut right_node, right_num_inserted) = Azks::recursive_batch_insert_nodes(
-                storage,
-                right_child_label,
-                right_node_set,
-                epoch,
-                insert_mode,
-                child_parallel_levels,
-            )
-            .await?;
+            let (mut right_node, right_is_new, right_num_inserted) =
+                Azks::recursive_batch_insert_nodes(
+                    storage,
+                    right_child_label,
+                    right_node_set,
+                    epoch,
+                    insert_mode,
+                    child_parallel_levels,
+                )
+                .await?;
 
             current_node.set_child(&mut right_node)?;
-            right_node.write_to_storage(storage).await?;
+            right_node.write_to_storage(storage, right_is_new).await?;
             num_inserted += right_num_inserted;
         }
 
         // join on the handle for the left child, if present
         if let Some(handle) = maybe_handle {
-            let (mut left_node, left_num_inserted) = handle
+            let (mut left_node, left_is_new, left_num_inserted) = handle
                 .await
                 .map_err(|e| AkdError::Parallelism(ParallelismError::JoinErr(e.to_string())))??;
             current_node.set_child(&mut left_node)?;
-            left_node.write_to_storage(storage).await?;
+            left_node.write_to_storage(storage, left_is_new).await?;
             num_inserted += left_num_inserted;
         }
 
@@ -456,7 +463,7 @@ impl Azks {
             .update_node_hash::<_>(storage, NodeHashingMode::from(insert_mode))
             .await?;
 
-        Ok((current_node, num_inserted))
+        Ok((current_node, is_new, num_inserted))
     }
 
     pub(crate) async fn preload_lookup_nodes<S: Database + Send + Sync>(
@@ -959,7 +966,7 @@ mod tests {
             let hash = crate::hash::hash(&input);
             let node = Node { label, hash };
             node_set.push(node);
-            let (root_node, _) = Azks::recursive_batch_insert_nodes(
+            let (root_node, is_new, _) = Azks::recursive_batch_insert_nodes(
                 &db,
                 Some(NodeLabel::root()),
                 NodeSet::from(vec![node]),
@@ -968,7 +975,7 @@ mod tests {
                 None,
             )
             .await?;
-            root_node.write_to_storage(&db).await?;
+            root_node.write_to_storage(&db, is_new).await?;
         }
 
         let database2 = AsyncInMemoryDatabase::new();
@@ -1067,7 +1074,7 @@ mod tests {
             rng.fill_bytes(&mut hash);
             let node = Node { label, hash };
             node_set.push(node);
-            let (root_node, _) = Azks::recursive_batch_insert_nodes(
+            let (root_node, is_new, _) = Azks::recursive_batch_insert_nodes(
                 &db,
                 Some(NodeLabel::root()),
                 NodeSet::from(vec![node]),
@@ -1076,7 +1083,7 @@ mod tests {
                 None,
             )
             .await?;
-            root_node.write_to_storage(&db).await?;
+            root_node.write_to_storage(&db, is_new).await?;
         }
 
         // Try randomly permuting

--- a/akd/src/storage/manager/mod.rs
+++ b/akd/src/storage/manager/mod.rs
@@ -300,6 +300,8 @@ impl<Db: Database> StorageManager<Db> {
         }
 
         // cache miss, read direct from db
+        self.increment_metric(METRIC_GET);
+
         let record = self
             .tic_toc(METRIC_READ_TIME, self.db.get::<St>(id))
             .await?;
@@ -307,7 +309,6 @@ impl<Db: Database> StorageManager<Db> {
             // cache the result
             cache.put(&record).await;
         }
-        self.increment_metric(METRIC_GET);
         Ok(record)
     }
 

--- a/akd_client/Cargo.toml
+++ b/akd_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_client"
-version = "0.8.4"
+version = "0.8.5"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Client verification companion for the auditable key directory with limited dependencies."
 license = "MIT OR Apache-2.0"

--- a/akd_core/Cargo.toml
+++ b/akd_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_core"
-version = "0.8.4"
+version = "0.8.5"
 authors = ["Sean Lawlor <seanlawlor@fb.com>"]
 description = "Core utilities for the auditable-key-directory suite of crates (akd and akd_client)"
 license = "MIT OR Apache-2.0"

--- a/akd_local_auditor/Cargo.toml
+++ b/akd_local_auditor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "akd_local_auditor"
 default-run = "akd_local_auditor"
-version = "0.8.4"
+version = "0.8.5"
 authors = ["Sean Lawlor <seanlawlor@fb.com>"]
 edition = "2018"
 publish = false

--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_mysql"
-version = "0.8.4"
+version = "0.8.5"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "A MySQL storage layer implementation for an auditable key directory (AKD)"
 license = "MIT OR Apache-2.0"
@@ -25,9 +25,9 @@ async-recursion = "0.3"
 mysql_async = "0.31"
 mysql_common = "0.29.1"
 log = { version = "0.4.8", features = ["kv_unstable"] }
-akd = { path = "../akd", version = "0.8.1", features = ["serde_serialization"], default-features = false }
+akd = { path = "../akd", version = "0.8.5", features = ["serde_serialization"], default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"
 serial_test = "0.5"
-akd = { path = "../akd", version = "0.8.1", features = ["blake3", "public-tests"], default-features = false }
+akd = { path = "../akd", version = "0.8.5", features = ["blake3", "public-tests"], default-features = false }

--- a/akd_test_tools/Cargo.toml
+++ b/akd_test_tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_test_tools"
-version = "0.8.4"
+version = "0.8.5"
 authors = ["Evan Au <evanau@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Test utilities and tooling"
 license = "MIT OR Apache-2.0"
@@ -22,9 +22,9 @@ serde = "1.0"
 async-trait = "0.1"
 thread-id = "3"
 
-akd = { path = "../akd", features = ["serde_serialization"], version = "0.8.4" }
+akd = { path = "../akd", features = ["serde_serialization"], version = "0.8.5" }
 
 [dev-dependencies]
 assert_fs="1"
 
-akd = { path = "../akd", features = ["public-tests", "rand", "serde_serialization"], version = "0.8.4" }
+akd = { path = "../akd", features = ["public-tests", "rand", "serde_serialization"], version = "0.8.5" }


### PR DESCRIPTION
# Overview

When writing tree nodes to storage, we look up previous versions of the node to create the `TreeNodeWithPreviousValue` struct. However, this is not necessary when we know a node is new and does not have a previous value. By keeping track of whether a node is new, we save on incurring an unnecessary round trip to the database.

This PR performs the requisite change.

I would have liked to add a test for this change, however I cannot think of a straightforward way to assert that the database is not read beyond the initial preload. I believe this is something that can be addressed by bringing in a mocking library to mock out the `Database` trait, or implementing an in-memory database which we can mock. Filed an issue regarding this: #332

# Manual Test
Added the following test to `append_only_zks.rs`, which batch inserts 10 nodes on an empty tree and prints database access metrics:
```rust
#[tokio::test]
async fn test_get_count() -> Result<(), AkdError> {
    let num_nodes = 10;
    let node_set = gen_nodes(num_nodes);

    let database = AsyncInMemoryDatabase::new();
    let db = StorageManager::new(database.clone(), None, None, None);
    let mut azks = Azks::new(&db).await?;

    db.begin_transaction();
    azks.batch_insert_nodes(&db, node_set, InsertMode::Directory)
        .await?;
    db.log_metrics(log::Level::Trace).await;

    Ok(())
}
```
The test was ran with the following command:
```console
$ cargo test test_get_count -- --nocapture
```
If the change works, no gets are expected as the insert was performed on an empty tree with nothing to preload.
## Before
On the `main` branch, with 7878bcb cherry-picked:
```
===================================================
============ Database operation counts ============
===================================================
    SET 1, 
    BATCH SET 0, 
    GET 19, 
    BATCH GET 0
    TOMBSTONE 0
    GET USER STATE 0
    GET USER DATA 0
    GET USER STATE VERSIONS 0
```
19 gets are performed.
## After
On this PR's branch:
```
===================================================
============ Database operation counts ============
===================================================
    SET 1, 
    BATCH SET 0, 
    GET 0, 
    BATCH GET 0
    TOMBSTONE 0
    GET USER STATE 0
    GET USER DATA 0
    GET USER STATE VERSIONS 0
```

Indeed the number of gets are now 0.
