### PR TITLE
Skip metric logging if runtime_metrics feature is not enabled

### DIFF
--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -243,6 +243,7 @@ impl<S: Database + 'static, V: VRFKeyStorage> Directory<S, V> {
                 info!("Transaction committed ({} records)", num_records);
             }
             Err(err) => {
+                error!("Failed to commit transaction, rolling back");
                 let _ = self.storage.rollback_transaction();
                 return Err(AkdError::Storage(err));
             }

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -238,12 +238,15 @@ impl<S: Database + 'static, V: VRFKeyStorage> Directory<S, V> {
 
         // Commit the transaction
         info!("Committing transaction");
-        if let Err(err) = self.storage.commit_transaction().await {
-            let _ = self.storage.rollback_transaction();
-            return Err(AkdError::Storage(err));
-        } else {
-            info!("Transaction committed");
-        }
+        match self.storage.commit_transaction().await {
+            Ok(num_records) => {
+                info!("Transaction committed ({} records)", num_records);
+            }
+            Err(err) => {
+                let _ = self.storage.rollback_transaction();
+                return Err(AkdError::Storage(err));
+            }
+        };
 
         let root_hash = current_azks
             .get_root_hash_safe::<_>(&self.storage, next_epoch)

--- a/akd/src/storage/manager/mod.rs
+++ b/akd/src/storage/manager/mod.rs
@@ -123,14 +123,16 @@ impl<Db: Database> StorageManager<Db> {
 
         self.transaction.log_metrics(level);
 
-        let snapshot = self
-            .metrics
-            .iter()
-            .map(|metric| metric.load(Ordering::Relaxed))
-            .collect::<Vec<_>>();
+        #[cfg(feature = "runtime_metrics")]
+        {
+            let snapshot = self
+                .metrics
+                .iter()
+                .map(|metric| metric.load(Ordering::Relaxed))
+                .collect::<Vec<_>>();
 
-        let msg = format!(
-            "
+            let msg = format!(
+                "
 ===================================================
 ============ Database operation counts ============
 ===================================================
@@ -147,26 +149,27 @@ impl<Db: Database> StorageManager<Db> {
 ===================================================
     TIME READ {} ms
     TIME WRITE {} ms",
-            snapshot[METRIC_SET],
-            snapshot[METRIC_BATCH_SET],
-            snapshot[METRIC_GET],
-            snapshot[METRIC_BATCH_GET],
-            snapshot[METRIC_TOMBSTONE],
-            snapshot[METRIC_GET_USER_STATE],
-            snapshot[METRIC_GET_USER_DATA],
-            snapshot[METRIC_GET_USER_STATE_VERSIONS],
-            snapshot[METRIC_READ_TIME],
-            snapshot[METRIC_WRITE_TIME]
-        );
+                snapshot[METRIC_SET],
+                snapshot[METRIC_BATCH_SET],
+                snapshot[METRIC_GET],
+                snapshot[METRIC_BATCH_GET],
+                snapshot[METRIC_TOMBSTONE],
+                snapshot[METRIC_GET_USER_STATE],
+                snapshot[METRIC_GET_USER_DATA],
+                snapshot[METRIC_GET_USER_STATE_VERSIONS],
+                snapshot[METRIC_READ_TIME],
+                snapshot[METRIC_WRITE_TIME]
+            );
 
-        match level {
-            // Currently logs cannot be captured unless they are
-            // println!. Normally Level::Trace should use the trace! macro.
-            log::Level::Trace => println!("{}", msg),
-            log::Level::Debug => debug!("{}", msg),
-            log::Level::Info => info!("{}", msg),
-            log::Level::Warn => warn!("{}", msg),
-            _ => error!("{}", msg),
+            match level {
+                // Currently logs cannot be captured unless they are
+                // println!. Normally Level::Trace should use the trace! macro.
+                log::Level::Trace => println!("{}", msg),
+                log::Level::Debug => debug!("{}", msg),
+                log::Level::Info => info!("{}", msg),
+                log::Level::Warn => warn!("{}", msg),
+                _ => error!("{}", msg),
+            }
         }
     }
 

--- a/akd/src/storage/manager/mod.rs
+++ b/akd/src/storage/manager/mod.rs
@@ -22,10 +22,14 @@ use crate::storage::StorageError;
 use crate::AkdLabel;
 use crate::AkdValue;
 
-use log::{debug, error, info, warn};
+use log::debug;
+#[cfg(feature = "runtime_metrics")]
+use log::{error, info, warn};
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::AtomicU64;
+#[cfg(feature = "runtime_metrics")]
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/akd/src/storage/tests.rs
+++ b/akd/src/storage/tests.rs
@@ -381,7 +381,7 @@ async fn test_transactions<S: Database>(storage: &StorageManager<S>) {
     let tic = Instant::now();
     assert!(storage.begin_transaction());
     assert_eq!(Ok(()), storage.batch_set(new_data).await);
-    assert_eq!(Ok(()), storage.commit_transaction().await);
+    assert!(matches!(storage.commit_transaction().await, Ok(_)));
     let toc: Duration = Instant::now() - tic;
     println!("Transactional storage batch op: {} ms", toc.as_millis());
 

--- a/akd/src/storage/tests.rs
+++ b/akd/src/storage/tests.rs
@@ -381,7 +381,7 @@ async fn test_transactions<S: Database>(storage: &StorageManager<S>) {
     let tic = Instant::now();
     assert!(storage.begin_transaction());
     assert_eq!(Ok(()), storage.batch_set(new_data).await);
-    assert!(matches!(storage.commit_transaction().await, Ok(_)));
+    assert!(storage.commit_transaction().await.is_ok());
     let toc: Duration = Instant::now() - tic;
     println!("Transactional storage batch op: {} ms", toc.as_millis());
 

--- a/akd/src/storage/transaction.rs
+++ b/akd/src/storage/transaction.rs
@@ -14,6 +14,7 @@ use crate::storage::types::ValueStateRetrievalFlag;
 use crate::storage::Storable;
 
 use dashmap::DashMap;
+#[cfg(feature = "runtime_metrics")]
 use log::{debug, error, info, trace, warn};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -28,7 +29,9 @@ pub struct Transaction {
     mods: Arc<DashMap<Vec<u8>, DbRecord>>,
     active: Arc<AtomicBool>,
 
+    #[cfg(feature = "runtime_metrics")]
     num_reads: Arc<AtomicU64>,
+    #[cfg(feature = "runtime_metrics")]
     num_writes: Arc<AtomicU64>,
 }
 
@@ -54,7 +57,9 @@ impl Transaction {
             mods: Arc::new(DashMap::new()),
             active: Arc::new(AtomicBool::new(false)),
 
+            #[cfg(feature = "runtime_metrics")]
             num_reads: Arc::new(AtomicU64::new(0)),
+            #[cfg(feature = "runtime_metrics")]
             num_writes: Arc::new(AtomicU64::new(0)),
         }
     }
@@ -65,7 +70,7 @@ impl Transaction {
     }
 
     /// Log metrics about the current transaction instance. Metrics will be cleared after log call
-    pub fn log_metrics(&self, level: log::Level) {
+    pub fn log_metrics(&self, _level: log::Level) {
         #[cfg(feature = "runtime_metrics")]
         {
             let r = self.num_reads.swap(0, Ordering::Relaxed);
@@ -73,7 +78,7 @@ impl Transaction {
 
             let msg = format!("Transaction writes: {}, Transaction reads: {}", w, r);
 
-            match level {
+            match _level {
                 log::Level::Trace => trace!("{}", msg),
                 log::Level::Debug => debug!("{}", msg),
                 log::Level::Info => info!("{}", msg),

--- a/akd/src/storage/transaction.rs
+++ b/akd/src/storage/transaction.rs
@@ -66,17 +66,20 @@ impl Transaction {
 
     /// Log metrics about the current transaction instance. Metrics will be cleared after log call
     pub fn log_metrics(&self, level: log::Level) {
-        let r = self.num_reads.swap(0, Ordering::Relaxed);
-        let w = self.num_writes.swap(0, Ordering::Relaxed);
+        #[cfg(feature = "runtime_metrics")]
+        {
+            let r = self.num_reads.swap(0, Ordering::Relaxed);
+            let w = self.num_writes.swap(0, Ordering::Relaxed);
 
-        let msg = format!("Transaction writes: {}, Transaction reads: {}", w, r);
+            let msg = format!("Transaction writes: {}, Transaction reads: {}", w, r);
 
-        match level {
-            log::Level::Trace => trace!("{}", msg),
-            log::Level::Debug => debug!("{}", msg),
-            log::Level::Info => info!("{}", msg),
-            log::Level::Warn => warn!("{}", msg),
-            _ => error!("{}", msg),
+            match level {
+                log::Level::Trace => trace!("{}", msg),
+                log::Level::Debug => debug!("{}", msg),
+                log::Level::Info => info!("{}", msg),
+                log::Level::Warn => warn!("{}", msg),
+                _ => error!("{}", msg),
+            }
         }
     }
 

--- a/akd/src/storage/transaction.rs
+++ b/akd/src/storage/transaction.rs
@@ -17,7 +17,9 @@ use dashmap::DashMap;
 #[cfg(feature = "runtime_metrics")]
 use log::{debug, error, info, trace, warn};
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+#[cfg(feature = "runtime_metrics")]
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 /// Represents an in-memory transaction, keeping a mutable state


### PR DESCRIPTION
Currently, non-populated transaction metrics and database metrics are printed when the `runtime_metrics` feature is not enabled. We can skip these for cleaner logs.

This PR also adds the number of records to the transaction commit log statement.