### PR TITLE
Renaming of functions / fields (part 1)

### DIFF
--- a/akd/benches/azks.rs
+++ b/akd/benches/azks.rs
@@ -11,7 +11,7 @@ extern crate criterion;
 use akd::append_only_zks::InsertMode;
 use akd::storage::manager::StorageManager;
 use akd::storage::memory::AsyncInMemoryDatabase;
-use akd::{Azks, Node, NodeLabel};
+use akd::{Azks, AzksElement, NodeLabel};
 use criterion::{BatchSize, Criterion};
 use rand::rngs::StdRng;
 use rand::{RngCore, SeedableRng};
@@ -30,7 +30,7 @@ fn batch_insertion(c: &mut Criterion) {
         let mut input = [0u8; 32];
         rng.fill_bytes(&mut input);
         let hash = akd_core::hash::hash(&input);
-        initial_node_set.push(Node { label, hash });
+        initial_node_set.push(AzksElement { label, value: hash });
     }
 
     // prepare node set for batch insertion
@@ -40,7 +40,7 @@ fn batch_insertion(c: &mut Criterion) {
         let mut input = [0u8; 32];
         rng.fill_bytes(&mut input);
         let hash = akd_core::hash::hash(&input);
-        node_set.push(Node { label, hash });
+        node_set.push(AzksElement { label, value: hash });
     }
 
     // benchmark batch insertion

--- a/akd/src/auditor.rs
+++ b/akd/src/auditor.rs
@@ -65,7 +65,7 @@ pub async fn verify_consecutive_append_only(
         .iter()
         .map(|x| {
             let mut y = *x;
-            y.hash = akd_core::hash::merge_with_int(x.hash, epoch);
+            y.value = akd_core::hash::merge_with_int(x.value, epoch);
             y
         })
         .collect();

--- a/akd/src/storage/cache/tests.rs
+++ b/akd/src/storage/cache/tests.rs
@@ -29,7 +29,7 @@ async fn test_cache_put_and_expires() {
             label_len: 1,
             label_val: [0u8; 32],
         },
-        plaintext_val: AkdValue::from_utf8_str("some value"),
+        value: AkdValue::from_utf8_str("some value"),
         username: AkdLabel::from_utf8_str("user"),
     });
     let key = ValueStateKey(AkdLabel::from_utf8_str("user").0.to_vec(), 1);
@@ -55,7 +55,7 @@ async fn test_cache_overwrite() {
             label_len: 1,
             label_val: [0u8; 32],
         },
-        plaintext_val: AkdValue::from_utf8_str("some value"),
+        value: AkdValue::from_utf8_str("some value"),
         username: AkdLabel::from_utf8_str("user"),
     };
     let key = ValueStateKey(AkdLabel::from_utf8_str("user").0.to_vec(), 1);
@@ -67,7 +67,7 @@ async fn test_cache_overwrite() {
             label_len: 2,
             label_val: [0u8; 32],
         },
-        plaintext_val: AkdValue::from_utf8_str("some value"),
+        value: AkdValue::from_utf8_str("some value"),
         username: AkdLabel::from_utf8_str("user"),
     };
     cache.put(&DbRecord::ValueState(value_state)).await;
@@ -94,7 +94,7 @@ async fn test_cache_memory_pressure() {
             label_len: 1,
             label_val: [0u8; 32],
         },
-        plaintext_val: AkdValue::from_utf8_str("some value"),
+        value: AkdValue::from_utf8_str("some value"),
         username: AkdLabel::from_utf8_str("user"),
     });
     let key = ValueStateKey(AkdLabel::from_utf8_str("user").0.to_vec(), 1);
@@ -125,7 +125,7 @@ async fn test_many_memory_pressure() {
                 label_len: 1,
                 label_val: [0u8; 32],
             },
-            plaintext_val: AkdValue::from_utf8_str("test"),
+            value: AkdValue::from_utf8_str("test"),
             username: AkdLabel::from_utf8_str("user"),
         })
         .map(DbRecord::ValueState)

--- a/akd/src/storage/manager/mod.rs
+++ b/akd/src/storage/manager/mod.rs
@@ -412,7 +412,7 @@ impl<Db: Database> StorageManager<Db> {
                 new_data.push(DbRecord::ValueState(ValueState {
                     epoch: value_state.epoch,
                     label: value_state.label,
-                    plaintext_val: crate::AkdValue(crate::TOMBSTONE.to_vec()),
+                    value: crate::AkdValue(crate::TOMBSTONE.to_vec()),
                     username: value_state.username,
                     version: value_state.version,
                 }));
@@ -547,12 +547,12 @@ impl<Db: Database> StorageManager<Db> {
                     if let Some(updated_record) =
                         Self::compare_db_and_transaction_records(*epoch, value_state, flag)
                     {
-                        data.insert(label, (*epoch, updated_record.plaintext_val));
+                        data.insert(label, (*epoch, updated_record.value));
                     }
                 } else {
                     // there is no db-equivalent record, but there IS a record in the transaction log.
                     // Take the transaction log value
-                    data.insert(label, (value_state.epoch, value_state.plaintext_val));
+                    data.insert(label, (value_state.epoch, value_state.value));
                 }
             }
         }

--- a/akd/src/storage/memory.rs
+++ b/akd/src/storage/memory.rs
@@ -260,7 +260,7 @@ impl Database for AsyncInMemoryDatabase {
             if let Ok(result) = self.get_user_state(username, flag).await {
                 map.insert(
                     AkdLabel(result.username.to_vec()),
-                    (result.version, AkdValue(result.plaintext_val.to_vec())),
+                    (result.version, AkdValue(result.value.to_vec())),
                 );
             }
         }

--- a/akd/src/storage/tests.rs
+++ b/akd/src/storage/tests.rs
@@ -83,7 +83,7 @@ async fn test_get_and_set_item<Ns: Database>(storage: &Ns) {
         // FIXME: what should least_child_ep really be?
         min_descendant_epoch: 1,
         parent: NodeLabel::new(byte_arr_from_u64(1), 1),
-        node_type: NodeType::Leaf,
+        node_type: TreeNodeType::Leaf,
         left_child: None,
         right_child: None,
         hash: [0; crate::DIGEST_BYTES],
@@ -128,7 +128,7 @@ async fn test_get_and_set_item<Ns: Database>(storage: &Ns) {
         epoch: 1,
         label: NodeLabel::new(byte_arr_from_u64(1), 1),
         version: 1,
-        plaintext_val: AkdValue::from_utf8_str("abc123"),
+        value: AkdValue::from_utf8_str("abc123"),
     };
     let set_result = storage.set(DbRecord::ValueState(value.clone())).await;
     assert_eq!(Ok(()), set_result);
@@ -138,7 +138,7 @@ async fn test_get_and_set_item<Ns: Database>(storage: &Ns) {
         assert_eq!(got_state.username, value.username);
         assert_eq!(got_state.epoch, value.epoch);
         assert_eq!(got_state.label, value.label);
-        assert_eq!(got_state.plaintext_val, value.plaintext_val);
+        assert_eq!(got_state.value, value.value);
         assert_eq!(got_state.version, value.version);
     } else {
         panic!("Failed to retrieve history node state");
@@ -162,7 +162,7 @@ async fn test_batch_get_items<Ns: Database>(storage: &Ns) {
     for value in rand_users.iter() {
         for user in rand_users.iter() {
             data.push(DbRecord::ValueState(ValueState {
-                plaintext_val: AkdValue(value.clone()),
+                value: AkdValue(value.clone()),
                 version: epoch,
                 label: NodeLabel {
                     label_val: byte_arr_from_u64(1),
@@ -330,7 +330,7 @@ async fn test_transactions<S: Database>(storage: &StorageManager<S>) {
     for value in rand_users.iter() {
         for user in rand_users.iter() {
             data.push(DbRecord::ValueState(ValueState {
-                plaintext_val: AkdValue(value.clone()),
+                value: AkdValue(value.clone()),
                 version: 1u64,
                 label: NodeLabel {
                     label_val: byte_arr_from_u64(1),
@@ -409,7 +409,7 @@ async fn test_user_data<S: Database>(storage: &S) {
         .as_bytes()
         .to_vec();
     let mut sample_state = ValueState {
-        plaintext_val: AkdValue(rand_value.clone()),
+        value: AkdValue(rand_value.clone()),
         version: 1u64,
         label: NodeLabel {
             label_val: byte_arr_from_u64(1),
@@ -488,7 +488,7 @@ async fn test_user_data<S: Database>(storage: &S) {
             epoch: 123,
             version: 2,
             label: NodeLabel::new(byte_arr_from_u64(1), 1),
-            plaintext_val: AkdValue(rand_value.clone()),
+            value: AkdValue(rand_value.clone()),
             username: sample_state.username.clone(),
         }),
         specific_result
@@ -503,7 +503,7 @@ async fn test_user_data<S: Database>(storage: &S) {
                 epoch: 123,
                 version: 2,
                 label: NodeLabel::new(byte_arr_from_u64(1), 1),
-                plaintext_val: AkdValue(rand_value.clone()),
+                value: AkdValue(rand_value.clone()),
                 username: sample_state.username.clone(),
             },
             state
@@ -531,7 +531,7 @@ async fn test_user_data<S: Database>(storage: &S) {
             epoch: 123,
             version: 2,
             label: NodeLabel::new(byte_arr_from_u64(1), 1),
-            plaintext_val: AkdValue(rand_value.clone()),
+            value: AkdValue(rand_value.clone()),
             username: sample_state.username.clone(),
         }),
         specific_result
@@ -545,7 +545,7 @@ async fn test_user_data<S: Database>(storage: &S) {
             epoch: 1,
             version: 1,
             label: NodeLabel::new(byte_arr_from_u64(1), 1),
-            plaintext_val: AkdValue(rand_value.clone()),
+            value: AkdValue(rand_value.clone()),
             username: sample_state.username.clone(),
         }),
         specific_result
@@ -559,7 +559,7 @@ async fn test_user_data<S: Database>(storage: &S) {
             epoch: 456,
             version: 3,
             label: NodeLabel::new(byte_arr_from_u64(1), 1),
-            plaintext_val: AkdValue(rand_value.clone()),
+            value: AkdValue(rand_value.clone()),
             username: sample_state.username.clone(),
         }),
         specific_result
@@ -605,7 +605,7 @@ async fn test_tombstoning_data<S: Database>(
     let rand_value = rand_user.clone();
 
     let mut sample_state = ValueState {
-        plaintext_val: AkdValue(rand_value.clone()),
+        value: AkdValue(rand_value.clone()),
         version: 1u64,
         label: NodeLabel {
             label_val: byte_arr_from_u64(1),
@@ -669,10 +669,10 @@ async fn test_tombstoning_data<S: Database>(
                 assert_eq!(version, value_state.epoch);
                 if keys_to_tombstone.contains(&key) {
                     // should be a tombstone
-                    assert_eq!(crate::TOMBSTONE.to_vec(), value_state.plaintext_val.0);
+                    assert_eq!(crate::TOMBSTONE.to_vec(), value_state.value.0);
                 } else {
                     // should NOT be a tombstone
-                    assert_ne!(crate::TOMBSTONE.to_vec(), value_state.plaintext_val.0);
+                    assert_ne!(crate::TOMBSTONE.to_vec(), value_state.value.0);
                 }
             } else {
                 panic!("Unable to retrieve value state {:?}", key);

--- a/akd/src/storage/transaction.rs
+++ b/akd/src/storage/transaction.rs
@@ -303,7 +303,7 @@ mod tests {
             last_epoch: 1,
             min_descendant_epoch: 1,
             parent: NodeLabel::new(byte_arr_from_u64(0), 0),
-            node_type: NodeType::Root,
+            node_type: TreeNodeType::Root,
             left_child: None,
             right_child: None,
             hash: crate::hash::EMPTY_DIGEST,
@@ -313,7 +313,7 @@ mod tests {
             last_epoch: 1,
             min_descendant_epoch: 1,
             parent: NodeLabel::new(byte_arr_from_u64(0), 0),
-            node_type: NodeType::Leaf,
+            node_type: TreeNodeType::Leaf,
             left_child: None,
             right_child: None,
             hash: crate::hash::EMPTY_DIGEST,
@@ -323,14 +323,14 @@ mod tests {
             epoch: 1,
             label: NodeLabel::new(byte_arr_from_u64(1), 1),
             version: 1,
-            plaintext_val: AkdValue::from_utf8_str("abc123"),
+            value: AkdValue::from_utf8_str("abc123"),
         });
         let value2 = DbRecord::ValueState(ValueState {
             username: AkdLabel::from_utf8_str("test"),
             epoch: 2,
             label: NodeLabel::new(byte_arr_from_u64(1), 1),
             version: 2,
-            plaintext_val: AkdValue::from_utf8_str("abc1234"),
+            value: AkdValue::from_utf8_str("abc1234"),
         });
 
         let records = vec![azks, node1, node2, value1, value2];

--- a/akd/src/storage/types.rs
+++ b/akd/src/storage/types.rs
@@ -8,7 +8,7 @@
 //! Various storage and representation related types
 
 use crate::storage::Storable;
-use crate::tree_node::{NodeType, TreeNode, TreeNodeWithPreviousValue};
+use crate::tree_node::{TreeNode, TreeNodeType, TreeNodeWithPreviousValue};
 use crate::{AkdLabel, AkdValue};
 use crate::{Azks, NodeLabel};
 use std::convert::TryInto;
@@ -43,9 +43,9 @@ pub struct ValueStateKey(pub Vec<u8>, pub u64);
 #[cfg_attr(feature = "serde_serialization", serde(bound = ""))]
 pub struct ValueState {
     /// The plaintext value of the user information in the directory
-    pub plaintext_val: AkdValue, // This needs to be the plaintext value, to discuss
+    pub value: AkdValue, // The actual value
     /// The version of the user's value-state
-    pub version: u64, // to discuss
+    pub version: u64,
     /// The Node Label
     pub label: NodeLabel,
     /// The epoch this value state was published in
@@ -56,7 +56,7 @@ pub struct ValueState {
 
 impl akd_core::SizeOf for ValueState {
     fn size_of(&self) -> usize {
-        self.plaintext_val.size_of()
+        self.value.size_of()
             + std::mem::size_of::<u64>()
             + self.label.size_of()
             + std::mem::size_of::<u64>()
@@ -107,7 +107,7 @@ impl ValueState {
         epoch: u64,
     ) -> Self {
         ValueState {
-            plaintext_val,
+            value: plaintext_val,
             version,
             label,
             epoch,
@@ -251,7 +251,7 @@ impl DbRecord {
                 last_epoch: a,
                 min_descendant_epoch: b,
                 parent: NodeLabel::new(c, d),
-                node_type: NodeType::from_u8(e),
+                node_type: TreeNodeType::from_u8(e),
                 left_child: p_left_child,
                 right_child: p_right_child,
                 hash: f,
@@ -265,7 +265,7 @@ impl DbRecord {
                 last_epoch,
                 min_descendant_epoch: least_descendant_ep,
                 parent: NodeLabel::new(parent_label_val, parent_label_len),
-                node_type: NodeType::from_u8(node_type),
+                node_type: TreeNodeType::from_u8(node_type),
                 left_child,
                 right_child,
                 hash,
@@ -284,7 +284,7 @@ impl DbRecord {
         epoch: u64,
     ) -> ValueState {
         ValueState {
-            plaintext_val: AkdValue(plaintext_val),
+            value: AkdValue(plaintext_val),
             version,
             label: NodeLabel::new(label_val, label_len),
             epoch,

--- a/akd/src/tests.rs
+++ b/akd/src/tests.rs
@@ -964,10 +964,7 @@ async fn test_read_during_publish() -> Result<(), AkdError> {
 
     // Lookup proof should contain the checkpoint epoch's value and still verify
     let (lookup_proof, root_hash) = akd.lookup(AkdLabel::from_utf8_str("hello")).await?;
-    assert_eq!(
-        AkdValue::from_utf8_str("world_2"),
-        lookup_proof.plaintext_value
-    );
+    assert_eq!(AkdValue::from_utf8_str("world_2"), lookup_proof.value);
     lookup_verify(
         vrf_pk.as_bytes(),
         root_hash.hash(),
@@ -1351,7 +1348,7 @@ async fn async_poll_helper_proof<T: Database + 'static, V: VRFKeyStorage>(
 ) -> Result<(), AkdError> {
     // reader should read "hello" and this will populate the "cache" a log
     let (lookup_proof, root_hash) = reader.lookup(AkdLabel::from_utf8_str("hello")).await?;
-    assert_eq!(value, lookup_proof.plaintext_value);
+    assert_eq!(value, lookup_proof.value);
     let pk = reader.get_public_key().await?;
     lookup_verify(
         pk.as_bytes(),

--- a/akd_core/src/proto/specs/types.proto
+++ b/akd_core/src/proto/specs/types.proto
@@ -19,17 +19,17 @@ message NodeLabel {
     optional uint32 label_len = 2;
 }
 
-/* Node represents the "label" (location) of the node along with its associated hash */
-message Node {
+/* Element of an AZKS wihich contains a label and value */
+message AzksElement {
     optional NodeLabel label = 1;
-    optional bytes hash = 2;
+    optional bytes value = 2;
 }
 
 /* Represents a specific level of the tree with the parental sibling and the direction
 of the parent for use in tree hash calculations */
-message LayerProof {
+message SiblingProof {
     optional NodeLabel label = 1;
-    repeated Node siblings = 2;
+    repeated AzksElement siblings = 2;
     optional uint32 direction = 3;
 }
 
@@ -38,7 +38,7 @@ value in the tree at a given epoch */
 message MembershipProof {
     optional NodeLabel label = 1;
     optional bytes hash_val = 2;
-    repeated LayerProof layer_proofs = 3;
+    repeated SiblingProof sibling_proofs = 3;
 }
 
 /* Merkle Patricia proof of non-membership for a [`NodeLabel`] in the tree
@@ -46,7 +46,7 @@ at a given epoch. */
 message NonMembershipProof {
     optional NodeLabel label = 1;
     optional NodeLabel longest_prefix = 2;
-    repeated Node longest_prefix_children = 3;
+    repeated AzksElement longest_prefix_children = 3;
     optional MembershipProof longest_prefix_membership_proof = 4;
 }
 
@@ -58,7 +58,7 @@ This means we need to show that the state and version we are claiming for this n
 This proof is sent in response to a lookup query for a particular key. */
 message LookupProof {
     optional uint64 epoch = 1;
-    optional bytes plaintext_value = 2;
+    optional bytes value = 2;
     optional uint64 version = 3;
     optional bytes existence_vrf_proof = 4;
     optional MembershipProof existence_proof = 5;
@@ -66,7 +66,7 @@ message LookupProof {
     optional MembershipProof marker_proof = 7;
     optional bytes freshness_vrf_proof = 8;
     optional NonMembershipProof freshness_proof = 9;
-    optional bytes commitment_proof = 10;
+    optional bytes commitment_nonce = 10;
 }
 
 /* A vector of UpdateProofs are sent as the proof to a history query for a particular key.
@@ -78,28 +78,30 @@ For each version of the value associated with the key, the verifier must check t
 * the future marker versions did  not exist at this epoch. */
 message UpdateProof {
     optional uint64 epoch = 1;
-    optional bytes plaintext_value = 2;
+    optional bytes value = 2;
     optional uint64 version = 3;
     optional bytes existence_vrf_proof = 4;
-    optional MembershipProof existence_at_ep = 5;
+    optional MembershipProof existence_proof = 5;
     optional bytes previous_version_vrf_proof = 6;
-    optional MembershipProof previous_version_stale_at_ep = 7;
-    optional bytes commitment_proof = 8;
+    optional MembershipProof previous_version_proof = 7;
+    optional bytes commitment_nonce = 8;
 }
 
-/* This proof is just an array of [`UpdateProof`]s. */
+/* This proof consists of an array of [`UpdateProof`]s, non-membership proofs for 
+the versions up until the next marker, and then non-membership proofs for future markers
+up until the current epoch. */
 message HistoryProof {
     repeated UpdateProof update_proofs = 1;
-    repeated bytes next_few_vrf_proofs = 2;
-    repeated NonMembershipProof non_existence_of_next_few = 3;
+    repeated bytes until_marker_vrf_proofs = 2;
+    repeated NonMembershipProof non_existence_until_marker_proofs = 3;
     repeated bytes future_marker_vrf_proofs = 4;
-    repeated NonMembershipProof non_existence_of_future_markers = 5;
+    repeated NonMembershipProof non_existence_of_future_marker_proofs = 5;
 }
 
 /* SingleEncodedProof represents a proof that no leaves were changed or removed between epoch t and t + 1 */
 message SingleAppendOnlyProof {
-    repeated Node inserted = 1;
-    repeated Node unchanged_nodes = 2;
+    repeated AzksElement inserted = 1;
+    repeated AzksElement unchanged_nodes = 2;
 }
 
 /* An append-only proof is a proof that no nodes were changes from epochs[0] to epochs[end], epoch-by-epoch */

--- a/akd_core/src/proto/tests.rs
+++ b/akd_core/src/proto/tests.rs
@@ -18,10 +18,10 @@ fn random_hash() -> [u8; 32] {
     thread_rng().gen::<[u8; 32]>()
 }
 
-fn random_node() -> crate::Node {
-    crate::Node {
+fn random_azks_element() -> crate::AzksElement {
+    crate::AzksElement {
         label: random_label(),
-        hash: random_hash(),
+        value: random_hash(),
     }
 }
 
@@ -43,22 +43,22 @@ fn test_convert_nodelabel() {
 }
 
 #[test]
-fn test_convert_node() {
-    let original = random_node();
+fn test_convert_azks_element() {
+    let original = random_azks_element();
 
-    let protobuf: Node = (&original).into();
+    let protobuf: AzksElement = (&original).into();
     assert_eq!(original, (&protobuf).try_into().unwrap());
 }
 
 #[test]
 fn test_convert_layer_proof() {
-    let original = crate::LayerProof {
+    let original = crate::SiblingProof {
         label: random_label(),
-        siblings: [random_node()],
+        siblings: [random_azks_element()],
         direction: Direction::Right,
     };
 
-    let protobuf: LayerProof = (&original).into();
+    let protobuf: SiblingProof = (&original).into();
     assert_eq!(original, (&protobuf).try_into().unwrap());
 }
 
@@ -67,9 +67,9 @@ fn test_convert_membership_proof() {
     let original = crate::MembershipProof {
         label: random_label(),
         hash_val: random_hash(),
-        layer_proofs: vec![crate::LayerProof {
+        sibling_proofs: vec![crate::SiblingProof {
             label: random_label(),
-            siblings: [random_node()],
+            siblings: [random_azks_element()],
             direction: Direction::Right,
         }],
     };
@@ -83,13 +83,13 @@ fn test_convert_non_membership_proof() {
     let original = crate::NonMembershipProof {
         label: random_label(),
         longest_prefix: random_label(),
-        longest_prefix_children: [random_node(), random_node()],
+        longest_prefix_children: [random_azks_element(), random_azks_element()],
         longest_prefix_membership_proof: crate::MembershipProof {
             label: random_label(),
             hash_val: random_hash(),
-            layer_proofs: vec![crate::LayerProof {
+            sibling_proofs: vec![crate::SiblingProof {
                 label: random_label(),
-                siblings: [random_node()],
+                siblings: [random_azks_element()],
                 direction: Direction::Right,
             }],
         },
@@ -104,15 +104,15 @@ fn test_convert_lookup_proof() {
     let mut rng = thread_rng();
     let original = crate::LookupProof {
         epoch: rng.gen(),
-        plaintext_value: crate::AkdValue(random_hash().to_vec()),
+        value: crate::AkdValue(random_hash().to_vec()),
         version: rng.gen(),
         existence_vrf_proof: random_hash().to_vec(),
         existence_proof: crate::MembershipProof {
             label: random_label(),
             hash_val: random_hash(),
-            layer_proofs: vec![crate::LayerProof {
+            sibling_proofs: vec![crate::SiblingProof {
                 label: random_label(),
-                siblings: [random_node()],
+                siblings: [random_azks_element()],
                 direction: Direction::Right,
             }],
         },
@@ -120,9 +120,9 @@ fn test_convert_lookup_proof() {
         marker_proof: crate::MembershipProof {
             label: random_label(),
             hash_val: random_hash(),
-            layer_proofs: vec![crate::LayerProof {
+            sibling_proofs: vec![crate::SiblingProof {
                 label: random_label(),
-                siblings: [random_node()],
+                siblings: [random_azks_element()],
                 direction: Direction::Right,
             }],
         },
@@ -130,18 +130,18 @@ fn test_convert_lookup_proof() {
         freshness_proof: crate::NonMembershipProof {
             label: random_label(),
             longest_prefix: random_label(),
-            longest_prefix_children: [random_node(), random_node()],
+            longest_prefix_children: [random_azks_element(), random_azks_element()],
             longest_prefix_membership_proof: crate::MembershipProof {
                 label: random_label(),
                 hash_val: random_hash(),
-                layer_proofs: vec![crate::LayerProof {
+                sibling_proofs: vec![crate::SiblingProof {
                     label: random_label(),
-                    siblings: [random_node()],
+                    siblings: [random_azks_element()],
                     direction: Direction::Right,
                 }],
             },
         },
-        commitment_proof: random_hash().to_vec(),
+        commitment_nonce: random_hash().to_vec(),
     };
 
     let protobuf: LookupProof = (&original).into();
@@ -153,29 +153,29 @@ fn test_convert_update_proof() {
     let mut rng = thread_rng();
     let original = crate::UpdateProof {
         epoch: rng.gen(),
-        plaintext_value: crate::AkdValue(random_hash().to_vec()),
+        value: crate::AkdValue(random_hash().to_vec()),
         version: rng.gen(),
         existence_vrf_proof: random_hash().to_vec(),
-        existence_at_ep: crate::MembershipProof {
+        existence_proof: crate::MembershipProof {
             label: random_label(),
             hash_val: random_hash(),
-            layer_proofs: vec![crate::LayerProof {
+            sibling_proofs: vec![crate::SiblingProof {
                 label: random_label(),
-                siblings: [random_node()],
+                siblings: [random_azks_element()],
                 direction: Direction::Right,
             }],
         },
         previous_version_vrf_proof: Some(random_hash().to_vec()),
-        previous_version_stale_at_ep: Some(crate::MembershipProof {
+        previous_version_proof: Some(crate::MembershipProof {
             label: random_label(),
             hash_val: random_hash(),
-            layer_proofs: vec![crate::LayerProof {
+            sibling_proofs: vec![crate::SiblingProof {
                 label: random_label(),
-                siblings: [random_node()],
+                siblings: [random_azks_element()],
                 direction: Direction::Right,
             }],
         }),
-        commitment_proof: random_hash().to_vec(),
+        commitment_nonce: random_hash().to_vec(),
     };
 
     let protobuf: UpdateProof = (&original).into();
@@ -188,13 +188,13 @@ fn test_convert_history_proof() {
         crate::NonMembershipProof {
             label: random_label(),
             longest_prefix: random_label(),
-            longest_prefix_children: [random_node(), random_node()],
+            longest_prefix_children: [random_azks_element(), random_azks_element()],
             longest_prefix_membership_proof: crate::MembershipProof {
                 label: random_label(),
                 hash_val: random_hash(),
-                layer_proofs: vec![crate::LayerProof {
+                sibling_proofs: vec![crate::SiblingProof {
                     label: random_label(),
-                    siblings: [random_node()],
+                    siblings: [random_azks_element()],
                     direction: Direction::Right,
                 }],
             },
@@ -205,40 +205,40 @@ fn test_convert_history_proof() {
         let mut rng = thread_rng();
         crate::UpdateProof {
             epoch: rng.gen(),
-            plaintext_value: crate::AkdValue(random_hash().to_vec()),
+            value: crate::AkdValue(random_hash().to_vec()),
             version: rng.gen(),
             existence_vrf_proof: random_hash().to_vec(),
-            existence_at_ep: crate::MembershipProof {
+            existence_proof: crate::MembershipProof {
                 label: random_label(),
                 hash_val: random_hash(),
-                layer_proofs: vec![crate::LayerProof {
+                sibling_proofs: vec![crate::SiblingProof {
                     label: random_label(),
-                    siblings: [random_node()],
+                    siblings: [random_azks_element()],
                     direction: Direction::Right,
                 }],
             },
             previous_version_vrf_proof: Some(random_hash().to_vec()),
-            previous_version_stale_at_ep: Some(crate::MembershipProof {
+            previous_version_proof: Some(crate::MembershipProof {
                 label: random_label(),
                 hash_val: random_hash(),
-                layer_proofs: vec![crate::LayerProof {
+                sibling_proofs: vec![crate::SiblingProof {
                     label: random_label(),
-                    siblings: [random_node()],
+                    siblings: [random_azks_element()],
                     direction: Direction::Right,
                 }],
             }),
-            commitment_proof: random_hash().to_vec(),
+            commitment_nonce: random_hash().to_vec(),
         }
     }
 
     let original = crate::HistoryProof {
         update_proofs: vec![upd_proof(), upd_proof(), upd_proof()],
-        next_few_vrf_proofs: vec![
+        until_marker_vrf_proofs: vec![
             random_hash().to_vec(),
             random_hash().to_vec(),
             random_hash().to_vec(),
         ],
-        non_existence_of_next_few: vec![
+        non_existence_until_marker_proofs: vec![
             non_membership_proof(),
             non_membership_proof(),
             non_membership_proof(),
@@ -248,7 +248,7 @@ fn test_convert_history_proof() {
             random_hash().to_vec(),
             random_hash().to_vec(),
         ],
-        non_existence_of_future_markers: vec![
+        non_existence_of_future_marker_proofs: vec![
             non_membership_proof(),
             non_membership_proof(),
             non_membership_proof(),
@@ -261,14 +261,18 @@ fn test_convert_history_proof() {
 
 #[test]
 fn test_convert_single_append_only_proof() {
-    let inserted = [random_node(), random_node(), random_node()];
+    let inserted = [
+        random_azks_element(),
+        random_azks_element(),
+        random_azks_element(),
+    ];
     let unchanged_nodes = [
-        random_node(),
-        random_node(),
-        random_node(),
-        random_node(),
-        random_node(),
-        random_node(),
+        random_azks_element(),
+        random_azks_element(),
+        random_azks_element(),
+        random_azks_element(),
+        random_azks_element(),
+        random_azks_element(),
     ];
     let original = crate::SingleAppendOnlyProof {
         inserted: inserted.to_vec(),

--- a/akd_core/src/utils.rs
+++ b/akd_core/src/utils.rs
@@ -15,8 +15,9 @@ use alloc::vec::Vec;
 #[cfg(feature = "rand")]
 use rand::{distributions::Alphanumeric, CryptoRng, Rng};
 
-/// Retrieve the marker version
-pub fn get_marker_version(version: u64) -> u64 {
+/// Retrieve log_2 of the marker version, referring to the exponent
+/// of the largest power of two that is at most the input version
+pub fn get_marker_version_log2(version: u64) -> u64 {
     64 - (version.leading_zeros() as u64) - 1
 }
 

--- a/akd_core/src/verify/base.rs
+++ b/akd_core/src/verify/base.rs
@@ -28,11 +28,11 @@ pub fn verify_membership(
 ) -> Result<(), VerificationError> {
     let mut current_hash = merge(&[proof.hash_val, proof.label.hash()]);
 
-    for parent in proof.layer_proofs.iter().rev() {
+    for parent in proof.sibling_proofs.iter().rev() {
         let hashes = parent
             .siblings
             .iter()
-            .map(|s| merge(&[s.hash, s.label.hash()]))
+            .map(|s| merge(&[s.value, s.label.hash()]))
             .collect();
         current_hash = build_and_hash_layer(hashes, parent.direction, current_hash, parent.label)?;
     }
@@ -57,12 +57,12 @@ pub fn verify_nonmembership(
     let mut lcp_real = proof.longest_prefix_children[0].label;
 
     let child_hash_left = merge(&[
-        proof.longest_prefix_children[0].hash,
+        proof.longest_prefix_children[0].value,
         proof.longest_prefix_children[0].label.hash(),
     ]);
 
     let child_hash_right = merge(&[
-        proof.longest_prefix_children[1].hash,
+        proof.longest_prefix_children[1].value,
         proof.longest_prefix_children[1].label.hash(),
     ]);
 

--- a/akd_core/src/verify/lookup.rs
+++ b/akd_core/src/verify/lookup.rs
@@ -25,14 +25,14 @@ pub fn lookup_verify(
 ) -> Result<VerifyResult, VerificationError> {
     let version = proof.version;
 
-    let marker_version = 1 << crate::utils::get_marker_version(version);
+    let marker_version = 1 << crate::utils::get_marker_version_log2(version);
     let existence_proof = proof.existence_proof;
     let marker_proof = proof.marker_proof;
     let freshness_proof = proof.freshness_proof;
 
     let fresh_label = existence_proof.label;
 
-    if hash_leaf_with_value(&proof.plaintext_value, proof.epoch, &proof.commitment_proof)
+    if hash_leaf_with_value(&proof.value, proof.epoch, &proof.commitment_nonce)
         != existence_proof.hash_val
     {
         return Err(VerificationError::LookupProof(
@@ -77,6 +77,6 @@ pub fn lookup_verify(
     Ok(VerifyResult {
         epoch: proof.epoch,
         version: proof.version,
-        value: proof.plaintext_value,
+        value: proof.value,
     })
 }

--- a/akd_mysql/src/mysql.rs
+++ b/akd_mysql/src/mysql.rs
@@ -905,7 +905,7 @@ impl Database for AsyncMySqlDatabase {
                                     label_val,
                                     label_len: node_label_len,
                                 },
-                                plaintext_val: AkdValue(data),
+                                value: AkdValue(data),
                                 username: AkdLabel(username),
                             });
                         }
@@ -995,7 +995,7 @@ impl Database for AsyncMySqlDatabase {
                                     label_val,
                                     label_len: node_label_len,
                                 },
-                                plaintext_val: AkdValue(data),
+                                value: AkdValue(data),
                                 username: AkdLabel(username),
                             });
                         }

--- a/akd_mysql/src/mysql_storables.rs
+++ b/akd_mysql/src/mysql_storables.rs
@@ -149,7 +149,7 @@ impl MySqlStorable for DbRecord {
                 "p_hash" => node.previous_node.clone().map(|a| a.hash),
             }),
             DbRecord::ValueState(state) => Some(
-                params! { "username" => state.get_id().0, "epoch" => state.epoch, "version" => state.version, "node_label_len" => state.label.label_len, "node_label_val" => state.label.label_val, "data" => state.plaintext_val.0.clone() },
+                params! { "username" => state.get_id().0, "epoch" => state.epoch, "version" => state.version, "node_label_len" => state.label.label_len, "node_label_val" => state.label.label_val, "data" => state.value.0.clone() },
             ),
         }
     }
@@ -377,10 +377,7 @@ impl MySqlStorable for DbRecord {
                         format!("node_label_val{}", idx),
                         Value::from(state.label.label_val),
                     ),
-                    (
-                        format!("data{}", idx),
-                        Value::from(state.plaintext_val.0.clone()),
-                    ),
+                    (format!("data{}", idx), Value::from(state.value.0.clone())),
                 ]),
             })
             .into_iter()

--- a/akd_test_tools/src/fixture_generator/examples/test.yaml
+++ b/akd_test_tools/src/fixture_generator/examples/test.yaml
@@ -22,7 +22,7 @@ args:
     - 10
   out: src/fixture_generator/examples/test.yaml
   no_generated_updates: false
-version: 0.8.2
+version: 0.8.6
 
 # State - Epoch 9
 ---
@@ -30,22 +30,210 @@ epoch: 9
 records:
   - TreeNode:
       label:
-        label_val: 45789452B4B106A5990C2B07CC2BD5B37F6B9859DF7738EEA6FF39CEAA2132A1
+        label_val: 40B7654182ACF470672602DCE7186CEA1DB59738D7C9F1D607A9B24C362BE6C0
         label_len: 256
       latest_node:
         label:
-          label_val: 45789452B4B106A5990C2B07CC2BD5B37F6B9859DF7738EEA6FF39CEAA2132A1
+          label_val: 40B7654182ACF470672602DCE7186CEA1DB59738D7C9F1D607A9B24C362BE6C0
           label_len: 256
-        last_epoch: 8
-        min_descendant_epoch: 8
+        last_epoch: 1
+        min_descendant_epoch: 1
         parent:
           label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 6
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: D46E3C909F32721265EF6071FCE64DCA908A62F3F71ABD67F439A47921A9FC46
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 2
+      latest_node:
+        label:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        last_epoch: 7
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        right_child:
+          label_val: 398E7F16B6562B76B5A9E5B1F9B584263DA97CA6F4D06220A0EF2C2F1A95AB12
+          label_len: 256
+        hash: A0318F4B4DEB30690D39EB391FFF9A8499CDA168EDCED649A7DF43162D54C23D
+      previous_node:
+        label:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        last_epoch: 1
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: 06DEEEE0508C6152127EEBA6B13C7EF8E78DD54126A36B27E6AA1D7C8AF297DE
+          label_len: 256
+        right_child:
+          label_val: 398E7F16B6562B76B5A9E5B1F9B584263DA97CA6F4D06220A0EF2C2F1A95AB12
+          label_len: 256
+        hash: 35507B39883CE485CF2FEA949FE4805508ABC9C5D82C02A74B97886E44421125
+  - TreeNode:
+      label:
+        label_val: "7800000000000000000000000000000000000000000000000000000000000000"
+        label_len: 5
+      latest_node:
+        label:
+          label_val: "7800000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        last_epoch: 3
+        min_descendant_epoch: 2
+        parent:
+          label_val: "7000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        node_type: Interior
+        left_child:
+          label_val: 7948F1797F2C5BDE543241EDD4F6D826AAA9F65331493ED8D6D96BFE6BC9507C
+          label_len: 256
+        right_child:
+          label_val: 7EC32D61A61F3D8C53F1B3F312F3AE60E153AB552FC46E94091F89C35A0E1341
+          label_len: 256
+        hash: C4D95421B1B98792217BD9C141F9A4D8CF6CE172704803A744FB749981657B4C
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: E6B42CD9ABDFBE613158800BF70011C56F9D17F001BBD0C7CA0EA900FD4845DF
+        label_len: 256
+      latest_node:
+        label:
+          label_val: E6B42CD9ABDFBE613158800BF70011C56F9D17F001BBD0C7CA0EA900FD4845DF
+          label_len: 256
+        last_epoch: 6
+        min_descendant_epoch: 6
+        parent:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: FCE19AB15447C3AAC5C3F34294CD6D7B93C44136ABA76FDDE2692E0273086B1C
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 7948F1797F2C5BDE543241EDD4F6D826AAA9F65331493ED8D6D96BFE6BC9507C
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 7948F1797F2C5BDE543241EDD4F6D826AAA9F65331493ED8D6D96BFE6BC9507C
+          label_len: 256
+        last_epoch: 2
+        min_descendant_epoch: 2
+        parent:
+          label_val: "7800000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: E0D68F634ED5C06DAB0EA8DF51AC4B4182AB0DEC2DC11C0821F1C4E491525196
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: C7BAF6ABCDCC44429E4FD296B3E506F3BBC9BAE0CCCAF3D51C052FD3EA12A643
+        label_len: 256
+      latest_node:
+        label:
+          label_val: C7BAF6ABCDCC44429E4FD296B3E506F3BBC9BAE0CCCAF3D51C052FD3EA12A643
+          label_len: 256
+        last_epoch: 2
+        min_descendant_epoch: 2
+        parent:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
           label_len: 4
         node_type: Leaf
         left_child: ~
         right_child: ~
-        hash: 91333870F8E36C126D745D2213982DABA93D05FFA6A789A3E5D352A06E0E9802
+        hash: FDB008ED88BDE9A12D86608DC80201AFB31C5EF9182B3062CA0CFD1E93E3FB1A
       previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 97B2F1F86164C236771A8CC90D192CD7D99A3016C5A5C1D912EAD392BC94AE20
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 97B2F1F86164C236771A8CC90D192CD7D99A3016C5A5C1D912EAD392BC94AE20
+          label_len: 256
+        last_epoch: 5
+        min_descendant_epoch: 5
+        parent:
+          label_val: "9000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 16705337F7867CEF5D8CB2D48D274E31EBB0C976EF40BDCF23C44F995F319909
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: E963B4F8460FFD1F7D93D4DE499B11AAC91030B2AD59EC45AE63C4479A45A133
+        label_len: 256
+      latest_node:
+        label:
+          label_val: E963B4F8460FFD1F7D93D4DE499B11AAC91030B2AD59EC45AE63C4479A45A133
+          label_len: 256
+        last_epoch: 5
+        min_descendant_epoch: 5
+        parent:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 79EE6AD0FF9BD73A07986F40011FD3759E4C91FCD47D6F06E35C245A1F14CFB9
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: E000000000000000000000000000000000000000000000000000000000000000
+        label_len: 4
+      latest_node:
+        label:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        last_epoch: 6
+        min_descendant_epoch: 4
+        parent:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        node_type: Interior
+        left_child:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 5
+        right_child:
+          label_val: E963B4F8460FFD1F7D93D4DE499B11AAC91030B2AD59EC45AE63C4479A45A133
+          label_len: 256
+        hash: 8084B8304AEECE6920B40F935247662C53450C38F458F70E15117F522A0056AD
+      previous_node:
+        label:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        last_epoch: 5
+        min_descendant_epoch: 4
+        parent:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        node_type: Interior
+        left_child:
+          label_val: E1E2366C30A2E8246783077E6AD13599563448038C78C0B9E492AC365614DEB7
+          label_len: 256
+        right_child:
+          label_val: E963B4F8460FFD1F7D93D4DE499B11AAC91030B2AD59EC45AE63C4479A45A133
+          label_len: 256
+        hash: C020D10B09DC6551292B9A4C4FEA692238EF07132D5311F3AFF68740263EBF08
   - TreeNode:
       label:
         label_val: "0000000000000000000000000000000000000000000000000000000000000000"
@@ -54,23 +242,6 @@ records:
         label:
           label_val: "0000000000000000000000000000000000000000000000000000000000000000"
           label_len: 0
-        last_epoch: 8
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 0
-        node_type: Root
-        left_child:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        right_child:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        hash: 0FFA62E6F773C87A007B0951717F0561E1D24B650F02EDEB29116ACEB33D9881
-      previous_node:
-        label:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 0
         last_epoch: 7
         min_descendant_epoch: 1
         parent:
@@ -83,311 +254,311 @@ records:
         right_child:
           label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 1
-        hash: A1B48E00088A713D56DB52395EB49F4FC96B76309CD73B9466F09188C3037177
-  - TreeNode:
-      label:
-        label_val: FFF787AFEAAD6597325AED191C7A854D2800F1ABD8C141AB42F06DED3F3C67D2
-        label_len: 256
-      latest_node:
-        label:
-          label_val: FFF787AFEAAD6597325AED191C7A854D2800F1ABD8C141AB42F06DED3F3C67D2
-          label_len: 256
-        last_epoch: 3
-        min_descendant_epoch: 3
-        parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: A0A1157A3AB3AA69FCD5801DB235D9FB497DFBA9A132808B03C6973CF6AB7785
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: BC00000000000000000000000000000000000000000000000000000000000000
-        label_len: 7
-      latest_node:
-        label:
-          label_val: BC00000000000000000000000000000000000000000000000000000000000000
-          label_len: 7
-        last_epoch: 5
-        min_descendant_epoch: 1
-        parent:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        node_type: Interior
-        left_child:
-          label_val: BC64211486279C25347A354E1BA6030EF7F37728A650F9930D2360356DA87901
-          label_len: 256
-        right_child:
-          label_val: BDBB810BEC5125B8B60493ECFC875A6FC73C9F90185988DED0418751031FC833
-          label_len: 256
-        hash: D080CBC9859CA85B928B8759C8DC851F29CB53E9EA743DFC49B03D29E549AB93
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: C000000000000000000000000000000000000000000000000000000000000000
-        label_len: 2
-      latest_node:
-        label:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        last_epoch: 8
-        min_descendant_epoch: 2
-        parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        right_child:
-          label_val: FFF787AFEAAD6597325AED191C7A854D2800F1ABD8C141AB42F06DED3F3C67D2
-          label_len: 256
-        hash: A5E7345C592FEF7684D32AF8CF835BBBD5C81D1D5C44951314841FD695D19576
+        hash: 0B7F32D70650E5113548BB6EA7464A48B3C6EB847421B148E0910E95FCB933FC
       previous_node:
         label:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        last_epoch: 3
-        min_descendant_epoch: 2
-        parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        right_child:
-          label_val: FFF787AFEAAD6597325AED191C7A854D2800F1ABD8C141AB42F06DED3F3C67D2
-          label_len: 256
-        hash: 5D013E217917C6C45180DE797A9E6517C3D5BE630BABA2C91979634BA5722F0A
-  - TreeNode:
-      label:
-        label_val: A029FCA21E0590E42E7BCBCA972AA1D3B732E6EE60A66FE92CE4FC0E1B871AA5
-        label_len: 256
-      latest_node:
-        label:
-          label_val: A029FCA21E0590E42E7BCBCA972AA1D3B732E6EE60A66FE92CE4FC0E1B871AA5
-          label_len: 256
-        last_epoch: 7
-        min_descendant_epoch: 7
-        parent:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 7
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 2A21F859CDA67E1CE949D26C02FB96E53130CC2651E5E870ED2295981B9DEA28
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 1
-      latest_node:
-        label:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        last_epoch: 8
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 0
+        last_epoch: 6
         min_descendant_epoch: 1
         parent:
           label_val: "0000000000000000000000000000000000000000000000000000000000000000"
           label_len: 0
-        node_type: Interior
+        node_type: Root
         left_child:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
         right_child:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        hash: 6220D51E9A01370B70D8001F1E17E84E987799C0FDBCBF43BEA259A76DF46B5D
-      previous_node:
-        label:
           label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 1
-        last_epoch: 7
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 0
-        node_type: Interior
-        left_child:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        right_child:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        hash: 898C614BFEEA925A0903BE1F1ACB811A6D764C93EF88670BEB41C5F5B01E2252
+        hash: E61E54194BCC3AC7476DAF7AF7875FEF93C5B05590BF247A9C0ABDA5D649E0B3
   - TreeNode:
       label:
-        label_val: 4A14CFF125F7D143C61AD0ADF29FF986A2AEAC35949F3A945E5553D8DBA16522
+        label_val: 74F6AB77F795C02E81A82D318C73EEF444C184E8A6D994E0F4B64F91553351DA
         label_len: 256
       latest_node:
         label:
-          label_val: 4A14CFF125F7D143C61AD0ADF29FF986A2AEAC35949F3A945E5553D8DBA16522
+          label_val: 74F6AB77F795C02E81A82D318C73EEF444C184E8A6D994E0F4B64F91553351DA
           label_len: 256
-        last_epoch: 2
-        min_descendant_epoch: 2
+        last_epoch: 6
+        min_descendant_epoch: 6
         parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_val: "7000000000000000000000000000000000000000000000000000000000000000"
           label_len: 4
         node_type: Leaf
         left_child: ~
         right_child: ~
-        hash: A7747125CDADCF6D82F0AF8B16D228FE0CD6309AB2E3297803553E430C8A6A3A
+        hash: CDE1E79EFC56AAF9FF7774912836B5A32E6C145B5AA0D53303ADB9D37617024B
       previous_node: ~
   - TreeNode:
       label:
-        label_val: A7D256522785EA6C704252815543BC1070EE225740FE572EAF34596141922631
-        label_len: 256
-      latest_node:
-        label:
-          label_val: A7D256522785EA6C704252815543BC1070EE225740FE572EAF34596141922631
-          label_len: 256
-        last_epoch: 3
-        min_descendant_epoch: 3
-        parent:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 5
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 97BA35C108C6A5746703C16C48BCA973C74A642F6B8BA7EEF13CD4D30476773B
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: C3532C2564360056BE35E0D0498A372A1D6D0B296B34E26CD6FDD58E7E945921
-        label_len: 256
-      latest_node:
-        label:
-          label_val: C3532C2564360056BE35E0D0498A372A1D6D0B296B34E26CD6FDD58E7E945921
-          label_len: 256
-        last_epoch: 8
-        min_descendant_epoch: 8
-        parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 5
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: DF35FB0227096C62BEF6324132ED5FD9101F30BF0280C6738F0B2B62B8BF9FB7
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+        label_val: "0000000000000000000000000000000000000000000000000000000000000000"
         label_len: 3
       latest_node:
         label:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
           label_len: 3
-        last_epoch: 8
-        min_descendant_epoch: 2
+        last_epoch: 7
+        min_descendant_epoch: 1
         parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
           label_len: 2
         node_type: Interior
         left_child:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        right_child:
-          label_val: "5620000000000000000000000000000000000000000000000000000000000000"
-          label_len: 12
-        hash: 2A9D53D189D4638FDD5F046FE5051269D7BB0E23C571E44238B07813611442F0
-      previous_node:
-        label:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        last_epoch: 5
-        min_descendant_epoch: 2
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: 4A14CFF125F7D143C61AD0ADF29FF986A2AEAC35949F3A945E5553D8DBA16522
+          label_val: 06DEEEE0508C6152127EEBA6B13C7EF8E78DD54126A36B27E6AA1D7C8AF297DE
           label_len: 256
         right_child:
-          label_val: "5620000000000000000000000000000000000000000000000000000000000000"
-          label_len: 12
-        hash: 37941036C27A665B42BD3F556138417389D63835E164EE098A89B67340148B92
+          label_val: 1B3197016C32205D6B4768770B19A563B0E204CA0F291071A4B5690FDE5D5E9F
+          label_len: 256
+        hash: 13001B6E41A82103B6DD1CA5706D098228EEF8F8882F58EF605B76A3CB003027
+      previous_node: ~
   - TreeNode:
       label:
-        label_val: BC64211486279C25347A354E1BA6030EF7F37728A650F9930D2360356DA87901
+        label_val: AEBC771586C4265DAB54EBC4629AB9BFD382BE30FDC67FDBA7FB067E3B51D8B7
         label_len: 256
       latest_node:
         label:
-          label_val: BC64211486279C25347A354E1BA6030EF7F37728A650F9930D2360356DA87901
+          label_val: AEBC771586C4265DAB54EBC4629AB9BFD382BE30FDC67FDBA7FB067E3B51D8B7
+          label_len: 256
+        last_epoch: 3
+        min_descendant_epoch: 3
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: E01C1A1008385C4E202CFBF866C5476E442A21393D6C7F76597603A58B43CF0A
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "9000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 4
+      latest_node:
+        label:
+          label_val: "9000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        last_epoch: 5
+        min_descendant_epoch: 5
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        node_type: Interior
+        left_child:
+          label_val: 97B2F1F86164C236771A8CC90D192CD7D99A3016C5A5C1D912EAD392BC94AE20
+          label_len: 256
+        right_child:
+          label_val: 9EC4B36008568F3A571EE4BDE03E76611E51BBE7D7C6D2777CCA71B0BDF31E7F
+          label_len: 256
+        hash: EEF38B64D48863F92ADDF92317B3E56C1D29BD59A39EC15D71288238710863D9
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 398E7F16B6562B76B5A9E5B1F9B584263DA97CA6F4D06220A0EF2C2F1A95AB12
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 398E7F16B6562B76B5A9E5B1F9B584263DA97CA6F4D06220A0EF2C2F1A95AB12
           label_len: 256
         last_epoch: 1
         min_descendant_epoch: 1
         parent:
-          label_val: BC00000000000000000000000000000000000000000000000000000000000000
-          label_len: 7
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
         node_type: Leaf
         left_child: ~
         right_child: ~
-        hash: 0C46AF311EBE9FABB6DF86B89F2900DC218C5B07A08E57ED9083F1B9FCD8C03F
+        hash: 2DC2E4EDB446FFC7683FE23D5E4E9ABE78373B19FB1BE5B2C337E54CE1D810EF
       previous_node: ~
   - TreeNode:
       label:
-        label_val: A000000000000000000000000000000000000000000000000000000000000000
-        label_len: 7
+        label_val: 4DF787D51E8E649F935F4DBBDEF0AE7E79C12A4ADBB250DEEAD4FE9E8D983756
+        label_len: 256
       latest_node:
         label:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 7
-        last_epoch: 7
-        min_descendant_epoch: 2
+          label_val: 4DF787D51E8E649F935F4DBBDEF0AE7E79C12A4ADBB250DEEAD4FE9E8D983756
+          label_len: 256
+        last_epoch: 1
+        min_descendant_epoch: 1
         parent:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: B2B00BD1FD3F45C450E492A634F305A43D5EE9A665834A49A1AD1BC81E3D0E57
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 7EC32D61A61F3D8C53F1B3F312F3AE60E153AB552FC46E94091F89C35A0E1341
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 7EC32D61A61F3D8C53F1B3F312F3AE60E153AB552FC46E94091F89C35A0E1341
+          label_len: 256
+        last_epoch: 3
+        min_descendant_epoch: 3
+        parent:
+          label_val: "7800000000000000000000000000000000000000000000000000000000000000"
           label_len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 86C886D0733EDEEAF5E5C9FC8B7A26369AAB1A91CC27593E0881A7487D69FA29
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 2
+      latest_node:
+        label:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        last_epoch: 5
+        min_descendant_epoch: 3
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
         node_type: Interior
         left_child:
-          label_val: A029FCA21E0590E42E7BCBCA972AA1D3B732E6EE60A66FE92CE4FC0E1B871AA5
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        right_child:
+          label_val: AEBC771586C4265DAB54EBC4629AB9BFD382BE30FDC67FDBA7FB067E3B51D8B7
+          label_len: 256
+        hash: 57F5F89B1B02EE45700F1CE1C7FF3C071EBA6F456E06E35BE57C6BBF9297B144
+      previous_node:
+        label:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        last_epoch: 3
+        min_descendant_epoch: 3
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: 8E2DF8905DE002AD29677FEF43C369E0D0504F9A7E3CB3F221E65E1AA9554A8B
           label_len: 256
         right_child:
-          label_val: A1CF74F89155EA542C417BD891E0403080ED2124486D7F8A415F468383AB2289
+          label_val: AEBC771586C4265DAB54EBC4629AB9BFD382BE30FDC67FDBA7FB067E3B51D8B7
           label_len: 256
-        hash: 945E6E7A5990D7992EB04420165607F5B4B71FDE6FB72C11D7B230A0CC9F285B
-      previous_node: ~
-  - Azks:
-      latest_epoch: 8
-      num_nodes: 33
+        hash: A8B214D604FF4F2CB6A6764BBD9784D0CC3960A4A6FB634C800C2BBF7388A4E2
   - TreeNode:
       label:
-        label_val: BDBB810BEC5125B8B60493ECFC875A6FC73C9F90185988DED0418751031FC833
+        label_val: F30D287863718B9C41B6318D293C68D6B2D7F10A106EECA37A4411A41759AAD3
         label_len: 256
       latest_node:
         label:
-          label_val: BDBB810BEC5125B8B60493ECFC875A6FC73C9F90185988DED0418751031FC833
+          label_val: F30D287863718B9C41B6318D293C68D6B2D7F10A106EECA37A4411A41759AAD3
           label_len: 256
-        last_epoch: 5
-        min_descendant_epoch: 5
+        last_epoch: 2
+        min_descendant_epoch: 2
         parent:
-          label_val: BC00000000000000000000000000000000000000000000000000000000000000
-          label_len: 7
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 0344848820715FBA584363550A7985E90F0BE4ED78DE5FA68AAB644ADD94ECBC
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 262590AAF0A16AA59EB0C34385AD5861480E574847393C5141A125B219C46364
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 262590AAF0A16AA59EB0C34385AD5861480E574847393C5141A125B219C46364
-          label_len: 256
-        last_epoch: 4
-        min_descendant_epoch: 4
-        parent:
-          label_val: "2000000000000000000000000000000000000000000000000000000000000000"
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
           label_len: 3
         node_type: Leaf
         left_child: ~
         right_child: ~
-        hash: 35247A8BA087218C901494DB68BB5D84177A0335DAF37DCF2DFBC7F4C055AE01
+        hash: 9CE6DAF35CB1EE1BFE3EA244FCFB8AEA9DA36E43F0EC803694122E989576AD55
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 57BDA197268698B8CBB74D80A5510AC869EEB21D80810BAD3FEABD26F258B52B
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 57BDA197268698B8CBB74D80A5510AC869EEB21D80810BAD3FEABD26F258B52B
+          label_len: 256
+        last_epoch: 6
+        min_descendant_epoch: 6
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: C01B322B0EFD793157C858ED5FB761C0A487A7A303EF2394FBD151E93B18FCB0
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 06DEEEE0508C6152127EEBA6B13C7EF8E78DD54126A36B27E6AA1D7C8AF297DE
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 06DEEEE0508C6152127EEBA6B13C7EF8E78DD54126A36B27E6AA1D7C8AF297DE
+          label_len: 256
+        last_epoch: 1
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: A9873E9802E830CB3F25F0CE69405F7C891CE40EB301AE1658B3D657A0E72A5E
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: E000000000000000000000000000000000000000000000000000000000000000
+        label_len: 5
+      latest_node:
+        label:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 5
+        last_epoch: 6
+        min_descendant_epoch: 4
+        parent:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        node_type: Interior
+        left_child:
+          label_val: E1E2366C30A2E8246783077E6AD13599563448038C78C0B9E492AC365614DEB7
+          label_len: 256
+        right_child:
+          label_val: E6B42CD9ABDFBE613158800BF70011C56F9D17F001BBD0C7CA0EA900FD4845DF
+          label_len: 256
+        hash: 307FC535938EA908B3DF094277EE8E1ED5813FBA5B9D0D1615C7567B5E19304F
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: E1E2366C30A2E8246783077E6AD13599563448038C78C0B9E492AC365614DEB7
+        label_len: 256
+      latest_node:
+        label:
+          label_val: E1E2366C30A2E8246783077E6AD13599563448038C78C0B9E492AC365614DEB7
+          label_len: 256
+        last_epoch: 4
+        min_descendant_epoch: 4
+        parent:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 01C5F16CC625193DEA287DAE19DB5EE2686C8D15DB3B4843DEC49EB0F62E4FBE
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "6000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 3
+      latest_node:
+        label:
+          label_val: "6000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        last_epoch: 6
+        min_descendant_epoch: 2
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: 6AB612EBC1965816ECCDD704B2D9AF25269ABC0E0D02990FED0B2BCE6C06C389
+          label_len: 256
+        right_child:
+          label_val: "7000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        hash: BFB9BAD32CCC7D57FC347D0B30E15B31233B4F72204DB357FE07625AC4CAAC74
       previous_node: ~
   - TreeNode:
       label:
@@ -397,115 +568,252 @@ records:
         label:
           label_val: "4000000000000000000000000000000000000000000000000000000000000000"
           label_len: 4
-        last_epoch: 8
-        min_descendant_epoch: 2
+        last_epoch: 5
+        min_descendant_epoch: 1
         parent:
           label_val: "4000000000000000000000000000000000000000000000000000000000000000"
           label_len: 3
         node_type: Interior
         left_child:
-          label_val: 45789452B4B106A5990C2B07CC2BD5B37F6B9859DF7738EEA6FF39CEAA2132A1
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 6
+        right_child:
+          label_val: 4DF787D51E8E649F935F4DBBDEF0AE7E79C12A4ADBB250DEEAD4FE9E8D983756
+          label_len: 256
+        hash: 9C8BE6689D023806C211BE990A8E4DF848AC9D4AC695A170F283C999CF8088F6
+      previous_node:
+        label:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        last_epoch: 1
+        min_descendant_epoch: 1
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: 40B7654182ACF470672602DCE7186CEA1DB59738D7C9F1D607A9B24C362BE6C0
           label_len: 256
         right_child:
-          label_val: 4A14CFF125F7D143C61AD0ADF29FF986A2AEAC35949F3A945E5553D8DBA16522
+          label_val: 4DF787D51E8E649F935F4DBBDEF0AE7E79C12A4ADBB250DEEAD4FE9E8D983756
           label_len: 256
-        hash: A135DFB278062C48F42A733D176FFB6CDB193EC404518709F016E91F24B69702
-      previous_node: ~
+        hash: A013AAEBF9C1B54B8513B90A62953DC2A0776457C71B84E7665078FF128D8D03
   - TreeNode:
       label:
-        label_val: "5620000000000000000000000000000000000000000000000000000000000000"
-        label_len: 12
+        label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 1
       latest_node:
         label:
-          label_val: "5620000000000000000000000000000000000000000000000000000000000000"
-          label_len: 12
-        last_epoch: 5
-        min_descendant_epoch: 3
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        last_epoch: 7
+        min_descendant_epoch: 1
         parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 0
         node_type: Interior
         left_child:
-          label_val: 5624A58EE465FD68E2BD187BAC7109E3EC53F2645F99618EE447F03760D49750
-          label_len: 256
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
         right_child:
-          label_val: 562AC9D00F07A030298F9CE48DD0ACE19A1C1F1DC360AF8480FFC70A9373845A
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        hash: 38A7EB89FDBBB2A2DB4E8E120C79F729A9D0AE6515B7E26AF4C5B937D755DC7A
+      previous_node:
+        label:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        last_epoch: 6
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 0
+        node_type: Interior
+        left_child:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        right_child:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        hash: 745681934FD31751D6C7226970C82AD034E44359515561FD2D78CDDF5EE4C6E9
+  - Azks:
+      latest_epoch: 7
+      num_nodes: 41
+  - TreeNode:
+      label:
+        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 3
+      latest_node:
+        label:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        last_epoch: 6
+        min_descendant_epoch: 1
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        right_child:
+          label_val: 57BDA197268698B8CBB74D80A5510AC869EEB21D80810BAD3FEABD26F258B52B
           label_len: 256
-        hash: 4B2027CDC94B686B1B61DFFA957A95073330E23F290C8869DE2B7449FB736A43
+        hash: F16C3BA290E76296FA4F7E4702C2CB3CC4C726867C904D145B4D30232EB4AB2E
       previous_node: ~
   - TreeNode:
       label:
-        label_val: A1CF74F89155EA542C417BD891E0403080ED2124486D7F8A415F468383AB2289
+        label_val: CA3A8FB4749A2F7C6FC2C0BEEBD5D4270758E7A06D9D92D2928D1AFCB5E7F648
         label_len: 256
       latest_node:
         label:
-          label_val: A1CF74F89155EA542C417BD891E0403080ED2124486D7F8A415F468383AB2289
+          label_val: CA3A8FB4749A2F7C6FC2C0BEEBD5D4270758E7A06D9D92D2928D1AFCB5E7F648
           label_len: 256
         last_epoch: 2
         min_descendant_epoch: 2
         parent:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 7
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
         node_type: Leaf
         left_child: ~
         right_child: ~
-        hash: E1F60D50473A1AD2293391E0543A1015C717FB2B661E406BC9C8A61BBDBE5AA9
+        hash: 806BAC5DC57EBCEAFE9B6461B817415E1BDBB0E0FB8B5B6A7C66FBF36205591B
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: C000000000000000000000000000000000000000000000000000000000000000
+        label_len: 2
+      latest_node:
+        label:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 2
+        last_epoch: 6
+        min_descendant_epoch: 2
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        right_child:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        hash: 92D33A2244593647B3018A132C5175EA811D20E3C77A22514257F25FA6731B53
+      previous_node:
+        label:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 2
+        last_epoch: 5
+        min_descendant_epoch: 2
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        right_child:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        hash: CEE2BAFCBFD6600DE9DEAA86D402A1147581C7C35716AB098B4CEB6027F7C11D
+  - TreeNode:
+      label:
+        label_val: 426B148EEF56E37D269EFC61247411446CE289AA5D167BD32CCFEC877765FCB2
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 426B148EEF56E37D269EFC61247411446CE289AA5D167BD32CCFEC877765FCB2
+          label_len: 256
+        last_epoch: 5
+        min_descendant_epoch: 5
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 6
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 2F2A621AD1F7BCD1BA26EEE24CF076A0A88B6D4D77CDB4F06191C27A857F1629
       previous_node: ~
   - TreeNode:
       label:
         label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 2
+        label_len: 3
       latest_node:
         label:
           label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        last_epoch: 7
-        min_descendant_epoch: 1
-        parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: 9820B4017B5C29AC567B403361AF73E1BD7EC668A1E62557427F18066D0CBF7F
-          label_len: 256
-        right_child:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
           label_len: 3
-        hash: DE556607BACE40B761C58C2E34E46C242D7C654FFF4144B239697C44B3E09EEF
-      previous_node:
-        label:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
         last_epoch: 5
-        min_descendant_epoch: 1
+        min_descendant_epoch: 3
         parent:
           label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
+          label_len: 2
         node_type: Interior
         left_child:
-          label_val: 9820B4017B5C29AC567B403361AF73E1BD7EC668A1E62557427F18066D0CBF7F
+          label_val: 8E2DF8905DE002AD29677FEF43C369E0D0504F9A7E3CB3F221E65E1AA9554A8B
           label_len: 256
         right_child:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        hash: EAC034EEA7B30C3CE95C98174EB39437991E01E9D33569D4146C80D9942533C1
+          label_val: "9000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        hash: 149E9A9B04E072C0B682DFE0E6370F2E5E8CB9CBAB465E4A15D0F7DB555D21B0
+      previous_node: ~
   - TreeNode:
       label:
-        label_val: C4AED26C5A84EE6640D7C81F4ECE294C7ADBA6ED09D5E13C0E830EB18F3F45F0
+        label_val: 8E2DF8905DE002AD29677FEF43C369E0D0504F9A7E3CB3F221E65E1AA9554A8B
         label_len: 256
       latest_node:
         label:
-          label_val: C4AED26C5A84EE6640D7C81F4ECE294C7ADBA6ED09D5E13C0E830EB18F3F45F0
+          label_val: 8E2DF8905DE002AD29677FEF43C369E0D0504F9A7E3CB3F221E65E1AA9554A8B
           label_len: 256
         last_epoch: 3
         min_descendant_epoch: 3
         parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 5
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
         node_type: Leaf
         left_child: ~
         right_child: ~
-        hash: 083974703AFA5CDC8BA315E2FC5E313AD95BC4A8292BD1E73B970FA7FFDD78D3
+        hash: 795E3424A3DF236DCBAA461600BA4F0719974B638A2BC3DF0721626093B02818
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 6AB612EBC1965816ECCDD704B2D9AF25269ABC0E0D02990FED0B2BCE6C06C389
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 6AB612EBC1965816ECCDD704B2D9AF25269ABC0E0D02990FED0B2BCE6C06C389
+          label_len: 256
+        last_epoch: 6
+        min_descendant_epoch: 6
+        parent:
+          label_val: "6000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: FD5808558FD229CA27E68F61076ED0D9C37E8E50FAD97592ACCE5ED30CC51AB2
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 6
+      latest_node:
+        label:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 6
+        last_epoch: 5
+        min_descendant_epoch: 1
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        node_type: Interior
+        left_child:
+          label_val: 40B7654182ACF470672602DCE7186CEA1DB59738D7C9F1D607A9B24C362BE6C0
+          label_len: 256
+        right_child:
+          label_val: 426B148EEF56E37D269EFC61247411446CE289AA5D167BD32CCFEC877765FCB2
+          label_len: 256
+        hash: 6B3419C7C423D84C7B07EDE63A174BB163A67222C6A4FAF1E2C77527A7684F8A
       previous_node: ~
   - TreeNode:
       label:
@@ -515,8 +823,8 @@ records:
         label:
           label_val: "4000000000000000000000000000000000000000000000000000000000000000"
           label_len: 2
-        last_epoch: 8
-        min_descendant_epoch: 2
+        last_epoch: 6
+        min_descendant_epoch: 1
         parent:
           label_val: "0000000000000000000000000000000000000000000000000000000000000000"
           label_len: 1
@@ -525,202 +833,95 @@ records:
           label_val: "4000000000000000000000000000000000000000000000000000000000000000"
           label_len: 3
         right_child:
-          label_val: 696A5F91A39FC533619534BC2A084F2C305ED1F9E5915770BFC9BFD303B4121C
-          label_len: 256
-        hash: 2A8B5D0C04D0BB914AC4C2FFF348D6FA871BB20199402BFADEE11F31FA86B73E
+          label_val: "6000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        hash: A857119636BF4BDA061A5AF477DA9D05CFDA9BDCB164B42AC50E2AD68003D174
       previous_node:
         label:
           label_val: "4000000000000000000000000000000000000000000000000000000000000000"
           label_len: 2
+        last_epoch: 5
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        right_child:
+          label_val: "7800000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        hash: 9CF75C2B55AAC473E0C21B3FA587700F7F10B745B656AAB94227058FA3505FB8
+  - TreeNode:
+      label:
+        label_val: "7000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 4
+      latest_node:
+        label:
+          label_val: "7000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
         last_epoch: 6
         min_descendant_epoch: 2
         parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
+          label_val: "6000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
         node_type: Interior
         left_child:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        right_child:
-          label_val: 696A5F91A39FC533619534BC2A084F2C305ED1F9E5915770BFC9BFD303B4121C
+          label_val: 74F6AB77F795C02E81A82D318C73EEF444C184E8A6D994E0F4B64F91553351DA
           label_len: 256
-        hash: E9A9A8E1D9391657DA2BA15535E39C686E1DE6D77A805501445978ADBA30D492
-  - TreeNode:
-      label:
-        label_val: C000000000000000000000000000000000000000000000000000000000000000
-        label_len: 5
-      latest_node:
-        label:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
+        right_child:
+          label_val: "7800000000000000000000000000000000000000000000000000000000000000"
           label_len: 5
-        last_epoch: 8
-        min_descendant_epoch: 3
-        parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        node_type: Interior
-        left_child:
-          label_val: C3532C2564360056BE35E0D0498A372A1D6D0B296B34E26CD6FDD58E7E945921
-          label_len: 256
-        right_child:
-          label_val: C4AED26C5A84EE6640D7C81F4ECE294C7ADBA6ED09D5E13C0E830EB18F3F45F0
-          label_len: 256
-        hash: 9A87F247FAD6ABCF8EA684353600CEC4F826D70774AB75599983140D17F712D5
+        hash: 22C6EAF3539F43F0B6A493C3D6813FB06777C7365713E634645E8E8F166B2317
       previous_node: ~
   - TreeNode:
       label:
-        label_val: 9820B4017B5C29AC567B403361AF73E1BD7EC668A1E62557427F18066D0CBF7F
+        label_val: 9EC4B36008568F3A571EE4BDE03E76611E51BBE7D7C6D2777CCA71B0BDF31E7F
         label_len: 256
       latest_node:
         label:
-          label_val: 9820B4017B5C29AC567B403361AF73E1BD7EC668A1E62557427F18066D0CBF7F
+          label_val: 9EC4B36008568F3A571EE4BDE03E76611E51BBE7D7C6D2777CCA71B0BDF31E7F
           label_len: 256
+        last_epoch: 5
+        min_descendant_epoch: 5
+        parent:
+          label_val: "9000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: FD1EB17D43CAD8D453C2C8A38E00D9A00BAE17E0C00E4D19DA646D887E3A8DBB
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: C000000000000000000000000000000000000000000000000000000000000000
+        label_len: 4
+      latest_node:
+        label:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
         last_epoch: 2
         min_descendant_epoch: 2
         parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
           label_len: 2
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: E9C6A4D21D14AB5EF044183DE7BBE975C3ECAC907618EEFCDAA31A702DAC6D0D
+        node_type: Interior
+        left_child:
+          label_val: C7BAF6ABCDCC44429E4FD296B3E506F3BBC9BAE0CCCAF3D51C052FD3EA12A643
+          label_len: 256
+        right_child:
+          label_val: CA3A8FB4749A2F7C6FC2C0BEEBD5D4270758E7A06D9D92D2928D1AFCB5E7F648
+          label_len: 256
+        hash: AB87A500A9DA1FE84837DFEFC72529CAABE2A0EF2A2C693778D9DF54B172DF31
       previous_node: ~
   - TreeNode:
       label:
-        label_val: C000000000000000000000000000000000000000000000000000000000000000
-        label_len: 3
-      latest_node:
-        label:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        last_epoch: 8
-        min_descendant_epoch: 2
-        parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 5
-        right_child:
-          label_val: D67047C370958792923714F7F9E8F67A0BD6DD566DCF64B8B43EA1D285CDEF27
-          label_len: 256
-        hash: 91EB319EC26483C9479E0B85042F3DCF7D63307789D231518A1684B679153853
-      previous_node:
-        label:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        last_epoch: 3
-        min_descendant_epoch: 2
-        parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: C4AED26C5A84EE6640D7C81F4ECE294C7ADBA6ED09D5E13C0E830EB18F3F45F0
-          label_len: 256
-        right_child:
-          label_val: D67047C370958792923714F7F9E8F67A0BD6DD566DCF64B8B43EA1D285CDEF27
-          label_len: 256
-        hash: C7C5344620F367264008899FBFEB08C6A6CC34B1A2593B452FA0A4AD6408F131
-  - TreeNode:
-      label:
-        label_val: 5624A58EE465FD68E2BD187BAC7109E3EC53F2645F99618EE447F03760D49750
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 5624A58EE465FD68E2BD187BAC7109E3EC53F2645F99618EE447F03760D49750
-          label_len: 256
-        last_epoch: 5
-        min_descendant_epoch: 5
-        parent:
-          label_val: "5620000000000000000000000000000000000000000000000000000000000000"
-          label_len: 12
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 0E258B0275632E48B2BC369C4F11418E09CA594A140FEEE772489E70148A6E0F
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 3ACABED73828CEFC02CF6B2F6B524023749D243D6F5D46A147045649CFB9115C
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 3ACABED73828CEFC02CF6B2F6B524023749D243D6F5D46A147045649CFB9115C
-          label_len: 256
-        last_epoch: 5
-        min_descendant_epoch: 5
-        parent:
-          label_val: "2000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 382DEDBE2B4BB962D14CF2C18257BD2F24020CA7619120172389D2571F728FA1
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: A000000000000000000000000000000000000000000000000000000000000000
-        label_len: 3
-      latest_node:
-        label:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        last_epoch: 7
-        min_descendant_epoch: 1
-        parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 5
-        right_child:
-          label_val: BC00000000000000000000000000000000000000000000000000000000000000
-          label_len: 7
-        hash: 43EF361095C8F09953800B71DEEBBC94AEF1C6F15DEA739A7CDFB056C63BEAAE
-      previous_node:
-        label:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        last_epoch: 5
-        min_descendant_epoch: 1
-        parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 5
-        right_child:
-          label_val: BC00000000000000000000000000000000000000000000000000000000000000
-          label_len: 7
-        hash: 74FDF03A8EE8A6404634B5080289404BE489DDAB78807E291A2A34566895BBDB
-  - TreeNode:
-      label:
-        label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+        label_val: "8000000000000000000000000000000000000000000000000000000000000000"
         label_len: 1
       latest_node:
         label:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        last_epoch: 8
-        min_descendant_epoch: 2
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 0
-        node_type: Interior
-        left_child:
-          label_val: "2000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        right_child:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        hash: D34E706699FC477D4DE6A1B7A9C4689CD5BDE231B50873B8E42B0537CEA9E080
-      previous_node:
-        label:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 1
         last_epoch: 6
         min_descendant_epoch: 2
@@ -729,273 +930,264 @@ records:
           label_len: 0
         node_type: Interior
         left_child:
-          label_val: "2000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        right_child:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 2
-        hash: D3062EBD4134A758A1F9C5CA213C3E50D23202AC297A1A634D1E67250C06D3DB
-  - TreeNode:
-      label:
-        label_val: D67047C370958792923714F7F9E8F67A0BD6DD566DCF64B8B43EA1D285CDEF27
-        label_len: 256
-      latest_node:
+        right_child:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 2
+        hash: EA0B4997CD2435F434F46AC1D7B0AD4DC5860BB83EC6A10F8EB0463A950B5510
+      previous_node:
         label:
-          label_val: D67047C370958792923714F7F9E8F67A0BD6DD566DCF64B8B43EA1D285CDEF27
-          label_len: 256
-        last_epoch: 2
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        last_epoch: 5
         min_descendant_epoch: 2
         parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 0
+        node_type: Interior
+        left_child:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        right_child:
           label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 6E03127AFE3E84BE07F20F3A2819648D26BE281D53388700A044E5CD050A723C
-      previous_node: ~
+          label_len: 2
+        hash: 9CD58CF3FA36641084A1D114E82B94376C36BAB8CBE008787ED1AD3CC021350B
   - TreeNode:
       label:
-        label_val: "2000000000000000000000000000000000000000000000000000000000000000"
+        label_val: E000000000000000000000000000000000000000000000000000000000000000
         label_len: 3
       latest_node:
         label:
-          label_val: "2000000000000000000000000000000000000000000000000000000000000000"
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
           label_len: 3
-        last_epoch: 5
-        min_descendant_epoch: 4
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: 262590AAF0A16AA59EB0C34385AD5861480E574847393C5141A125B219C46364
-          label_len: 256
-        right_child:
-          label_val: 3ACABED73828CEFC02CF6B2F6B524023749D243D6F5D46A147045649CFB9115C
-          label_len: 256
-        hash: F5DE6EB21403DD6E329EE86E9D121B4BCF20DCE103A106F54B30843002F2DDC6
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: A000000000000000000000000000000000000000000000000000000000000000
-        label_len: 5
-      latest_node:
-        label:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 5
-        last_epoch: 7
+        last_epoch: 6
         min_descendant_epoch: 2
         parent:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 2
         node_type: Interior
         left_child:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 7
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
         right_child:
-          label_val: A7D256522785EA6C704252815543BC1070EE225740FE572EAF34596141922631
+          label_val: F30D287863718B9C41B6318D293C68D6B2D7F10A106EECA37A4411A41759AAD3
           label_len: 256
-        hash: 2DCFCD612B121357FAE09CA9E5AFB4B3660D8F29B4A429E3BCE59D4C8FB4D6A7
+        hash: FE55F5CC713923396B9C4B88CF1075D2CCB04270E7D0F8680EF2189850ABAC8F
       previous_node:
         label:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 5
-        last_epoch: 3
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        last_epoch: 5
         min_descendant_epoch: 2
         parent:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 2
         node_type: Interior
         left_child:
-          label_val: A1CF74F89155EA542C417BD891E0403080ED2124486D7F8A415F468383AB2289
-          label_len: 256
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
         right_child:
-          label_val: A7D256522785EA6C704252815543BC1070EE225740FE572EAF34596141922631
+          label_val: F30D287863718B9C41B6318D293C68D6B2D7F10A106EECA37A4411A41759AAD3
           label_len: 256
-        hash: 2C739CB97C2A75C278BFD5EDB143E566846663897A24F9F90082F4E692B11D3B
+        hash: 4BB78E7180A19BF15294290CE178B589532412A6C9528A44B6E21D53CBB142FC
   - TreeNode:
       label:
-        label_val: 696A5F91A39FC533619534BC2A084F2C305ED1F9E5915770BFC9BFD303B4121C
+        label_val: 1B3197016C32205D6B4768770B19A563B0E204CA0F291071A4B5690FDE5D5E9F
         label_len: 256
       latest_node:
         label:
-          label_val: 696A5F91A39FC533619534BC2A084F2C305ED1F9E5915770BFC9BFD303B4121C
+          label_val: 1B3197016C32205D6B4768770B19A563B0E204CA0F291071A4B5690FDE5D5E9F
           label_len: 256
-        last_epoch: 6
-        min_descendant_epoch: 6
+        last_epoch: 7
+        min_descendant_epoch: 7
         parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
         node_type: Leaf
         left_child: ~
         right_child: ~
-        hash: 256F50289AD3F58A206554BE44599EB6D5EC0755D78112DA9229F6B928040315
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 562AC9D00F07A030298F9CE48DD0ACE19A1C1F1DC360AF8480FFC70A9373845A
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 562AC9D00F07A030298F9CE48DD0ACE19A1C1F1DC360AF8480FFC70A9373845A
-          label_len: 256
-        last_epoch: 3
-        min_descendant_epoch: 3
-        parent:
-          label_val: "5620000000000000000000000000000000000000000000000000000000000000"
-          label_len: 12
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 53D076977493CDCFB6F28AEDFF691A8B395434E156BD7E7F591FE2175C7F4C88
+        hash: 6A8C04B3FB065A530FD6A1D8B4EDAE0A27864A92EF5F33FD8DB728DDA04D4082
       previous_node: ~
   - ValueState:
-      plaintext_val: 42344750444E534F4854376A45436D4A54767878744D4C65676F39324650746C
+      value: 334146627651746464545A4E4338326A353968706A744C4D4665356974717366
       version: 1
       label:
-        label_val: D67047C370958792923714F7F9E8F67A0BD6DD566DCF64B8B43EA1D285CDEF27
-        label_len: 256
-      epoch: 2
-      username: 55517664506A4730614A7A5157454751686A586B526876796248524B69794258
-  - ValueState:
-      plaintext_val: 49704C466B425841696557354D754A6A6C7A705879616C45756172724555536F
-      version: 1
-      label:
-        label_val: BDBB810BEC5125B8B60493ECFC875A6FC73C9F90185988DED0418751031FC833
-        label_len: 256
-      epoch: 5
-      username: 586D717057716B557632527357385731557A66593941626A704E644B31673450
-  - ValueState:
-      plaintext_val: 4D534B757678613669634B7033314968514E65576E414E6A6A53506D326D4D4C
-      version: 1
-      label:
-        label_val: 696A5F91A39FC533619534BC2A084F2C305ED1F9E5915770BFC9BFD303B4121C
-        label_len: 256
-      epoch: 6
-      username: 7070726833424262555374446E585637726D5047363734494B5A47304D694F5A
-  - ValueState:
-      plaintext_val: 34774561314D3858566E525A456169777666395855454D4B6F365A6C50533270
-      version: 1
-      label:
-        label_val: A1CF74F89155EA542C417BD891E0403080ED2124486D7F8A415F468383AB2289
-        label_len: 256
-      epoch: 2
-      username: 726841445830786372526F4A687345706F534D51747933467470617A3546474F
-  - ValueState:
-      plaintext_val: 4761574D524C574D6C55537A424E674A52776148326E454C4C47413564673978
-      version: 1
-      label:
-        label_val: 262590AAF0A16AA59EB0C34385AD5861480E574847393C5141A125B219C46364
+        label_val: E1E2366C30A2E8246783077E6AD13599563448038C78C0B9E492AC365614DEB7
         label_len: 256
       epoch: 4
-      username: 545466663742364335306C786765544B4369474C4F6165464D44536844673441
+      username: 736C7959594437396856435531627164426668746167537163624259736E3130
   - ValueState:
-      plaintext_val: 6C697673455138444D667A7863736C467352576A4C3067476342304172774454
+      value: 745A517042743972666B50436F36734F6A54495A6872635A6A574D6247715633
       version: 1
       label:
-        label_val: BC64211486279C25347A354E1BA6030EF7F37728A650F9930D2360356DA87901
+        label_val: 8E2DF8905DE002AD29677FEF43C369E0D0504F9A7E3CB3F221E65E1AA9554A8B
+        label_len: 256
+      epoch: 3
+      username: 4765526F3841636563306E7769367A39346B766F5541443951355470794D3862
+  - ValueState:
+      value: 7851725473327746684A56703548514136706A7A714A426E5251316D326D7853
+      version: 1
+      label:
+        label_val: CA3A8FB4749A2F7C6FC2C0BEEBD5D4270758E7A06D9D92D2928D1AFCB5E7F648
+        label_len: 256
+      epoch: 2
+      username: 6B6F50796B564C414D726C7277395367426C72376A4D4B56304F5035504F4F35
+  - ValueState:
+      value: 6E65787774725065716547767A77504853704E73686C4644675A77715857746E
+      version: 1
+      label:
+        label_val: 426B148EEF56E37D269EFC61247411446CE289AA5D167BD32CCFEC877765FCB2
+        label_len: 256
+      epoch: 5
+      username: 6C36684E777569306D6F454D71714865555A6132335769516E6470633066564C
+  - ValueState:
+      value: 4D626971477730574A4F6639615379424E7A357438764353576B487753596548
+      version: 1
+      label:
+        label_val: 9EC4B36008568F3A571EE4BDE03E76611E51BBE7D7C6D2777CCA71B0BDF31E7F
+        label_len: 256
+      epoch: 5
+      username: 35637332787368554B4950575A57536D3435526F657A514A324246705542674B
+  - ValueState:
+      value: 44395942376C7361446A356A776F74746D5864375176425341484D65694F4167
+      version: 1
+      label:
+        label_val: 97B2F1F86164C236771A8CC90D192CD7D99A3016C5A5C1D912EAD392BC94AE20
+        label_len: 256
+      epoch: 5
+      username: 526372714F4D574A4A7278676C47644841566865374E654479567561744F7975
+  - ValueState:
+      value: 795871456A5371334935704D57775A5451744743695848566F50517575465A51
+      version: 1
+      label:
+        label_val: C7BAF6ABCDCC44429E4FD296B3E506F3BBC9BAE0CCCAF3D51C052FD3EA12A643
+        label_len: 256
+      epoch: 2
+      username: 673448775A58634162733235734D496D3851787271776F4B7730746A53384249
+  - ValueState:
+      value: 3550397A6F364B6A666D565A624B36784E504A6661556C4E5974696353717277
+      version: 1
+      label:
+        label_val: 40B7654182ACF470672602DCE7186CEA1DB59738D7C9F1D607A9B24C362BE6C0
         label_len: 256
       epoch: 1
-      username: 624338356F6E6F61484453796C736E74334164505261706273526B4D3777326C
+      username: 64534A635475736B6D59617155384C693779776F4141494832426D6E49554259
   - ValueState:
-      plaintext_val: 783155426571613935596C796C676168413469517A64763134476347786A5356
+      value: 5A6F456D6E48624A62626F3636715A554971703631644A6C656E556C64377953
       version: 1
       label:
-        label_val: A029FCA21E0590E42E7BCBCA972AA1D3B732E6EE60A66FE92CE4FC0E1B871AA5
+        label_val: AEBC771586C4265DAB54EBC4629AB9BFD382BE30FDC67FDBA7FB067E3B51D8B7
+        label_len: 256
+      epoch: 3
+      username: 6E30374D356341694C664665746A317137447861665850644C4E59724D627A66
+  - ValueState:
+      value: 6C5779574964696D3176315359424B524E4F3343723533456B736F737143746D
+      version: 1
+      label:
+        label_val: E963B4F8460FFD1F7D93D4DE499B11AAC91030B2AD59EC45AE63C4479A45A133
+        label_len: 256
+      epoch: 5
+      username: 533545636F7530467532586A704B634A4258774B79764570734D33416F377462
+  - ValueState:
+      value: 6E4473387A65663370756B4D676F6254534F663455426D334A7A734C4D627342
+      version: 1
+      label:
+        label_val: 57BDA197268698B8CBB74D80A5510AC869EEB21D80810BAD3FEABD26F258B52B
+        label_len: 256
+      epoch: 6
+      username: 5A306B4F56696230477739355131666B4C53586E3057397A33544B67746B5768
+  - ValueState:
+      value: 6E4C4E636A7371787665307345513455436E7075634D33304A6B515A4567504A
+      version: 1
+      label:
+        label_val: 1B3197016C32205D6B4768770B19A563B0E204CA0F291071A4B5690FDE5D5E9F
         label_len: 256
       epoch: 7
-      username: 6678366A556C5531453541764435776A35704A507458326D5947556837453068
+      username: 79593474675A6B346E6261416D3550333363467431307639574F376C64436B4D
   - ValueState:
-      plaintext_val: 41374C4B754C36765542655734314C4D6B716876634C3179386D6C426F723677
+      value: 496E5870394F544351646B57794B32345A786B3555746E62594A4D31784C5330
       version: 1
       label:
-        label_val: 4A14CFF125F7D143C61AD0ADF29FF986A2AEAC35949F3A945E5553D8DBA16522
+        label_val: 398E7F16B6562B76B5A9E5B1F9B584263DA97CA6F4D06220A0EF2C2F1A95AB12
+        label_len: 256
+      epoch: 1
+      username: 674F733959655638316E5976736D743367714978424372755052493551357A30
+  - ValueState:
+      value: 4B336F51544563567A3431564A354B6E33385A7335534B6A486667316662754A
+      version: 1
+      label:
+        label_val: 7948F1797F2C5BDE543241EDD4F6D826AAA9F65331493ED8D6D96BFE6BC9507C
         label_len: 256
       epoch: 2
-      username: 56457073444B77396A53474435586C4B763638496744486B6E4A6543634F4B76
+      username: 6C786E4664624D384D394E386166704B744B75536631696359367036426D7333
   - ValueState:
-      plaintext_val: 7957653067616F4B614953304D516A7A534232546C524A696E4962693433426C
+      value: 48516F694A6F75564271476D624C5166626E5A6D3462326E484863444D377254
       version: 1
       label:
-        label_val: 5624A58EE465FD68E2BD187BAC7109E3EC53F2645F99618EE447F03760D49750
+        label_val: E6B42CD9ABDFBE613158800BF70011C56F9D17F001BBD0C7CA0EA900FD4845DF
         label_len: 256
-      epoch: 5
-      username: 46764436754C6B5A396E6E736130767636376C526A7438635646444534646764
+      epoch: 6
+      username: 467A6E72444E484178547A6D4A6F466C655A70694B74326365597269464F6579
   - ValueState:
-      plaintext_val: 347A5A7A574D5570577A544243435945525838586B7044383968657471696549
+      value: 537A4334624577464C33595848437977746D5A3933495672725867475950526A
       version: 1
       label:
-        label_val: 45789452B4B106A5990C2B07CC2BD5B37F6B9859DF7738EEA6FF39CEAA2132A1
+        label_val: 06DEEEE0508C6152127EEBA6B13C7EF8E78DD54126A36B27E6AA1D7C8AF297DE
         label_len: 256
-      epoch: 8
-      username: 7751594252516B344A6932574C44426668584F59794F66697A7466676A7A6B4E
+      epoch: 1
+      username: 62736A34657A44596C4938534E7A304A3737316755506D394D75434861457A42
   - ValueState:
-      plaintext_val: 3367684738576768634751743077596930706A63717562616C73417647696833
+      value: 347474734845695A517947357165716E616D5957674445634258663757554E35
       version: 1
       label:
-        label_val: 9820B4017B5C29AC567B403361AF73E1BD7EC668A1E62557427F18066D0CBF7F
+        label_val: 7EC32D61A61F3D8C53F1B3F312F3AE60E153AB552FC46E94091F89C35A0E1341
+        label_len: 256
+      epoch: 3
+      username: 79426866585A39794B5541434C5737464C484B656E64326B3831747454723578
+  - ValueState:
+      value: 68444139424F674447374A50736964334F6B4F4655424C385547594F62733466
+      version: 1
+      label:
+        label_val: 4DF787D51E8E649F935F4DBBDEF0AE7E79C12A4ADBB250DEEAD4FE9E8D983756
+        label_len: 256
+      epoch: 1
+      username: 33464C395674314C58416661634E507574416A75636F7242587A724765316147
+  - ValueState:
+      value: 675A5A74764D564D336D6D494F577678423962777A3231565131515A72374173
+      version: 1
+      label:
+        label_val: 74F6AB77F795C02E81A82D318C73EEF444C184E8A6D994E0F4B64F91553351DA
+        label_len: 256
+      epoch: 6
+      username: 753264484171355A71763463557150444779346C6E6B48737043685645646F43
+  - ValueState:
+      value: 51307267667034654B646E6273795A384835356A42374D61377645726A78716C
+      version: 1
+      label:
+        label_val: F30D287863718B9C41B6318D293C68D6B2D7F10A106EECA37A4411A41759AAD3
         label_len: 256
       epoch: 2
-      username: 4B774938737A52433142336E6A4738717A316C4478386E417069706759743168
+      username: 533453507445775379383938534549706D3939756234586C5967304961706265
   - ValueState:
-      plaintext_val: 4D52314D4837334C5155537A74786878644D66526D674E5A3578374C51326978
+      value: 55505061453078335168596F78536B566D596E4C72324352426A626B6C633249
       version: 1
       label:
-        label_val: FFF787AFEAAD6597325AED191C7A854D2800F1ABD8C141AB42F06DED3F3C67D2
+        label_val: 6AB612EBC1965816ECCDD704B2D9AF25269ABC0E0D02990FED0B2BCE6C06C389
         label_len: 256
-      epoch: 3
-      username: 68395176724C6D3332554F56666170726E514B474F6E4E7438636B467353496F
-  - ValueState:
-      plaintext_val: 656235414C4E4B4842597158456D4A534D41636E3166626D5176764E54594E48
-      version: 1
-      label:
-        label_val: 562AC9D00F07A030298F9CE48DD0ACE19A1C1F1DC360AF8480FFC70A9373845A
-        label_len: 256
-      epoch: 3
-      username: 4C664A47346B6D53384C3649596B72384D72694B437242706166763156437344
-  - ValueState:
-      plaintext_val: 6377416B507A596457303749475861777836784A666D6131726C6F5536757A4C
-      version: 1
-      label:
-        label_val: C4AED26C5A84EE6640D7C81F4ECE294C7ADBA6ED09D5E13C0E830EB18F3F45F0
-        label_len: 256
-      epoch: 3
-      username: 684D576675334B70514F437976624B4E5970524A387A4C65326B493432504333
-  - ValueState:
-      plaintext_val: 613665687856434C676D71467968496647714A774D627372555374614F6A3067
-      version: 1
-      label:
-        label_val: 3ACABED73828CEFC02CF6B2F6B524023749D243D6F5D46A147045649CFB9115C
-        label_len: 256
-      epoch: 5
-      username: 776F634C31724D4F416D38427A62714877314D39356D477165484D4947363234
-  - ValueState:
-      plaintext_val: 55624C6B4E657A596F567A39666E336642314C33687058634C4C6262394C7170
-      version: 1
-      label:
-        label_val: C3532C2564360056BE35E0D0498A372A1D6D0B296B34E26CD6FDD58E7E945921
-        label_len: 256
-      epoch: 8
-      username: 69755A6439507A7765335A6D706E4C775845586D6E4F6A6A6638376F45355349
-  - ValueState:
-      plaintext_val: 5578575A3271344446395A634C784A326C655A326567416649365331714D4D71
-      version: 1
-      label:
-        label_val: A7D256522785EA6C704252815543BC1070EE225740FE572EAF34596141922631
-        label_len: 256
-      epoch: 3
-      username: 79683875496769737A7652446B4458444F44466868776256456568336A304336
+      epoch: 6
+      username: 7A5139346E6C4C5A465A6147386D5057546A4B67756F445632326B3232494741
 
 # Delta - Epoch 10
 ---
 epoch: 10
 updates:
-  - - 6E59524366344A6964527858524670583856443559546C4B53656C6970646C6D
-    - 3578337577576B43714552793870516651765936365567754C516A737236494B
-  - - 7836686A53706C424C4C6168464F376C763842793059646E396B565154514736
-    - 4A516536366F62656F39673634565675694F53744F31675530643476464D4878
-  - - 6D647566747756424A316D5A49786E424A313932387351325641564B61577354
-    - 637649764141505443463471705A5141775A6C454E795037646A4562544B4656
+  - - 324F4F5241506F5273514B38565250765839777A6E6972704C5470626765655A
+    - 4575636F65396269526B364E64675663316C464F6F6D77414368713662697377
+  - - 3956733254734748744F664F55386C687144366F6C614D36784A31494B384851
+    - 6F67553448504F3145585754324B706945396172594C514E383267775378526D
+  - - 736C4E386A4833483468456330624D395A6C6772356537716D68744B33627037
+    - 436D6331766332374376305273534E524D44707A337430454E68786976434650
 
 # State - Epoch 10
 ---
@@ -1003,22 +1195,232 @@ epoch: 10
 records:
   - TreeNode:
       label:
-        label_val: 45789452B4B106A5990C2B07CC2BD5B37F6B9859DF7738EEA6FF39CEAA2132A1
+        label_val: "5000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 4
+      latest_node:
+        label:
+          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        last_epoch: 8
+        min_descendant_epoch: 6
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        node_type: Interior
+        left_child:
+          label_val: 57BDA197268698B8CBB74D80A5510AC869EEB21D80810BAD3FEABD26F258B52B
+          label_len: 256
+        right_child:
+          label_val: 5D6D3BC6F72784D580BE798EF5816FB519485E184405F3BB517D7E1E11BE84B3
+          label_len: 256
+        hash: 06093EABD28C915F731E88679216F627DB7FBC9BF0DFA26D9DA9793BD8C251AD
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 40B7654182ACF470672602DCE7186CEA1DB59738D7C9F1D607A9B24C362BE6C0
         label_len: 256
       latest_node:
         label:
-          label_val: 45789452B4B106A5990C2B07CC2BD5B37F6B9859DF7738EEA6FF39CEAA2132A1
+          label_val: 40B7654182ACF470672602DCE7186CEA1DB59738D7C9F1D607A9B24C362BE6C0
           label_len: 256
-        last_epoch: 8
-        min_descendant_epoch: 8
+        last_epoch: 1
+        min_descendant_epoch: 1
         parent:
           label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 6
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: D46E3C909F32721265EF6071FCE64DCA908A62F3F71ABD67F439A47921A9FC46
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 2
+      latest_node:
+        label:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        last_epoch: 8
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        right_child:
+          label_val: 398E7F16B6562B76B5A9E5B1F9B584263DA97CA6F4D06220A0EF2C2F1A95AB12
+          label_len: 256
+        hash: 57A6A7DF092D2148F2CEF4EA7915AD45159986C5DAB074A65351A30C985013F0
+      previous_node:
+        label:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        last_epoch: 7
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        right_child:
+          label_val: 398E7F16B6562B76B5A9E5B1F9B584263DA97CA6F4D06220A0EF2C2F1A95AB12
+          label_len: 256
+        hash: A0318F4B4DEB30690D39EB391FFF9A8499CDA168EDCED649A7DF43162D54C23D
+  - TreeNode:
+      label:
+        label_val: "7800000000000000000000000000000000000000000000000000000000000000"
+        label_len: 5
+      latest_node:
+        label:
+          label_val: "7800000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        last_epoch: 3
+        min_descendant_epoch: 2
+        parent:
+          label_val: "7000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        node_type: Interior
+        left_child:
+          label_val: 7948F1797F2C5BDE543241EDD4F6D826AAA9F65331493ED8D6D96BFE6BC9507C
+          label_len: 256
+        right_child:
+          label_val: 7EC32D61A61F3D8C53F1B3F312F3AE60E153AB552FC46E94091F89C35A0E1341
+          label_len: 256
+        hash: C4D95421B1B98792217BD9C141F9A4D8CF6CE172704803A744FB749981657B4C
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: E6B42CD9ABDFBE613158800BF70011C56F9D17F001BBD0C7CA0EA900FD4845DF
+        label_len: 256
+      latest_node:
+        label:
+          label_val: E6B42CD9ABDFBE613158800BF70011C56F9D17F001BBD0C7CA0EA900FD4845DF
+          label_len: 256
+        last_epoch: 6
+        min_descendant_epoch: 6
+        parent:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: FCE19AB15447C3AAC5C3F34294CD6D7B93C44136ABA76FDDE2692E0273086B1C
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 7948F1797F2C5BDE543241EDD4F6D826AAA9F65331493ED8D6D96BFE6BC9507C
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 7948F1797F2C5BDE543241EDD4F6D826AAA9F65331493ED8D6D96BFE6BC9507C
+          label_len: 256
+        last_epoch: 2
+        min_descendant_epoch: 2
+        parent:
+          label_val: "7800000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: E0D68F634ED5C06DAB0EA8DF51AC4B4182AB0DEC2DC11C0821F1C4E491525196
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: C7BAF6ABCDCC44429E4FD296B3E506F3BBC9BAE0CCCAF3D51C052FD3EA12A643
+        label_len: 256
+      latest_node:
+        label:
+          label_val: C7BAF6ABCDCC44429E4FD296B3E506F3BBC9BAE0CCCAF3D51C052FD3EA12A643
+          label_len: 256
+        last_epoch: 2
+        min_descendant_epoch: 2
+        parent:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
           label_len: 4
         node_type: Leaf
         left_child: ~
         right_child: ~
-        hash: 91333870F8E36C126D745D2213982DABA93D05FFA6A789A3E5D352A06E0E9802
+        hash: FDB008ED88BDE9A12D86608DC80201AFB31C5EF9182B3062CA0CFD1E93E3FB1A
       previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 97B2F1F86164C236771A8CC90D192CD7D99A3016C5A5C1D912EAD392BC94AE20
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 97B2F1F86164C236771A8CC90D192CD7D99A3016C5A5C1D912EAD392BC94AE20
+          label_len: 256
+        last_epoch: 5
+        min_descendant_epoch: 5
+        parent:
+          label_val: "9000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 16705337F7867CEF5D8CB2D48D274E31EBB0C976EF40BDCF23C44F995F319909
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: E963B4F8460FFD1F7D93D4DE499B11AAC91030B2AD59EC45AE63C4479A45A133
+        label_len: 256
+      latest_node:
+        label:
+          label_val: E963B4F8460FFD1F7D93D4DE499B11AAC91030B2AD59EC45AE63C4479A45A133
+          label_len: 256
+        last_epoch: 5
+        min_descendant_epoch: 5
+        parent:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 79EE6AD0FF9BD73A07986F40011FD3759E4C91FCD47D6F06E35C245A1F14CFB9
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: E000000000000000000000000000000000000000000000000000000000000000
+        label_len: 4
+      latest_node:
+        label:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        last_epoch: 6
+        min_descendant_epoch: 4
+        parent:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        node_type: Interior
+        left_child:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 5
+        right_child:
+          label_val: E963B4F8460FFD1F7D93D4DE499B11AAC91030B2AD59EC45AE63C4479A45A133
+          label_len: 256
+        hash: 8084B8304AEECE6920B40F935247662C53450C38F458F70E15117F522A0056AD
+      previous_node:
+        label:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        last_epoch: 5
+        min_descendant_epoch: 4
+        parent:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        node_type: Interior
+        left_child:
+          label_val: E1E2366C30A2E8246783077E6AD13599563448038C78C0B9E492AC365614DEB7
+          label_len: 256
+        right_child:
+          label_val: E963B4F8460FFD1F7D93D4DE499B11AAC91030B2AD59EC45AE63C4479A45A133
+          label_len: 256
+        hash: C020D10B09DC6551292B9A4C4FEA692238EF07132D5311F3AFF68740263EBF08
   - TreeNode:
       label:
         label_val: "0000000000000000000000000000000000000000000000000000000000000000"
@@ -1027,23 +1429,6 @@ records:
         label:
           label_val: "0000000000000000000000000000000000000000000000000000000000000000"
           label_len: 0
-        last_epoch: 9
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 0
-        node_type: Root
-        left_child:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        right_child:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        hash: C862A67D365FE324F16C99DDCB27D3D4A70360A9D6290DB96FDF42DDD066600B
-      previous_node:
-        label:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 0
         last_epoch: 8
         min_descendant_epoch: 1
         parent:
@@ -1056,465 +1441,213 @@ records:
         right_child:
           label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 1
-        hash: 0FFA62E6F773C87A007B0951717F0561E1D24B650F02EDEB29116ACEB33D9881
-  - TreeNode:
-      label:
-        label_val: FFF787AFEAAD6597325AED191C7A854D2800F1ABD8C141AB42F06DED3F3C67D2
-        label_len: 256
-      latest_node:
-        label:
-          label_val: FFF787AFEAAD6597325AED191C7A854D2800F1ABD8C141AB42F06DED3F3C67D2
-          label_len: 256
-        last_epoch: 3
-        min_descendant_epoch: 3
-        parent:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: A0A1157A3AB3AA69FCD5801DB235D9FB497DFBA9A132808B03C6973CF6AB7785
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: BC00000000000000000000000000000000000000000000000000000000000000
-        label_len: 7
-      latest_node:
-        label:
-          label_val: BC00000000000000000000000000000000000000000000000000000000000000
-          label_len: 7
-        last_epoch: 5
-        min_descendant_epoch: 1
-        parent:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        node_type: Interior
-        left_child:
-          label_val: BC64211486279C25347A354E1BA6030EF7F37728A650F9930D2360356DA87901
-          label_len: 256
-        right_child:
-          label_val: BDBB810BEC5125B8B60493ECFC875A6FC73C9F90185988DED0418751031FC833
-          label_len: 256
-        hash: D080CBC9859CA85B928B8759C8DC851F29CB53E9EA743DFC49B03D29E549AB93
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: C000000000000000000000000000000000000000000000000000000000000000
-        label_len: 2
-      latest_node:
-        label:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        last_epoch: 9
-        min_descendant_epoch: 2
-        parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        right_child:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        hash: AE4AD159212364E13BD80F8CEAD63919518BD0480FE4CB433161D6B400391E7E
+        hash: FC899BCF7E43E3719CB5A1734663645462BF54F1CFE972BB83FAE52790C7E538
       previous_node:
         label:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        last_epoch: 8
-        min_descendant_epoch: 2
-        parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        right_child:
-          label_val: FFF787AFEAAD6597325AED191C7A854D2800F1ABD8C141AB42F06DED3F3C67D2
-          label_len: 256
-        hash: A5E7345C592FEF7684D32AF8CF835BBBD5C81D1D5C44951314841FD695D19576
-  - TreeNode:
-      label:
-        label_val: A029FCA21E0590E42E7BCBCA972AA1D3B732E6EE60A66FE92CE4FC0E1B871AA5
-        label_len: 256
-      latest_node:
-        label:
-          label_val: A029FCA21E0590E42E7BCBCA972AA1D3B732E6EE60A66FE92CE4FC0E1B871AA5
-          label_len: 256
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 0
         last_epoch: 7
-        min_descendant_epoch: 7
-        parent:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 7
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 2A21F859CDA67E1CE949D26C02FB96E53130CC2651E5E870ED2295981B9DEA28
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 1
-      latest_node:
-        label:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        last_epoch: 9
         min_descendant_epoch: 1
         parent:
           label_val: "0000000000000000000000000000000000000000000000000000000000000000"
           label_len: 0
-        node_type: Interior
+        node_type: Root
         left_child:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
         right_child:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        hash: D449546D65DCAAC51E279FA28DEB36A966546252F4C0880E4F8D4093CFAEBE88
-      previous_node:
-        label:
           label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 1
+        hash: 0B7F32D70650E5113548BB6EA7464A48B3C6EB847421B148E0910E95FCB933FC
+  - TreeNode:
+      label:
+        label_val: 74F6AB77F795C02E81A82D318C73EEF444C184E8A6D994E0F4B64F91553351DA
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 74F6AB77F795C02E81A82D318C73EEF444C184E8A6D994E0F4B64F91553351DA
+          label_len: 256
+        last_epoch: 6
+        min_descendant_epoch: 6
+        parent:
+          label_val: "7000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: CDE1E79EFC56AAF9FF7774912836B5A32E6C145B5AA0D53303ADB9D37617024B
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 3
+      latest_node:
+        label:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
         last_epoch: 8
         min_descendant_epoch: 1
         parent:
           label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 0
+          label_len: 2
         node_type: Interior
         left_child:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
+          label_val: 06DEEEE0508C6152127EEBA6B13C7EF8E78DD54126A36B27E6AA1D7C8AF297DE
+          label_len: 256
         right_child:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_val: "1000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        hash: A6BE4FF2CAE66DF9A1E0231E59A28397ED27AE230BE167EC5396A818D6AEE279
+      previous_node:
+        label:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        last_epoch: 7
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
           label_len: 2
-        hash: 6220D51E9A01370B70D8001F1E17E84E987799C0FDBCBF43BEA259A76DF46B5D
-  - TreeNode:
-      label:
-        label_val: 4B97CC23D31578BAA5360CC34F3EA80E98746ACBD78A306ADB602D3FBFE7538D
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 4B97CC23D31578BAA5360CC34F3EA80E98746ACBD78A306ADB602D3FBFE7538D
+        node_type: Interior
+        left_child:
+          label_val: 06DEEEE0508C6152127EEBA6B13C7EF8E78DD54126A36B27E6AA1D7C8AF297DE
           label_len: 256
-        last_epoch: 9
-        min_descendant_epoch: 9
-        parent:
-          label_val: 4A00000000000000000000000000000000000000000000000000000000000000
-          label_len: 7
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: B7C5698A8031FC155341F662C7DFFD074F1B679850C60E8CF8CF24A0CAD7CB15
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 4A14CFF125F7D143C61AD0ADF29FF986A2AEAC35949F3A945E5553D8DBA16522
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 4A14CFF125F7D143C61AD0ADF29FF986A2AEAC35949F3A945E5553D8DBA16522
+        right_child:
+          label_val: 1B3197016C32205D6B4768770B19A563B0E204CA0F291071A4B5690FDE5D5E9F
           label_len: 256
-        last_epoch: 2
-        min_descendant_epoch: 2
-        parent:
-          label_val: 4A00000000000000000000000000000000000000000000000000000000000000
-          label_len: 7
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: A7747125CDADCF6D82F0AF8B16D228FE0CD6309AB2E3297803553E430C8A6A3A
-      previous_node: ~
+        hash: 13001B6E41A82103B6DD1CA5706D098228EEF8F8882F58EF605B76A3CB003027
   - TreeNode:
       label:
-        label_val: A7D256522785EA6C704252815543BC1070EE225740FE572EAF34596141922631
+        label_val: 1542AECD490E66E32D92BA6068843407531D99DE5C195A94EE7D229294431944
         label_len: 256
       latest_node:
         label:
-          label_val: A7D256522785EA6C704252815543BC1070EE225740FE572EAF34596141922631
-          label_len: 256
-        last_epoch: 3
-        min_descendant_epoch: 3
-        parent:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 5
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 97BA35C108C6A5746703C16C48BCA973C74A642F6B8BA7EEF13CD4D30476773B
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: C3532C2564360056BE35E0D0498A372A1D6D0B296B34E26CD6FDD58E7E945921
-        label_len: 256
-      latest_node:
-        label:
-          label_val: C3532C2564360056BE35E0D0498A372A1D6D0B296B34E26CD6FDD58E7E945921
+          label_val: 1542AECD490E66E32D92BA6068843407531D99DE5C195A94EE7D229294431944
           label_len: 256
         last_epoch: 8
         min_descendant_epoch: 8
         parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 5
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: DF35FB0227096C62BEF6324132ED5FD9101F30BF0280C6738F0B2B62B8BF9FB7
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: E56B7112A303CF2B1B1C64D4A0A800FF31635C9B388FDD125A9FF42726D14C3C
-        label_len: 256
-      latest_node:
-        label:
-          label_val: E56B7112A303CF2B1B1C64D4A0A800FF31635C9B388FDD125A9FF42726D14C3C
-          label_len: 256
-        last_epoch: 9
-        min_descendant_epoch: 9
-        parent:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_val: "1000000000000000000000000000000000000000000000000000000000000000"
           label_len: 4
         node_type: Leaf
         left_child: ~
         right_child: ~
-        hash: 22167C3002782912AD5A26063509687AFA1ED304F7AFD406FFEE12548E3A29DA
+        hash: 736C1913C079A62F8C486C2324B499A1ADAD1AB623AD949B2EE78CD4758057F3
       previous_node: ~
   - TreeNode:
       label:
-        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 3
+        label_val: "1000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 4
       latest_node:
         label:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        last_epoch: 9
-        min_descendant_epoch: 2
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_val: "1000000000000000000000000000000000000000000000000000000000000000"
           label_len: 4
-        right_child:
-          label_val: "5620000000000000000000000000000000000000000000000000000000000000"
-          label_len: 12
-        hash: BB714707BEF8543A4EF4B8A7A71940C1C4D4701A88DCB3A7ED90265210736BF0
-      previous_node:
-        label:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
         last_epoch: 8
-        min_descendant_epoch: 2
+        min_descendant_epoch: 7
         parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
         node_type: Interior
         left_child:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
+          label_val: 1542AECD490E66E32D92BA6068843407531D99DE5C195A94EE7D229294431944
+          label_len: 256
         right_child:
-          label_val: "5620000000000000000000000000000000000000000000000000000000000000"
-          label_len: 12
-        hash: 2A9D53D189D4638FDD5F046FE5051269D7BB0E23C571E44238B07813611442F0
+          label_val: 1B3197016C32205D6B4768770B19A563B0E204CA0F291071A4B5690FDE5D5E9F
+          label_len: 256
+        hash: 55FC509C998D39443D3F909CC4E54709678CF1612D22C2DF47F50D035CC90937
+      previous_node: ~
   - TreeNode:
       label:
-        label_val: BC64211486279C25347A354E1BA6030EF7F37728A650F9930D2360356DA87901
+        label_val: AEBC771586C4265DAB54EBC4629AB9BFD382BE30FDC67FDBA7FB067E3B51D8B7
         label_len: 256
       latest_node:
         label:
-          label_val: BC64211486279C25347A354E1BA6030EF7F37728A650F9930D2360356DA87901
+          label_val: AEBC771586C4265DAB54EBC4629AB9BFD382BE30FDC67FDBA7FB067E3B51D8B7
+          label_len: 256
+        last_epoch: 3
+        min_descendant_epoch: 3
+        parent:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: E01C1A1008385C4E202CFBF866C5476E442A21393D6C7F76597603A58B43CF0A
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "9000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 4
+      latest_node:
+        label:
+          label_val: "9000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        last_epoch: 5
+        min_descendant_epoch: 5
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        node_type: Interior
+        left_child:
+          label_val: 97B2F1F86164C236771A8CC90D192CD7D99A3016C5A5C1D912EAD392BC94AE20
+          label_len: 256
+        right_child:
+          label_val: 9EC4B36008568F3A571EE4BDE03E76611E51BBE7D7C6D2777CCA71B0BDF31E7F
+          label_len: 256
+        hash: EEF38B64D48863F92ADDF92317B3E56C1D29BD59A39EC15D71288238710863D9
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 398E7F16B6562B76B5A9E5B1F9B584263DA97CA6F4D06220A0EF2C2F1A95AB12
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 398E7F16B6562B76B5A9E5B1F9B584263DA97CA6F4D06220A0EF2C2F1A95AB12
           label_len: 256
         last_epoch: 1
         min_descendant_epoch: 1
         parent:
-          label_val: BC00000000000000000000000000000000000000000000000000000000000000
-          label_len: 7
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
         node_type: Leaf
         left_child: ~
         right_child: ~
-        hash: 0C46AF311EBE9FABB6DF86B89F2900DC218C5B07A08E57ED9083F1B9FCD8C03F
+        hash: 2DC2E4EDB446FFC7683FE23D5E4E9ABE78373B19FB1BE5B2C337E54CE1D810EF
       previous_node: ~
   - TreeNode:
       label:
-        label_val: A000000000000000000000000000000000000000000000000000000000000000
-        label_len: 7
-      latest_node:
-        label:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 7
-        last_epoch: 7
-        min_descendant_epoch: 2
-        parent:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 5
-        node_type: Interior
-        left_child:
-          label_val: A029FCA21E0590E42E7BCBCA972AA1D3B732E6EE60A66FE92CE4FC0E1B871AA5
-          label_len: 256
-        right_child:
-          label_val: A1CF74F89155EA542C417BD891E0403080ED2124486D7F8A415F468383AB2289
-          label_len: 256
-        hash: 945E6E7A5990D7992EB04420165607F5B4B71FDE6FB72C11D7B230A0CC9F285B
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: EAC65007055A764A9C7BD67847B44D1F3B1D4BB1C91EE5CDB673CDA8A334A6D1
+        label_val: 4DF787D51E8E649F935F4DBBDEF0AE7E79C12A4ADBB250DEEAD4FE9E8D983756
         label_len: 256
       latest_node:
         label:
-          label_val: EAC65007055A764A9C7BD67847B44D1F3B1D4BB1C91EE5CDB673CDA8A334A6D1
+          label_val: 4DF787D51E8E649F935F4DBBDEF0AE7E79C12A4ADBB250DEEAD4FE9E8D983756
           label_len: 256
-        last_epoch: 9
-        min_descendant_epoch: 9
+        last_epoch: 1
+        min_descendant_epoch: 1
         parent:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
           label_len: 4
         node_type: Leaf
         left_child: ~
         right_child: ~
-        hash: DB61B5882BB06338E6116983EC0C0F87830E5C190C595247233F3FDF86EC704E
+        hash: B2B00BD1FD3F45C450E492A634F305A43D5EE9A665834A49A1AD1BC81E3D0E57
       previous_node: ~
-  - Azks:
-      latest_epoch: 9
-      num_nodes: 39
   - TreeNode:
       label:
-        label_val: BDBB810BEC5125B8B60493ECFC875A6FC73C9F90185988DED0418751031FC833
+        label_val: 7EC32D61A61F3D8C53F1B3F312F3AE60E153AB552FC46E94091F89C35A0E1341
         label_len: 256
       latest_node:
         label:
-          label_val: BDBB810BEC5125B8B60493ECFC875A6FC73C9F90185988DED0418751031FC833
+          label_val: 7EC32D61A61F3D8C53F1B3F312F3AE60E153AB552FC46E94091F89C35A0E1341
           label_len: 256
-        last_epoch: 5
-        min_descendant_epoch: 5
-        parent:
-          label_val: BC00000000000000000000000000000000000000000000000000000000000000
-          label_len: 7
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 0344848820715FBA584363550A7985E90F0BE4ED78DE5FA68AAB644ADD94ECBC
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 262590AAF0A16AA59EB0C34385AD5861480E574847393C5141A125B219C46364
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 262590AAF0A16AA59EB0C34385AD5861480E574847393C5141A125B219C46364
-          label_len: 256
-        last_epoch: 4
-        min_descendant_epoch: 4
-        parent:
-          label_val: "2000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 35247A8BA087218C901494DB68BB5D84177A0335DAF37DCF2DFBC7F4C055AE01
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: E000000000000000000000000000000000000000000000000000000000000000
-        label_len: 4
-      latest_node:
-        label:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        last_epoch: 9
-        min_descendant_epoch: 9
-        parent:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        node_type: Interior
-        left_child:
-          label_val: E56B7112A303CF2B1B1C64D4A0A800FF31635C9B388FDD125A9FF42726D14C3C
-          label_len: 256
-        right_child:
-          label_val: EAC65007055A764A9C7BD67847B44D1F3B1D4BB1C91EE5CDB673CDA8A334A6D1
-          label_len: 256
-        hash: F0A628E8521641D247042E3E9401D290FF4682949843958D4AF33A586AA55754
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 4
-      latest_node:
-        label:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        last_epoch: 9
-        min_descendant_epoch: 2
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        node_type: Interior
-        left_child:
-          label_val: 45789452B4B106A5990C2B07CC2BD5B37F6B9859DF7738EEA6FF39CEAA2132A1
-          label_len: 256
-        right_child:
-          label_val: 4A00000000000000000000000000000000000000000000000000000000000000
-          label_len: 7
-        hash: 0FB699E98FF34BA422637D6A0F34F7280D4815AA4EC5D0500F9BA9EBD44A55CA
-      previous_node:
-        label:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        last_epoch: 8
-        min_descendant_epoch: 2
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        node_type: Interior
-        left_child:
-          label_val: 45789452B4B106A5990C2B07CC2BD5B37F6B9859DF7738EEA6FF39CEAA2132A1
-          label_len: 256
-        right_child:
-          label_val: 4A14CFF125F7D143C61AD0ADF29FF986A2AEAC35949F3A945E5553D8DBA16522
-          label_len: 256
-        hash: A135DFB278062C48F42A733D176FFB6CDB193EC404518709F016E91F24B69702
-  - TreeNode:
-      label:
-        label_val: "5620000000000000000000000000000000000000000000000000000000000000"
-        label_len: 12
-      latest_node:
-        label:
-          label_val: "5620000000000000000000000000000000000000000000000000000000000000"
-          label_len: 12
-        last_epoch: 5
+        last_epoch: 3
         min_descendant_epoch: 3
         parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        node_type: Interior
-        left_child:
-          label_val: 5624A58EE465FD68E2BD187BAC7109E3EC53F2645F99618EE447F03760D49750
-          label_len: 256
-        right_child:
-          label_val: 562AC9D00F07A030298F9CE48DD0ACE19A1C1F1DC360AF8480FFC70A9373845A
-          label_len: 256
-        hash: 4B2027CDC94B686B1B61DFFA957A95073330E23F290C8869DE2B7449FB736A43
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: A1CF74F89155EA542C417BD891E0403080ED2124486D7F8A415F468383AB2289
-        label_len: 256
-      latest_node:
-        label:
-          label_val: A1CF74F89155EA542C417BD891E0403080ED2124486D7F8A415F468383AB2289
-          label_len: 256
-        last_epoch: 2
-        min_descendant_epoch: 2
-        parent:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 7
+          label_val: "7800000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
         node_type: Leaf
         left_child: ~
         right_child: ~
-        hash: E1F60D50473A1AD2293391E0543A1015C717FB2B661E406BC9C8A61BBDBE5AA9
+        hash: 86C886D0733EDEEAF5E5C9FC8B7A26369AAB1A91CC27593E0881A7487D69FA29
       previous_node: ~
   - TreeNode:
       label:
@@ -1524,244 +1657,208 @@ records:
         label:
           label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 2
-        last_epoch: 7
-        min_descendant_epoch: 1
+        last_epoch: 8
+        min_descendant_epoch: 3
         parent:
           label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 1
         node_type: Interior
         left_child:
-          label_val: 9820B4017B5C29AC567B403361AF73E1BD7EC668A1E62557427F18066D0CBF7F
-          label_len: 256
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
         right_child:
           label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        hash: DE556607BACE40B761C58C2E34E46C242D7C654FFF4144B239697C44B3E09EEF
+          label_len: 4
+        hash: 222E23DC085C30B086F1DCBDAADAEC05984CF6E0D13805D3F07DFCCB8D3F59AC
       previous_node:
         label:
           label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 2
         last_epoch: 5
-        min_descendant_epoch: 1
+        min_descendant_epoch: 3
         parent:
           label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 1
         node_type: Interior
         left_child:
-          label_val: 9820B4017B5C29AC567B403361AF73E1BD7EC668A1E62557427F18066D0CBF7F
-          label_len: 256
-        right_child:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 3
-        hash: EAC034EEA7B30C3CE95C98174EB39437991E01E9D33569D4146C80D9942533C1
+        right_child:
+          label_val: AEBC771586C4265DAB54EBC4629AB9BFD382BE30FDC67FDBA7FB067E3B51D8B7
+          label_len: 256
+        hash: 57F5F89B1B02EE45700F1CE1C7FF3C071EBA6F456E06E35BE57C6BBF9297B144
   - TreeNode:
       label:
-        label_val: C4AED26C5A84EE6640D7C81F4ECE294C7ADBA6ED09D5E13C0E830EB18F3F45F0
+        label_val: F30D287863718B9C41B6318D293C68D6B2D7F10A106EECA37A4411A41759AAD3
         label_len: 256
       latest_node:
         label:
-          label_val: C4AED26C5A84EE6640D7C81F4ECE294C7ADBA6ED09D5E13C0E830EB18F3F45F0
-          label_len: 256
-        last_epoch: 3
-        min_descendant_epoch: 3
-        parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 5
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 083974703AFA5CDC8BA315E2FC5E313AD95BC4A8292BD1E73B970FA7FFDD78D3
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 2
-      latest_node:
-        label:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        last_epoch: 9
-        min_descendant_epoch: 2
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        right_child:
-          label_val: 696A5F91A39FC533619534BC2A084F2C305ED1F9E5915770BFC9BFD303B4121C
-          label_len: 256
-        hash: 28409C715FF6DA78A681A933A0712F2581B5BCAD121568412CEED15D58E4629E
-      previous_node:
-        label:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        last_epoch: 8
-        min_descendant_epoch: 2
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        right_child:
-          label_val: 696A5F91A39FC533619534BC2A084F2C305ED1F9E5915770BFC9BFD303B4121C
-          label_len: 256
-        hash: 2A8B5D0C04D0BB914AC4C2FFF348D6FA871BB20199402BFADEE11F31FA86B73E
-  - TreeNode:
-      label:
-        label_val: C000000000000000000000000000000000000000000000000000000000000000
-        label_len: 5
-      latest_node:
-        label:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 5
-        last_epoch: 8
-        min_descendant_epoch: 3
-        parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        node_type: Interior
-        left_child:
-          label_val: C3532C2564360056BE35E0D0498A372A1D6D0B296B34E26CD6FDD58E7E945921
-          label_len: 256
-        right_child:
-          label_val: C4AED26C5A84EE6640D7C81F4ECE294C7ADBA6ED09D5E13C0E830EB18F3F45F0
-          label_len: 256
-        hash: 9A87F247FAD6ABCF8EA684353600CEC4F826D70774AB75599983140D17F712D5
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 9820B4017B5C29AC567B403361AF73E1BD7EC668A1E62557427F18066D0CBF7F
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 9820B4017B5C29AC567B403361AF73E1BD7EC668A1E62557427F18066D0CBF7F
+          label_val: F30D287863718B9C41B6318D293C68D6B2D7F10A106EECA37A4411A41759AAD3
           label_len: 256
         last_epoch: 2
         min_descendant_epoch: 2
         parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
         node_type: Leaf
         left_child: ~
         right_child: ~
-        hash: E9C6A4D21D14AB5EF044183DE7BBE975C3ECAC907618EEFCDAA31A702DAC6D0D
+        hash: 9CE6DAF35CB1EE1BFE3EA244FCFB8AEA9DA36E43F0EC803694122E989576AD55
       previous_node: ~
   - TreeNode:
       label:
-        label_val: C000000000000000000000000000000000000000000000000000000000000000
-        label_len: 3
+        label_val: 57BDA197268698B8CBB74D80A5510AC869EEB21D80810BAD3FEABD26F258B52B
+        label_len: 256
       latest_node:
         label:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_val: 57BDA197268698B8CBB74D80A5510AC869EEB21D80810BAD3FEABD26F258B52B
+          label_len: 256
+        last_epoch: 6
+        min_descendant_epoch: 6
+        parent:
+          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: C01B322B0EFD793157C858ED5FB761C0A487A7A303EF2394FBD151E93B18FCB0
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 06DEEEE0508C6152127EEBA6B13C7EF8E78DD54126A36B27E6AA1D7C8AF297DE
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 06DEEEE0508C6152127EEBA6B13C7EF8E78DD54126A36B27E6AA1D7C8AF297DE
+          label_len: 256
+        last_epoch: 1
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
           label_len: 3
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: A9873E9802E830CB3F25F0CE69405F7C891CE40EB301AE1658B3D657A0E72A5E
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: E000000000000000000000000000000000000000000000000000000000000000
+        label_len: 5
+      latest_node:
+        label:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 5
+        last_epoch: 6
+        min_descendant_epoch: 4
+        parent:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        node_type: Interior
+        left_child:
+          label_val: E1E2366C30A2E8246783077E6AD13599563448038C78C0B9E492AC365614DEB7
+          label_len: 256
+        right_child:
+          label_val: E6B42CD9ABDFBE613158800BF70011C56F9D17F001BBD0C7CA0EA900FD4845DF
+          label_len: 256
+        hash: 307FC535938EA908B3DF094277EE8E1ED5813FBA5B9D0D1615C7567B5E19304F
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 5D6D3BC6F72784D580BE798EF5816FB519485E184405F3BB517D7E1E11BE84B3
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 5D6D3BC6F72784D580BE798EF5816FB519485E184405F3BB517D7E1E11BE84B3
+          label_len: 256
         last_epoch: 8
-        min_descendant_epoch: 2
+        min_descendant_epoch: 8
         parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 553647B0596DF12C041504B33817A2F1EFB9D908B66EE92F36B7AA9E78992DDF
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: E1E2366C30A2E8246783077E6AD13599563448038C78C0B9E492AC365614DEB7
+        label_len: 256
+      latest_node:
+        label:
+          label_val: E1E2366C30A2E8246783077E6AD13599563448038C78C0B9E492AC365614DEB7
+          label_len: 256
+        last_epoch: 4
+        min_descendant_epoch: 4
+        parent:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
           label_len: 5
-        right_child:
-          label_val: D67047C370958792923714F7F9E8F67A0BD6DD566DCF64B8B43EA1D285CDEF27
-          label_len: 256
-        hash: 91EB319EC26483C9479E0B85042F3DCF7D63307789D231518A1684B679153853
-      previous_node:
-        label:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        last_epoch: 3
-        min_descendant_epoch: 2
-        parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: C4AED26C5A84EE6640D7C81F4ECE294C7ADBA6ED09D5E13C0E830EB18F3F45F0
-          label_len: 256
-        right_child:
-          label_val: D67047C370958792923714F7F9E8F67A0BD6DD566DCF64B8B43EA1D285CDEF27
-          label_len: 256
-        hash: C7C5344620F367264008899FBFEB08C6A6CC34B1A2593B452FA0A4AD6408F131
-  - TreeNode:
-      label:
-        label_val: 5624A58EE465FD68E2BD187BAC7109E3EC53F2645F99618EE447F03760D49750
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 5624A58EE465FD68E2BD187BAC7109E3EC53F2645F99618EE447F03760D49750
-          label_len: 256
-        last_epoch: 5
-        min_descendant_epoch: 5
-        parent:
-          label_val: "5620000000000000000000000000000000000000000000000000000000000000"
-          label_len: 12
         node_type: Leaf
         left_child: ~
         right_child: ~
-        hash: 0E258B0275632E48B2BC369C4F11418E09CA594A140FEEE772489E70148A6E0F
+        hash: 01C5F16CC625193DEA287DAE19DB5EE2686C8D15DB3B4843DEC49EB0F62E4FBE
       previous_node: ~
   - TreeNode:
       label:
-        label_val: 3ACABED73828CEFC02CF6B2F6B524023749D243D6F5D46A147045649CFB9115C
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 3ACABED73828CEFC02CF6B2F6B524023749D243D6F5D46A147045649CFB9115C
-          label_len: 256
-        last_epoch: 5
-        min_descendant_epoch: 5
-        parent:
-          label_val: "2000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 382DEDBE2B4BB962D14CF2C18257BD2F24020CA7619120172389D2571F728FA1
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: A000000000000000000000000000000000000000000000000000000000000000
+        label_val: "6000000000000000000000000000000000000000000000000000000000000000"
         label_len: 3
       latest_node:
         label:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_val: "6000000000000000000000000000000000000000000000000000000000000000"
           label_len: 3
-        last_epoch: 7
-        min_descendant_epoch: 1
+        last_epoch: 6
+        min_descendant_epoch: 2
         parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
           label_len: 2
         node_type: Interior
         left_child:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 5
+          label_val: 6AB612EBC1965816ECCDD704B2D9AF25269ABC0E0D02990FED0B2BCE6C06C389
+          label_len: 256
         right_child:
-          label_val: BC00000000000000000000000000000000000000000000000000000000000000
-          label_len: 7
-        hash: 43EF361095C8F09953800B71DEEBBC94AEF1C6F15DEA739A7CDFB056C63BEAAE
-      previous_node:
+          label_val: "7000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        hash: BFB9BAD32CCC7D57FC347D0B30E15B31233B4F72204DB357FE07625AC4CAAC74
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 4
+      latest_node:
         label:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
         last_epoch: 5
         min_descendant_epoch: 1
         parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        node_type: Interior
+        left_child:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 6
+        right_child:
+          label_val: 4DF787D51E8E649F935F4DBBDEF0AE7E79C12A4ADBB250DEEAD4FE9E8D983756
+          label_len: 256
+        hash: 9C8BE6689D023806C211BE990A8E4DF848AC9D4AC695A170F283C999CF8088F6
+      previous_node:
+        label:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        last_epoch: 1
+        min_descendant_epoch: 1
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
           label_len: 2
         node_type: Interior
         left_child:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 5
+          label_val: 40B7654182ACF470672602DCE7186CEA1DB59738D7C9F1D607A9B24C362BE6C0
+          label_len: 256
         right_child:
-          label_val: BC00000000000000000000000000000000000000000000000000000000000000
-          label_len: 7
-        hash: 74FDF03A8EE8A6404634B5080289404BE489DDAB78807E291A2A34566895BBDB
+          label_val: 4DF787D51E8E649F935F4DBBDEF0AE7E79C12A4ADBB250DEEAD4FE9E8D983756
+          label_len: 256
+        hash: A013AAEBF9C1B54B8513B90A62953DC2A0776457C71B84E7665078FF128D8D03
   - TreeNode:
       label:
         label_val: "0000000000000000000000000000000000000000000000000000000000000000"
@@ -1770,22 +1867,378 @@ records:
         label:
           label_val: "0000000000000000000000000000000000000000000000000000000000000000"
           label_len: 1
-        last_epoch: 9
-        min_descendant_epoch: 2
+        last_epoch: 8
+        min_descendant_epoch: 1
         parent:
           label_val: "0000000000000000000000000000000000000000000000000000000000000000"
           label_len: 0
         node_type: Interior
         left_child:
-          label_val: "2000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
         right_child:
           label_val: "4000000000000000000000000000000000000000000000000000000000000000"
           label_len: 2
-        hash: ED022A51B65946B1072EC9E7C62B20D7C04999EB3F23532C9FD2B6404FBA8967
+        hash: A4A91E7E947147C473E29A78ADD36E7164D53C1A3F019E1222DF535427F089EC
       previous_node:
         label:
           label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        last_epoch: 7
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 0
+        node_type: Interior
+        left_child:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        right_child:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        hash: 38A7EB89FDBBB2A2DB4E8E120C79F729A9D0AE6515B7E26AF4C5B937D755DC7A
+  - TreeNode:
+      label:
+        label_val: A4D9DDD2ED43F51B4123A55FC47610B129B7DB8B521248F4DAC92258AB960EF9
+        label_len: 256
+      latest_node:
+        label:
+          label_val: A4D9DDD2ED43F51B4123A55FC47610B129B7DB8B521248F4DAC92258AB960EF9
+          label_len: 256
+        last_epoch: 8
+        min_descendant_epoch: 8
+        parent:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 0691523E9E7C825AA161AC49066A9FB92EB30AF57321ED7F594D167DC1FE5C36
+      previous_node: ~
+  - Azks:
+      latest_epoch: 8
+      num_nodes: 47
+  - TreeNode:
+      label:
+        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 3
+      latest_node:
+        label:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        last_epoch: 8
+        min_descendant_epoch: 1
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        right_child:
+          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        hash: A1B2870FB1DA6E0F139FA01EEB45BA0CB826E2AE5A7FFFE922ABB287D0DA36AB
+      previous_node:
+        label:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        last_epoch: 6
+        min_descendant_epoch: 1
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        right_child:
+          label_val: 57BDA197268698B8CBB74D80A5510AC869EEB21D80810BAD3FEABD26F258B52B
+          label_len: 256
+        hash: F16C3BA290E76296FA4F7E4702C2CB3CC4C726867C904D145B4D30232EB4AB2E
+  - TreeNode:
+      label:
+        label_val: CA3A8FB4749A2F7C6FC2C0BEEBD5D4270758E7A06D9D92D2928D1AFCB5E7F648
+        label_len: 256
+      latest_node:
+        label:
+          label_val: CA3A8FB4749A2F7C6FC2C0BEEBD5D4270758E7A06D9D92D2928D1AFCB5E7F648
+          label_len: 256
+        last_epoch: 2
+        min_descendant_epoch: 2
+        parent:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 806BAC5DC57EBCEAFE9B6461B817415E1BDBB0E0FB8B5B6A7C66FBF36205591B
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: C000000000000000000000000000000000000000000000000000000000000000
+        label_len: 2
+      latest_node:
+        label:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 2
+        last_epoch: 6
+        min_descendant_epoch: 2
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        right_child:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        hash: 92D33A2244593647B3018A132C5175EA811D20E3C77A22514257F25FA6731B53
+      previous_node:
+        label:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 2
+        last_epoch: 5
+        min_descendant_epoch: 2
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        right_child:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        hash: CEE2BAFCBFD6600DE9DEAA86D402A1147581C7C35716AB098B4CEB6027F7C11D
+  - TreeNode:
+      label:
+        label_val: 426B148EEF56E37D269EFC61247411446CE289AA5D167BD32CCFEC877765FCB2
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 426B148EEF56E37D269EFC61247411446CE289AA5D167BD32CCFEC877765FCB2
+          label_len: 256
+        last_epoch: 5
+        min_descendant_epoch: 5
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 6
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 2F2A621AD1F7BCD1BA26EEE24CF076A0A88B6D4D77CDB4F06191C27A857F1629
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 3
+      latest_node:
+        label:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        last_epoch: 5
+        min_descendant_epoch: 3
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: 8E2DF8905DE002AD29677FEF43C369E0D0504F9A7E3CB3F221E65E1AA9554A8B
+          label_len: 256
+        right_child:
+          label_val: "9000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        hash: 149E9A9B04E072C0B682DFE0E6370F2E5E8CB9CBAB465E4A15D0F7DB555D21B0
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 8E2DF8905DE002AD29677FEF43C369E0D0504F9A7E3CB3F221E65E1AA9554A8B
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 8E2DF8905DE002AD29677FEF43C369E0D0504F9A7E3CB3F221E65E1AA9554A8B
+          label_len: 256
+        last_epoch: 3
+        min_descendant_epoch: 3
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 795E3424A3DF236DCBAA461600BA4F0719974B638A2BC3DF0721626093B02818
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: A000000000000000000000000000000000000000000000000000000000000000
+        label_len: 4
+      latest_node:
+        label:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        last_epoch: 8
+        min_descendant_epoch: 3
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: A4D9DDD2ED43F51B4123A55FC47610B129B7DB8B521248F4DAC92258AB960EF9
+          label_len: 256
+        right_child:
+          label_val: AEBC771586C4265DAB54EBC4629AB9BFD382BE30FDC67FDBA7FB067E3B51D8B7
+          label_len: 256
+        hash: D0D4236D5B92692E870E16601C2AAC5D5989CE48EEA4E9AD45088F638C862723
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 6AB612EBC1965816ECCDD704B2D9AF25269ABC0E0D02990FED0B2BCE6C06C389
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 6AB612EBC1965816ECCDD704B2D9AF25269ABC0E0D02990FED0B2BCE6C06C389
+          label_len: 256
+        last_epoch: 6
+        min_descendant_epoch: 6
+        parent:
+          label_val: "6000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: FD5808558FD229CA27E68F61076ED0D9C37E8E50FAD97592ACCE5ED30CC51AB2
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 6
+      latest_node:
+        label:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 6
+        last_epoch: 5
+        min_descendant_epoch: 1
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        node_type: Interior
+        left_child:
+          label_val: 40B7654182ACF470672602DCE7186CEA1DB59738D7C9F1D607A9B24C362BE6C0
+          label_len: 256
+        right_child:
+          label_val: 426B148EEF56E37D269EFC61247411446CE289AA5D167BD32CCFEC877765FCB2
+          label_len: 256
+        hash: 6B3419C7C423D84C7B07EDE63A174BB163A67222C6A4FAF1E2C77527A7684F8A
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 2
+      latest_node:
+        label:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        last_epoch: 8
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        right_child:
+          label_val: "6000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        hash: BD71CB156FC8155DE6EB132929F0B7F6BE9D7B7228232F030A5E764D572DE138
+      previous_node:
+        label:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        last_epoch: 6
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        right_child:
+          label_val: "6000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        hash: A857119636BF4BDA061A5AF477DA9D05CFDA9BDCB164B42AC50E2AD68003D174
+  - TreeNode:
+      label:
+        label_val: "7000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 4
+      latest_node:
+        label:
+          label_val: "7000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        last_epoch: 6
+        min_descendant_epoch: 2
+        parent:
+          label_val: "6000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        node_type: Interior
+        left_child:
+          label_val: 74F6AB77F795C02E81A82D318C73EEF444C184E8A6D994E0F4B64F91553351DA
+          label_len: 256
+        right_child:
+          label_val: "7800000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        hash: 22C6EAF3539F43F0B6A493C3D6813FB06777C7365713E634645E8E8F166B2317
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 9EC4B36008568F3A571EE4BDE03E76611E51BBE7D7C6D2777CCA71B0BDF31E7F
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 9EC4B36008568F3A571EE4BDE03E76611E51BBE7D7C6D2777CCA71B0BDF31E7F
+          label_len: 256
+        last_epoch: 5
+        min_descendant_epoch: 5
+        parent:
+          label_val: "9000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: FD1EB17D43CAD8D453C2C8A38E00D9A00BAE17E0C00E4D19DA646D887E3A8DBB
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: C000000000000000000000000000000000000000000000000000000000000000
+        label_len: 4
+      latest_node:
+        label:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        last_epoch: 2
+        min_descendant_epoch: 2
+        parent:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: C7BAF6ABCDCC44429E4FD296B3E506F3BBC9BAE0CCCAF3D51C052FD3EA12A643
+          label_len: 256
+        right_child:
+          label_val: CA3A8FB4749A2F7C6FC2C0BEEBD5D4270758E7A06D9D92D2928D1AFCB5E7F648
+          label_len: 256
+        hash: AB87A500A9DA1FE84837DFEFC72529CAABE2A0EF2A2C693778D9DF54B172DF31
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 1
+      latest_node:
+        label:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 1
         last_epoch: 8
         min_descendant_epoch: 2
@@ -1794,130 +2247,29 @@ records:
           label_len: 0
         node_type: Interior
         left_child:
-          label_val: "2000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        right_child:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 2
-        hash: D34E706699FC477D4DE6A1B7A9C4689CD5BDE231B50873B8E42B0537CEA9E080
-  - TreeNode:
-      label:
-        label_val: D67047C370958792923714F7F9E8F67A0BD6DD566DCF64B8B43EA1D285CDEF27
-        label_len: 256
-      latest_node:
-        label:
-          label_val: D67047C370958792923714F7F9E8F67A0BD6DD566DCF64B8B43EA1D285CDEF27
-          label_len: 256
-        last_epoch: 2
-        min_descendant_epoch: 2
-        parent:
+        right_child:
           label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 6E03127AFE3E84BE07F20F3A2819648D26BE281D53388700A044E5CD050A723C
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 4A00000000000000000000000000000000000000000000000000000000000000
-        label_len: 7
-      latest_node:
-        label:
-          label_val: 4A00000000000000000000000000000000000000000000000000000000000000
-          label_len: 7
-        last_epoch: 9
-        min_descendant_epoch: 2
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        node_type: Interior
-        left_child:
-          label_val: 4A14CFF125F7D143C61AD0ADF29FF986A2AEAC35949F3A945E5553D8DBA16522
-          label_len: 256
-        right_child:
-          label_val: 4B97CC23D31578BAA5360CC34F3EA80E98746ACBD78A306ADB602D3FBFE7538D
-          label_len: 256
-        hash: 63B5D47D23DDB75861744C745FF3D26139560910B6B85BE143E2166DBDB0BE11
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "2000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 3
-      latest_node:
-        label:
-          label_val: "2000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        last_epoch: 5
-        min_descendant_epoch: 4
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: 262590AAF0A16AA59EB0C34385AD5861480E574847393C5141A125B219C46364
-          label_len: 256
-        right_child:
-          label_val: 3ACABED73828CEFC02CF6B2F6B524023749D243D6F5D46A147045649CFB9115C
-          label_len: 256
-        hash: F5DE6EB21403DD6E329EE86E9D121B4BCF20DCE103A106F54B30843002F2DDC6
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: A000000000000000000000000000000000000000000000000000000000000000
-        label_len: 5
-      latest_node:
-        label:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 5
-        last_epoch: 7
-        min_descendant_epoch: 2
-        parent:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        node_type: Interior
-        left_child:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 7
-        right_child:
-          label_val: A7D256522785EA6C704252815543BC1070EE225740FE572EAF34596141922631
-          label_len: 256
-        hash: 2DCFCD612B121357FAE09CA9E5AFB4B3660D8F29B4A429E3BCE59D4C8FB4D6A7
+          label_len: 2
+        hash: 347E816B94F160C728BB4A02A20DA2F59115DA9C60DDF1E2D610A0C933C92352
       previous_node:
         label:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 5
-        last_epoch: 3
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        last_epoch: 6
         min_descendant_epoch: 2
         parent:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 0
         node_type: Interior
         left_child:
-          label_val: A1CF74F89155EA542C417BD891E0403080ED2124486D7F8A415F468383AB2289
-          label_len: 256
-        right_child:
-          label_val: A7D256522785EA6C704252815543BC1070EE225740FE572EAF34596141922631
-          label_len: 256
-        hash: 2C739CB97C2A75C278BFD5EDB143E566846663897A24F9F90082F4E692B11D3B
-  - TreeNode:
-      label:
-        label_val: 696A5F91A39FC533619534BC2A084F2C305ED1F9E5915770BFC9BFD303B4121C
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 696A5F91A39FC533619534BC2A084F2C305ED1F9E5915770BFC9BFD303B4121C
-          label_len: 256
-        last_epoch: 6
-        min_descendant_epoch: 6
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 2
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 256F50289AD3F58A206554BE44599EB6D5EC0755D78112DA9229F6B928040315
-      previous_node: ~
+        right_child:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 2
+        hash: EA0B4997CD2435F434F46AC1D7B0AD4DC5860BB83EC6A10F8EB0463A950B5510
   - TreeNode:
       label:
         label_val: E000000000000000000000000000000000000000000000000000000000000000
@@ -1926,8 +2278,8 @@ records:
         label:
           label_val: E000000000000000000000000000000000000000000000000000000000000000
           label_len: 3
-        last_epoch: 9
-        min_descendant_epoch: 3
+        last_epoch: 6
+        min_descendant_epoch: 2
         parent:
           label_val: C000000000000000000000000000000000000000000000000000000000000000
           label_len: 2
@@ -1936,185 +2288,233 @@ records:
           label_val: E000000000000000000000000000000000000000000000000000000000000000
           label_len: 4
         right_child:
-          label_val: FFF787AFEAAD6597325AED191C7A854D2800F1ABD8C141AB42F06DED3F3C67D2
+          label_val: F30D287863718B9C41B6318D293C68D6B2D7F10A106EECA37A4411A41759AAD3
           label_len: 256
-        hash: 4E62B2C65687E6EE1E7FD17F51F8FFCA283FFD9437F7F30F00EDB167715FE92B
-      previous_node: ~
+        hash: FE55F5CC713923396B9C4B88CF1075D2CCB04270E7D0F8680EF2189850ABAC8F
+      previous_node:
+        label:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 3
+        last_epoch: 5
+        min_descendant_epoch: 2
+        parent:
+          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        right_child:
+          label_val: F30D287863718B9C41B6318D293C68D6B2D7F10A106EECA37A4411A41759AAD3
+          label_len: 256
+        hash: 4BB78E7180A19BF15294290CE178B589532412A6C9528A44B6E21D53CBB142FC
   - TreeNode:
       label:
-        label_val: 562AC9D00F07A030298F9CE48DD0ACE19A1C1F1DC360AF8480FFC70A9373845A
+        label_val: 1B3197016C32205D6B4768770B19A563B0E204CA0F291071A4B5690FDE5D5E9F
         label_len: 256
       latest_node:
         label:
-          label_val: 562AC9D00F07A030298F9CE48DD0ACE19A1C1F1DC360AF8480FFC70A9373845A
+          label_val: 1B3197016C32205D6B4768770B19A563B0E204CA0F291071A4B5690FDE5D5E9F
           label_len: 256
-        last_epoch: 3
-        min_descendant_epoch: 3
+        last_epoch: 7
+        min_descendant_epoch: 7
         parent:
-          label_val: "5620000000000000000000000000000000000000000000000000000000000000"
-          label_len: 12
+          label_val: "1000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
         node_type: Leaf
         left_child: ~
         right_child: ~
-        hash: 53D076977493CDCFB6F28AEDFF691A8B395434E156BD7E7F591FE2175C7F4C88
+        hash: 6A8C04B3FB065A530FD6A1D8B4EDAE0A27864A92EF5F33FD8DB728DDA04D4082
       previous_node: ~
   - ValueState:
-      plaintext_val: 637649764141505443463471705A5141775A6C454E795037646A4562544B4656
+      value: 334146627651746464545A4E4338326A353968706A744C4D4665356974717366
       version: 1
       label:
-        label_val: EAC65007055A764A9C7BD67847B44D1F3B1D4BB1C91EE5CDB673CDA8A334A6D1
-        label_len: 256
-      epoch: 9
-      username: 6D647566747756424A316D5A49786E424A313932387351325641564B61577354
-  - ValueState:
-      plaintext_val: 3578337577576B43714552793870516651765936365567754C516A737236494B
-      version: 1
-      label:
-        label_val: E56B7112A303CF2B1B1C64D4A0A800FF31635C9B388FDD125A9FF42726D14C3C
-        label_len: 256
-      epoch: 9
-      username: 6E59524366344A6964527858524670583856443559546C4B53656C6970646C6D
-  - ValueState:
-      plaintext_val: 42344750444E534F4854376A45436D4A54767878744D4C65676F39324650746C
-      version: 1
-      label:
-        label_val: D67047C370958792923714F7F9E8F67A0BD6DD566DCF64B8B43EA1D285CDEF27
-        label_len: 256
-      epoch: 2
-      username: 55517664506A4730614A7A5157454751686A586B526876796248524B69794258
-  - ValueState:
-      plaintext_val: 49704C466B425841696557354D754A6A6C7A705879616C45756172724555536F
-      version: 1
-      label:
-        label_val: BDBB810BEC5125B8B60493ECFC875A6FC73C9F90185988DED0418751031FC833
-        label_len: 256
-      epoch: 5
-      username: 586D717057716B557632527357385731557A66593941626A704E644B31673450
-  - ValueState:
-      plaintext_val: 4D534B757678613669634B7033314968514E65576E414E6A6A53506D326D4D4C
-      version: 1
-      label:
-        label_val: 696A5F91A39FC533619534BC2A084F2C305ED1F9E5915770BFC9BFD303B4121C
-        label_len: 256
-      epoch: 6
-      username: 7070726833424262555374446E585637726D5047363734494B5A47304D694F5A
-  - ValueState:
-      plaintext_val: 4A516536366F62656F39673634565675694F53744F31675530643476464D4878
-      version: 1
-      label:
-        label_val: 4B97CC23D31578BAA5360CC34F3EA80E98746ACBD78A306ADB602D3FBFE7538D
-        label_len: 256
-      epoch: 9
-      username: 7836686A53706C424C4C6168464F376C763842793059646E396B565154514736
-  - ValueState:
-      plaintext_val: 34774561314D3858566E525A456169777666395855454D4B6F365A6C50533270
-      version: 1
-      label:
-        label_val: A1CF74F89155EA542C417BD891E0403080ED2124486D7F8A415F468383AB2289
-        label_len: 256
-      epoch: 2
-      username: 726841445830786372526F4A687345706F534D51747933467470617A3546474F
-  - ValueState:
-      plaintext_val: 4761574D524C574D6C55537A424E674A52776148326E454C4C47413564673978
-      version: 1
-      label:
-        label_val: 262590AAF0A16AA59EB0C34385AD5861480E574847393C5141A125B219C46364
+        label_val: E1E2366C30A2E8246783077E6AD13599563448038C78C0B9E492AC365614DEB7
         label_len: 256
       epoch: 4
-      username: 545466663742364335306C786765544B4369474C4F6165464D44536844673441
+      username: 736C7959594437396856435531627164426668746167537163624259736E3130
   - ValueState:
-      plaintext_val: 6C697673455138444D667A7863736C467352576A4C3067476342304172774454
+      value: 745A517042743972666B50436F36734F6A54495A6872635A6A574D6247715633
       version: 1
       label:
-        label_val: BC64211486279C25347A354E1BA6030EF7F37728A650F9930D2360356DA87901
+        label_val: 8E2DF8905DE002AD29677FEF43C369E0D0504F9A7E3CB3F221E65E1AA9554A8B
+        label_len: 256
+      epoch: 3
+      username: 4765526F3841636563306E7769367A39346B766F5541443951355470794D3862
+  - ValueState:
+      value: 7851725473327746684A56703548514136706A7A714A426E5251316D326D7853
+      version: 1
+      label:
+        label_val: CA3A8FB4749A2F7C6FC2C0BEEBD5D4270758E7A06D9D92D2928D1AFCB5E7F648
+        label_len: 256
+      epoch: 2
+      username: 6B6F50796B564C414D726C7277395367426C72376A4D4B56304F5035504F4F35
+  - ValueState:
+      value: 6E65787774725065716547767A77504853704E73686C4644675A77715857746E
+      version: 1
+      label:
+        label_val: 426B148EEF56E37D269EFC61247411446CE289AA5D167BD32CCFEC877765FCB2
+        label_len: 256
+      epoch: 5
+      username: 6C36684E777569306D6F454D71714865555A6132335769516E6470633066564C
+  - ValueState:
+      value: 4D626971477730574A4F6639615379424E7A357438764353576B487753596548
+      version: 1
+      label:
+        label_val: 9EC4B36008568F3A571EE4BDE03E76611E51BBE7D7C6D2777CCA71B0BDF31E7F
+        label_len: 256
+      epoch: 5
+      username: 35637332787368554B4950575A57536D3435526F657A514A324246705542674B
+  - ValueState:
+      value: 44395942376C7361446A356A776F74746D5864375176425341484D65694F4167
+      version: 1
+      label:
+        label_val: 97B2F1F86164C236771A8CC90D192CD7D99A3016C5A5C1D912EAD392BC94AE20
+        label_len: 256
+      epoch: 5
+      username: 526372714F4D574A4A7278676C47644841566865374E654479567561744F7975
+  - ValueState:
+      value: 795871456A5371334935704D57775A5451744743695848566F50517575465A51
+      version: 1
+      label:
+        label_val: C7BAF6ABCDCC44429E4FD296B3E506F3BBC9BAE0CCCAF3D51C052FD3EA12A643
+        label_len: 256
+      epoch: 2
+      username: 673448775A58634162733235734D496D3851787271776F4B7730746A53384249
+  - ValueState:
+      value: 3550397A6F364B6A666D565A624B36784E504A6661556C4E5974696353717277
+      version: 1
+      label:
+        label_val: 40B7654182ACF470672602DCE7186CEA1DB59738D7C9F1D607A9B24C362BE6C0
         label_len: 256
       epoch: 1
-      username: 624338356F6E6F61484453796C736E74334164505261706273526B4D3777326C
+      username: 64534A635475736B6D59617155384C693779776F4141494832426D6E49554259
   - ValueState:
-      plaintext_val: 783155426571613935596C796C676168413469517A64763134476347786A5356
+      value: 5A6F456D6E48624A62626F3636715A554971703631644A6C656E556C64377953
       version: 1
       label:
-        label_val: A029FCA21E0590E42E7BCBCA972AA1D3B732E6EE60A66FE92CE4FC0E1B871AA5
+        label_val: AEBC771586C4265DAB54EBC4629AB9BFD382BE30FDC67FDBA7FB067E3B51D8B7
+        label_len: 256
+      epoch: 3
+      username: 6E30374D356341694C664665746A317137447861665850644C4E59724D627A66
+  - ValueState:
+      value: 6C5779574964696D3176315359424B524E4F3343723533456B736F737143746D
+      version: 1
+      label:
+        label_val: E963B4F8460FFD1F7D93D4DE499B11AAC91030B2AD59EC45AE63C4479A45A133
+        label_len: 256
+      epoch: 5
+      username: 533545636F7530467532586A704B634A4258774B79764570734D33416F377462
+  - ValueState:
+      value: 6E4473387A65663370756B4D676F6254534F663455426D334A7A734C4D627342
+      version: 1
+      label:
+        label_val: 57BDA197268698B8CBB74D80A5510AC869EEB21D80810BAD3FEABD26F258B52B
+        label_len: 256
+      epoch: 6
+      username: 5A306B4F56696230477739355131666B4C53586E3057397A33544B67746B5768
+  - ValueState:
+      value: 6E4C4E636A7371787665307345513455436E7075634D33304A6B515A4567504A
+      version: 1
+      label:
+        label_val: 1B3197016C32205D6B4768770B19A563B0E204CA0F291071A4B5690FDE5D5E9F
         label_len: 256
       epoch: 7
-      username: 6678366A556C5531453541764435776A35704A507458326D5947556837453068
+      username: 79593474675A6B346E6261416D3550333363467431307639574F376C64436B4D
   - ValueState:
-      plaintext_val: 41374C4B754C36765542655734314C4D6B716876634C3179386D6C426F723677
+      value: 496E5870394F544351646B57794B32345A786B3555746E62594A4D31784C5330
       version: 1
       label:
-        label_val: 4A14CFF125F7D143C61AD0ADF29FF986A2AEAC35949F3A945E5553D8DBA16522
+        label_val: 398E7F16B6562B76B5A9E5B1F9B584263DA97CA6F4D06220A0EF2C2F1A95AB12
+        label_len: 256
+      epoch: 1
+      username: 674F733959655638316E5976736D743367714978424372755052493551357A30
+  - ValueState:
+      value: 4B336F51544563567A3431564A354B6E33385A7335534B6A486667316662754A
+      version: 1
+      label:
+        label_val: 7948F1797F2C5BDE543241EDD4F6D826AAA9F65331493ED8D6D96BFE6BC9507C
         label_len: 256
       epoch: 2
-      username: 56457073444B77396A53474435586C4B763638496744486B6E4A6543634F4B76
+      username: 6C786E4664624D384D394E386166704B744B75536631696359367036426D7333
   - ValueState:
-      plaintext_val: 7957653067616F4B614953304D516A7A534232546C524A696E4962693433426C
+      value: 48516F694A6F75564271476D624C5166626E5A6D3462326E484863444D377254
       version: 1
       label:
-        label_val: 5624A58EE465FD68E2BD187BAC7109E3EC53F2645F99618EE447F03760D49750
+        label_val: E6B42CD9ABDFBE613158800BF70011C56F9D17F001BBD0C7CA0EA900FD4845DF
         label_len: 256
-      epoch: 5
-      username: 46764436754C6B5A396E6E736130767636376C526A7438635646444534646764
+      epoch: 6
+      username: 467A6E72444E484178547A6D4A6F466C655A70694B74326365597269464F6579
   - ValueState:
-      plaintext_val: 347A5A7A574D5570577A544243435945525838586B7044383968657471696549
+      value: 537A4334624577464C33595848437977746D5A3933495672725867475950526A
       version: 1
       label:
-        label_val: 45789452B4B106A5990C2B07CC2BD5B37F6B9859DF7738EEA6FF39CEAA2132A1
+        label_val: 06DEEEE0508C6152127EEBA6B13C7EF8E78DD54126A36B27E6AA1D7C8AF297DE
+        label_len: 256
+      epoch: 1
+      username: 62736A34657A44596C4938534E7A304A3737316755506D394D75434861457A42
+  - ValueState:
+      value: 4575636F65396269526B364E64675663316C464F6F6D77414368713662697377
+      version: 1
+      label:
+        label_val: 1542AECD490E66E32D92BA6068843407531D99DE5C195A94EE7D229294431944
         label_len: 256
       epoch: 8
-      username: 7751594252516B344A6932574C44426668584F59794F66697A7466676A7A6B4E
+      username: 324F4F5241506F5273514B38565250765839777A6E6972704C5470626765655A
   - ValueState:
-      plaintext_val: 3367684738576768634751743077596930706A63717562616C73417647696833
+      value: 347474734845695A517947357165716E616D5957674445634258663757554E35
       version: 1
       label:
-        label_val: 9820B4017B5C29AC567B403361AF73E1BD7EC668A1E62557427F18066D0CBF7F
+        label_val: 7EC32D61A61F3D8C53F1B3F312F3AE60E153AB552FC46E94091F89C35A0E1341
+        label_len: 256
+      epoch: 3
+      username: 79426866585A39794B5541434C5737464C484B656E64326B3831747454723578
+  - ValueState:
+      value: 68444139424F674447374A50736964334F6B4F4655424C385547594F62733466
+      version: 1
+      label:
+        label_val: 4DF787D51E8E649F935F4DBBDEF0AE7E79C12A4ADBB250DEEAD4FE9E8D983756
+        label_len: 256
+      epoch: 1
+      username: 33464C395674314C58416661634E507574416A75636F7242587A724765316147
+  - ValueState:
+      value: 436D6331766332374376305273534E524D44707A337430454E68786976434650
+      version: 1
+      label:
+        label_val: A4D9DDD2ED43F51B4123A55FC47610B129B7DB8B521248F4DAC92258AB960EF9
+        label_len: 256
+      epoch: 8
+      username: 736C4E386A4833483468456330624D395A6C6772356537716D68744B33627037
+  - ValueState:
+      value: 675A5A74764D564D336D6D494F577678423962777A3231565131515A72374173
+      version: 1
+      label:
+        label_val: 74F6AB77F795C02E81A82D318C73EEF444C184E8A6D994E0F4B64F91553351DA
+        label_len: 256
+      epoch: 6
+      username: 753264484171355A71763463557150444779346C6E6B48737043685645646F43
+  - ValueState:
+      value: 6F67553448504F3145585754324B706945396172594C514E383267775378526D
+      version: 1
+      label:
+        label_val: 5D6D3BC6F72784D580BE798EF5816FB519485E184405F3BB517D7E1E11BE84B3
+        label_len: 256
+      epoch: 8
+      username: 3956733254734748744F664F55386C687144366F6C614D36784A31494B384851
+  - ValueState:
+      value: 51307267667034654B646E6273795A384835356A42374D61377645726A78716C
+      version: 1
+      label:
+        label_val: F30D287863718B9C41B6318D293C68D6B2D7F10A106EECA37A4411A41759AAD3
         label_len: 256
       epoch: 2
-      username: 4B774938737A52433142336E6A4738717A316C4478386E417069706759743168
+      username: 533453507445775379383938534549706D3939756234586C5967304961706265
   - ValueState:
-      plaintext_val: 4D52314D4837334C5155537A74786878644D66526D674E5A3578374C51326978
+      value: 55505061453078335168596F78536B566D596E4C72324352426A626B6C633249
       version: 1
       label:
-        label_val: FFF787AFEAAD6597325AED191C7A854D2800F1ABD8C141AB42F06DED3F3C67D2
+        label_val: 6AB612EBC1965816ECCDD704B2D9AF25269ABC0E0D02990FED0B2BCE6C06C389
         label_len: 256
-      epoch: 3
-      username: 68395176724C6D3332554F56666170726E514B474F6E4E7438636B467353496F
-  - ValueState:
-      plaintext_val: 656235414C4E4B4842597158456D4A534D41636E3166626D5176764E54594E48
-      version: 1
-      label:
-        label_val: 562AC9D00F07A030298F9CE48DD0ACE19A1C1F1DC360AF8480FFC70A9373845A
-        label_len: 256
-      epoch: 3
-      username: 4C664A47346B6D53384C3649596B72384D72694B437242706166763156437344
-  - ValueState:
-      plaintext_val: 6377416B507A596457303749475861777836784A666D6131726C6F5536757A4C
-      version: 1
-      label:
-        label_val: C4AED26C5A84EE6640D7C81F4ECE294C7ADBA6ED09D5E13C0E830EB18F3F45F0
-        label_len: 256
-      epoch: 3
-      username: 684D576675334B70514F437976624B4E5970524A387A4C65326B493432504333
-  - ValueState:
-      plaintext_val: 613665687856434C676D71467968496647714A774D627372555374614F6A3067
-      version: 1
-      label:
-        label_val: 3ACABED73828CEFC02CF6B2F6B524023749D243D6F5D46A147045649CFB9115C
-        label_len: 256
-      epoch: 5
-      username: 776F634C31724D4F416D38427A62714877314D39356D477165484D4947363234
-  - ValueState:
-      plaintext_val: 55624C6B4E657A596F567A39666E336642314C33687058634C4C6262394C7170
-      version: 1
-      label:
-        label_val: C3532C2564360056BE35E0D0498A372A1D6D0B296B34E26CD6FDD58E7E945921
-        label_len: 256
-      epoch: 8
-      username: 69755A6439507A7765335A6D706E4C775845586D6E4F6A6A6638376F45355349
-  - ValueState:
-      plaintext_val: 5578575A3271344446395A634C784A326C655A326567416649365331714D4D71
-      version: 1
-      label:
-        label_val: A7D256522785EA6C704252815543BC1070EE225740FE572EAF34596141922631
-        label_len: 256
-      epoch: 3
-      username: 79683875496769737A7652446B4458444F44466868776256456568336A304336
+      epoch: 6
+      username: 7A5139346E6C4C5A465A6147386D5057546A4B67756F445632326B3232494741


### PR DESCRIPTION
Renaming of:
- `struct Node` -> `struct AzksElement`
- field `hash` of `AzksElement` to be called `value`
- `NodeSet` -> `AzksElementSet`
- `NodeType` -> `TreeNodeType`
- `commitment_proof` -> `commitment_nonce`
- `next_few_vrf_proofs` -> `until_marker_vrf_proofs`
- `non_existence_of_next_few` -> `non_existence_until_marker_proofs`
- `non_existence_of_future_markers` -> `non_existence_of_future_marker_proofs`
- `previous_version_stale_at_ep` -> `previous_version_proof`
- `existence_at_ep` -> `existence_proof`
- `plaintext_value` -> `value`
- `LayerProof` -> `SiblingProof`
- `get_marker_version()` -> `get_marker_version_log2()`
- `random_node()` -> `random_azks_element()`

Note that this will require a bump in version since it changes the protobuf files.