### PR TITLE
Cleanups and akd_core documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,41 @@ jobs:
           command: fmt
           args: --all -- --check
 
+  benches:
+    name: benches
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Run benches
+        uses: actions-rs/cargo@v1
+        with:
+          command: bench
+          args: -F bench
+
+  docs:
+    name: docs
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -Dwarnings
+    steps:
+      - uses: actions/checkout@main
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Run rustdoc
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+
   wasm-tests:
     name: ${{matrix.name}}
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ This library provides a stateless API for an auditable key directory, meaning th
 Documentation
 -------------
 
-The API can be found [here](https://docs.rs/akd/) along with an example for usage.
+The API can be found [here](https://docs.rs/akd/) along with an example for usage. To learn more about the technical details
+behind how the directory is constructed, see [here](https://docs.rs/akd_core/).
 
 Installation
 ------------

--- a/akd/benches/azks.rs
+++ b/akd/benches/azks.rs
@@ -18,8 +18,8 @@ use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 
 fn batch_insertion(c: &mut Criterion) {
-    let num_initial_leaves = 10000;
-    let num_inserted_leaves = 100000;
+    let num_initial_leaves = 1000;
+    let num_inserted_leaves = 1000;
 
     let mut rng = StdRng::seed_from_u64(42);
     let runtime = tokio::runtime::Builder::new_multi_thread().build().unwrap();

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -614,7 +614,7 @@ impl Azks {
     /// the azks tree that remain unchanged from `start_epoch` to `end_epoch` and the leaves inserted into the
     /// tree after `start_epoch` and  up until `end_epoch`.
     /// If there is no errors, this function returns an `Ok` result, containing the
-    ///  append-only proof and otherwise, it returns a [errors::AkdError].
+    ///  append-only proof and otherwise, it returns an [AkdError].
     ///
     /// **RESTRICTIONS**: Note that `start_epoch` and `end_epoch` are valid only when the following are true
     /// * `start_epoch` <= `end_epoch`
@@ -925,7 +925,7 @@ impl Azks {
             sibling_proofs.pop();
         }
         let hash_val = if curr_node.node_type == TreeNodeType::Leaf {
-            crate::hash::merge_with_int(curr_node.hash, curr_node.last_epoch)
+            crate::hash::merge_with_u64(curr_node.hash, curr_node.last_epoch)
         } else {
             curr_node.hash
         };
@@ -1024,7 +1024,7 @@ mod tests {
 
             let new_leaf = new_leaf_node(label, value, 7 - i + 1);
             leaf_hashes.push(crate::hash::merge(&[
-                crate::hash::merge_with_int(crate::hash::hash(&leaf_u64.to_be_bytes()), 7 - i + 1),
+                crate::hash::merge_with_u64(crate::hash::hash(&leaf_u64.to_be_bytes()), 7 - i + 1),
                 new_leaf.label.hash(),
             ]));
             leaves.push(new_leaf);

--- a/akd/src/auditor.rs
+++ b/akd/src/auditor.rs
@@ -65,7 +65,7 @@ pub async fn verify_consecutive_append_only(
         .iter()
         .map(|x| {
             let mut y = *x;
-            y.value = akd_core::hash::merge_with_int(x.value, end_epoch);
+            y.value = akd_core::hash::merge_with_u64(x.value, end_epoch);
             y
         })
         .collect();

--- a/akd/src/lib.rs
+++ b/akd/src/lib.rs
@@ -42,7 +42,7 @@
 //!
 //! ## Setup
 //! A [`Directory`] represents an AKD. To set up a [`Directory`], we first need to pick on
-//! a database, a hash function, and a VRF. For this example, we use [blake3] as the hash function,
+//! a database, a hash function, and a VRF. For this example, we use Blake3 as the hash function,
 //! [`storage::memory::AsyncInMemoryDatabase`] as in-memory storage, and [`ecvrf::HardCodedAkdVRF`] as the VRF.
 //! The [`Directory::new`] function also takes as input a third parameter indicating whether or not it is "read-only".
 //! Note that a read-only directory cannot be updated, and so we most likely will want to keep this variable set
@@ -82,8 +82,8 @@
 //! use akd::Digest;
 //!
 //! let entries = vec![
-//!     (AkdLabel::from_utf8_str("first entry"), AkdValue::from_utf8_str("first value")),
-//!     (AkdLabel::from_utf8_str("second entry"), AkdValue::from_utf8_str("second value")),
+//!     (AkdLabel::from("first entry"), AkdValue::from("first value")),
+//!     (AkdLabel::from("second entry"), AkdValue::from("second value")),
 //! ];
 //! # let db = AsyncInMemoryDatabase::new();
 //! # let storage_manager = StorageManager::new_no_cache(db);
@@ -116,8 +116,8 @@
 //! # use akd::Digest;
 //! #
 //! # let entries = vec![
-//! #     (AkdLabel::from_utf8_str("first entry"), AkdValue::from_utf8_str("first value")),
-//! #     (AkdLabel::from_utf8_str("second entry"), AkdValue::from_utf8_str("second value")),
+//! #     (AkdLabel::from("first entry"), AkdValue::from("first value")),
+//! #     (AkdLabel::from("second entry"), AkdValue::from("second value")),
 //! # ];
 //! # let db = AsyncInMemoryDatabase::new();
 //! # let storage_manager = StorageManager::new_no_cache(db);
@@ -128,7 +128,7 @@
 //! #     let EpochHash(epoch, root_hash) = akd.publish(entries)
 //! #         .await.expect("Error with publishing");
 //! let (lookup_proof, _) = akd.lookup(
-//!     AkdLabel::from_utf8_str("first entry")
+//!     AkdLabel::from("first entry")
 //! ).await.expect("Could not generate proof");
 //! # });
 //! ```
@@ -149,8 +149,8 @@
 //! # use akd::Digest;
 //! #
 //! # let entries = vec![
-//! #     (AkdLabel::from_utf8_str("first entry"), AkdValue::from_utf8_str("first value")),
-//! #     (AkdLabel::from_utf8_str("second entry"), AkdValue::from_utf8_str("second value")),
+//! #     (AkdLabel::from("first entry"), AkdValue::from("first value")),
+//! #     (AkdLabel::from("second entry"), AkdValue::from("second value")),
 //! # ];
 //! # let db = AsyncInMemoryDatabase::new();
 //! # let storage_manager = StorageManager::new_no_cache(db);
@@ -161,14 +161,14 @@
 //! #     let _ = akd.publish(entries)
 //! #         .await.expect("Error with publishing");
 //! #     let (lookup_proof, epoch_hash) = akd.lookup(
-//! #         AkdLabel::from_utf8_str("first entry")
+//! #         AkdLabel::from("first entry")
 //! #     ).await.expect("Could not generate proof");
 //! let public_key = akd.get_public_key().await.expect("Could not fetch public key");
 //!
 //! let lookup_result = akd::client::lookup_verify(
 //!     public_key.as_bytes(),
 //!     epoch_hash.hash(),
-//!     AkdLabel::from_utf8_str("first entry"),
+//!     AkdLabel::from("first entry"),
 //!     lookup_proof,
 //! ).expect("Could not verify lookup proof");
 //!
@@ -177,7 +177,7 @@
 //!     akd::VerifyResult {
 //!         epoch: 1,
 //!         version: 1,
-//!         value: AkdValue::from_utf8_str("first value"),
+//!         value: AkdValue::from("first value"),
 //!     },
 //! );
 //! # });
@@ -203,8 +203,8 @@
 //! # use akd::Digest;
 //! #
 //! # let entries = vec![
-//! #     (AkdLabel::from_utf8_str("first entry"), AkdValue::from_utf8_str("first value")),
-//! #     (AkdLabel::from_utf8_str("second entry"), AkdValue::from_utf8_str("second value")),
+//! #     (AkdLabel::from("first entry"), AkdValue::from("first value")),
+//! #     (AkdLabel::from("second entry"), AkdValue::from("second value")),
 //! # ];
 //! # let db = AsyncInMemoryDatabase::new();
 //! # let storage_manager = StorageManager::new_no_cache(db);
@@ -217,10 +217,10 @@
 //! use akd::HistoryParams;
 //!
 //! let EpochHash(epoch2, root_hash2) = akd.publish(
-//!     vec![(AkdLabel::from_utf8_str("first entry"), AkdValue::from_utf8_str("updated value"))],
+//!     vec![(AkdLabel::from("first entry"), AkdValue::from("updated value"))],
 //! ).await.expect("Error with publishing");
 //! let (history_proof, _) = akd.key_history(
-//!     &AkdLabel::from_utf8_str("first entry"),
+//!     &AkdLabel::from("first entry"),
 //!     HistoryParams::default(),
 //! ).await.expect("Could not generate proof");
 //! # });
@@ -244,8 +244,8 @@
 //! # use akd::Digest;
 //! #
 //! # let entries = vec![
-//! #     (AkdLabel::from_utf8_str("first entry"), AkdValue::from_utf8_str("first value")),
-//! #     (AkdLabel::from_utf8_str("second entry"), AkdValue::from_utf8_str("second value")),
+//! #     (AkdLabel::from("first entry"), AkdValue::from("first value")),
+//! #     (AkdLabel::from("second entry"), AkdValue::from("second value")),
 //! # ];
 //! # let db = AsyncInMemoryDatabase::new();
 //! # let storage_manager = StorageManager::new_no_cache(db);
@@ -256,10 +256,10 @@
 //! #     let _ = akd.publish(entries)
 //! #         .await.expect("Error with publishing");
 //! #     let _ = akd.publish(
-//! #         vec![(AkdLabel::from_utf8_str("first entry"), AkdValue::from_utf8_str("updated value"))],
+//! #         vec![(AkdLabel::from("first entry"), AkdValue::from("updated value"))],
 //! #     ).await.expect("Error with publishing");
 //! #     let (history_proof, epoch_hash) = akd.key_history(
-//! #         &AkdLabel::from_utf8_str("first entry"),
+//! #         &AkdLabel::from("first entry"),
 //! #         HistoryParams::default(),
 //! #     ).await.expect("Could not generate proof");
 //! let public_key = akd.get_public_key().await.expect("Could not fetch public key");
@@ -267,7 +267,7 @@
 //!     public_key.as_bytes(),
 //!     epoch_hash.hash(),
 //!     epoch_hash.epoch(),
-//!     AkdLabel::from_utf8_str("first entry"),
+//!     AkdLabel::from("first entry"),
 //!     history_proof,
 //!     akd::HistoryVerificationParams::default(),
 //! ).expect("Could not verify history");
@@ -278,12 +278,12 @@
 //!         akd::VerifyResult {
 //!             epoch: 2,
 //!             version: 2,
-//!             value: AkdValue::from_utf8_str("updated value"),
+//!             value: AkdValue::from("updated value"),
 //!         },
 //!         akd::VerifyResult {
 //!             epoch: 1,
 //!             version: 1,
-//!             value: AkdValue::from_utf8_str("first value"),
+//!             value: AkdValue::from("first value"),
 //!         },
 //!     ],
 //! );
@@ -307,8 +307,8 @@
 //! # use akd::Digest;
 //! #
 //! # let entries = vec![
-//! #     (AkdLabel::from_utf8_str("first entry"), AkdValue::from_utf8_str("first value")),
-//! #     (AkdLabel::from_utf8_str("second entry"), AkdValue::from_utf8_str("second value")),
+//! #     (AkdLabel::from("first entry"), AkdValue::from("first value")),
+//! #     (AkdLabel::from("second entry"), AkdValue::from("second value")),
 //! # ];
 //! # let db = AsyncInMemoryDatabase::new();
 //! # let storage_manager = StorageManager::new_no_cache(db);
@@ -320,8 +320,8 @@
 //! #         .await.expect("Error with publishing");
 //! // Publish new entries into a second epoch
 //! let entries = vec![
-//!     (AkdLabel::from_utf8_str("first entry"), AkdValue::from_utf8_str("new first value")),
-//!     (AkdLabel::from_utf8_str("third entry"), AkdValue::from_utf8_str("third value")),
+//!     (AkdLabel::from("first entry"), AkdValue::from("new first value")),
+//!     (AkdLabel::from("third entry"), AkdValue::from("third value")),
 //! ];
 //! let EpochHash(epoch2, root_hash2) = akd.publish(entries)
 //!     .await.expect("Error with publishing");
@@ -346,8 +346,8 @@
 //! # use akd::Digest;
 //! #
 //! # let entries = vec![
-//! #     (AkdLabel::from_utf8_str("first entry"), AkdValue::from_utf8_str("first value")),
-//! #     (AkdLabel::from_utf8_str("second entry"), AkdValue::from_utf8_str("second value")),
+//! #     (AkdLabel::from("first entry"), AkdValue::from("first value")),
+//! #     (AkdLabel::from("second entry"), AkdValue::from("second value")),
 //! # ];
 //! # let db = AsyncInMemoryDatabase::new();
 //! # let storage_manager = StorageManager::new_no_cache(db);
@@ -359,8 +359,8 @@
 //! #         .await.expect("Error with publishing");
 //! #     // Publish new entries into a second epoch
 //! #     let new_entries = vec![
-//! #         (AkdLabel::from_utf8_str("first entry"), AkdValue::from_utf8_str("new first value")),
-//! #         (AkdLabel::from_utf8_str("third entry"), AkdValue::from_utf8_str("third value")),
+//! #         (AkdLabel::from("first entry"), AkdValue::from("new first value")),
+//! #         (AkdLabel::from("third entry"), AkdValue::from("third value")),
 //! #     ];
 //! #     let EpochHash(epoch2, root_hash2) = akd.publish(new_entries)
 //! #         .await.expect("Error with publishing");

--- a/akd/src/storage/cache/tests.rs
+++ b/akd/src/storage/cache/tests.rs
@@ -29,10 +29,10 @@ async fn test_cache_put_and_expires() {
             label_len: 1,
             label_val: [0u8; 32],
         },
-        value: AkdValue::from_utf8_str("some value"),
-        username: AkdLabel::from_utf8_str("user"),
+        value: AkdValue::from("some value"),
+        username: AkdLabel::from("user"),
     });
-    let key = ValueStateKey(AkdLabel::from_utf8_str("user").0.to_vec(), 1);
+    let key = ValueStateKey(AkdLabel::from("user").0.to_vec(), 1);
     cache.put(&value_state).await;
 
     let got = cache.hit_test::<ValueState>(&key).await;
@@ -55,10 +55,10 @@ async fn test_cache_overwrite() {
             label_len: 1,
             label_val: [0u8; 32],
         },
-        value: AkdValue::from_utf8_str("some value"),
-        username: AkdLabel::from_utf8_str("user"),
+        value: AkdValue::from("some value"),
+        username: AkdLabel::from("user"),
     };
-    let key = ValueStateKey(AkdLabel::from_utf8_str("user").0.to_vec(), 1);
+    let key = ValueStateKey(AkdLabel::from("user").0.to_vec(), 1);
 
     let value_state_2 = ValueState {
         epoch: 1,
@@ -67,8 +67,8 @@ async fn test_cache_overwrite() {
             label_len: 2,
             label_val: [0u8; 32],
         },
-        value: AkdValue::from_utf8_str("some value"),
-        username: AkdLabel::from_utf8_str("user"),
+        value: AkdValue::from("some value"),
+        username: AkdLabel::from("user"),
     };
     cache.put(&DbRecord::ValueState(value_state)).await;
     cache
@@ -94,10 +94,10 @@ async fn test_cache_memory_pressure() {
             label_len: 1,
             label_val: [0u8; 32],
         },
-        value: AkdValue::from_utf8_str("some value"),
-        username: AkdLabel::from_utf8_str("user"),
+        value: AkdValue::from("some value"),
+        username: AkdLabel::from("user"),
     });
-    let key = ValueStateKey(AkdLabel::from_utf8_str("user").0.to_vec(), 1);
+    let key = ValueStateKey(AkdLabel::from("user").0.to_vec(), 1);
     cache.put(&value_state).await;
 
     // we only do an "automated" clean every 50ms in test, which is when memory pressure is evaluated.
@@ -125,8 +125,8 @@ async fn test_many_memory_pressure() {
                 label_len: 1,
                 label_val: [0u8; 32],
             },
-            value: AkdValue::from_utf8_str("test"),
-            username: AkdLabel::from_utf8_str("user"),
+            value: AkdValue::from("test"),
+            username: AkdLabel::from("user"),
         })
         .map(DbRecord::ValueState)
         .collect::<Vec<_>>();

--- a/akd/src/storage/tests.rs
+++ b/akd/src/storage/tests.rs
@@ -124,11 +124,11 @@ async fn test_get_and_set_item<Ns: Database>(storage: &Ns) {
     // === ValueState storage === //
     let key = ValueStateKey("test".as_bytes().to_vec(), 1);
     let value = ValueState {
-        username: AkdLabel::from_utf8_str("test"),
+        username: AkdLabel::from("test"),
         epoch: 1,
         label: NodeLabel::new(byte_arr_from_u64(1), 1),
         version: 1,
-        value: AkdValue::from_utf8_str("abc123"),
+        value: AkdValue::from("abc123"),
     };
     let set_result = storage.set(DbRecord::ValueState(value.clone())).await;
     assert_eq!(Ok(()), set_result);
@@ -419,7 +419,7 @@ async fn test_user_data<S: Database>(storage: &S) {
         username: AkdLabel(rand_user),
     };
     let mut sample_state_2 = sample_state.clone();
-    sample_state_2.username = AkdLabel::from_utf8_str("test_user");
+    sample_state_2.username = AkdLabel::from("test_user");
 
     let result = storage
         .set(DbRecord::ValueState(sample_state.clone()))
@@ -615,7 +615,7 @@ async fn test_tombstoning_data<S: Database>(
         username: AkdLabel(rand_user.clone()),
     };
     let mut sample_state2 = sample_state.clone();
-    sample_state2.username = AkdLabel::from_utf8_str("tombstone_test_user");
+    sample_state2.username = AkdLabel::from("tombstone_test_user");
 
     // Load up a bunch of data into the storage layer
     for i in 0..5 {
@@ -657,10 +657,7 @@ async fn test_tombstoning_data<S: Database>(
     // tombstone the given states
     storage.tombstone_value_states(&keys_to_tombstone).await?;
 
-    for label in [
-        AkdLabel::from_utf8_str("tombstone_test_user"),
-        AkdLabel(rand_user),
-    ] {
+    for label in [AkdLabel::from("tombstone_test_user"), AkdLabel(rand_user)] {
         for version in 0..5 {
             let key = ValueStateKey(label.to_vec(), version);
             let got = storage.get::<ValueState>(&key).await?;

--- a/akd/src/storage/transaction.rs
+++ b/akd/src/storage/transaction.rs
@@ -319,18 +319,18 @@ mod tests {
             hash: crate::hash::EMPTY_DIGEST,
         }));
         let value1 = DbRecord::ValueState(ValueState {
-            username: AkdLabel::from_utf8_str("test"),
+            username: AkdLabel::from("test"),
             epoch: 1,
             label: NodeLabel::new(byte_arr_from_u64(1), 1),
             version: 1,
-            value: AkdValue::from_utf8_str("abc123"),
+            value: AkdValue::from("abc123"),
         });
         let value2 = DbRecord::ValueState(ValueState {
-            username: AkdLabel::from_utf8_str("test"),
+            username: AkdLabel::from("test"),
             epoch: 2,
             label: NodeLabel::new(byte_arr_from_u64(1), 1),
             version: 2,
-            value: AkdValue::from_utf8_str("abc1234"),
+            value: AkdValue::from("abc1234"),
         });
 
         let records = vec![azks, node1, node2, value1, value2];

--- a/akd/src/tests.rs
+++ b/akd/src/tests.rs
@@ -192,11 +192,8 @@ async fn test_simple_publish() -> Result<(), AkdError> {
     let akd = Directory::<_, _>::new(storage, vrf, false).await?;
     // Make sure you can publish and that something so simple
     // won't throw errors.
-    akd.publish(vec![(
-        AkdLabel::from_utf8_str("hello"),
-        AkdValue::from_utf8_str("world"),
-    )])
-    .await?;
+    akd.publish(vec![(AkdLabel::from("hello"), AkdValue::from("world"))])
+        .await?;
     Ok(())
 }
 
@@ -211,25 +208,19 @@ async fn test_simple_lookup() -> Result<(), AkdError> {
     let akd = Directory::<_, _>::new(storage, vrf, false).await?;
     // Add two labels and corresponding values to the akd
     akd.publish(vec![
-        (
-            AkdLabel::from_utf8_str("hello"),
-            AkdValue::from_utf8_str("world"),
-        ),
-        (
-            AkdLabel::from_utf8_str("hello2"),
-            AkdValue::from_utf8_str("world2"),
-        ),
+        (AkdLabel::from("hello"), AkdValue::from("world")),
+        (AkdLabel::from("hello2"), AkdValue::from("world2")),
     ])
     .await?;
     // Get the lookup proof
-    let (lookup_proof, root_hash) = akd.lookup(AkdLabel::from_utf8_str("hello")).await?;
+    let (lookup_proof, root_hash) = akd.lookup(AkdLabel::from("hello")).await?;
     // Get the VRF public key
     let vrf_pk = akd.get_public_key().await?;
     // Verify the lookup proof
     lookup_verify(
         vrf_pk.as_bytes(),
         root_hash.hash(),
-        AkdLabel::from_utf8_str("hello"),
+        AkdLabel::from("hello"),
         lookup_proof,
     )?;
     Ok(())
@@ -249,22 +240,16 @@ async fn test_small_key_history() -> Result<(), AkdError> {
     let akd = Directory::<_, _>::new(storage, vrf, false).await?;
     // Publish the first value for the label "hello"
     // Epoch here will be 1
-    akd.publish(vec![(
-        AkdLabel::from_utf8_str("hello"),
-        AkdValue::from_utf8_str("world"),
-    )])
-    .await?;
+    akd.publish(vec![(AkdLabel::from("hello"), AkdValue::from("world"))])
+        .await?;
     // Publish the second value for the label "hello"
     // Epoch here will be 2
-    akd.publish(vec![(
-        AkdLabel::from_utf8_str("hello"),
-        AkdValue::from_utf8_str("world2"),
-    )])
-    .await?;
+    akd.publish(vec![(AkdLabel::from("hello"), AkdValue::from("world2"))])
+        .await?;
 
     // Get the key_history_proof for the label "hello"
     let (key_history_proof, root_hash) = akd
-        .key_history(&AkdLabel::from_utf8_str("hello"), HistoryParams::default())
+        .key_history(&AkdLabel::from("hello"), HistoryParams::default())
         .await?;
     // Get the VRF public key
     let vrf_pk = akd.get_public_key().await?;
@@ -273,7 +258,7 @@ async fn test_small_key_history() -> Result<(), AkdError> {
         vrf_pk.as_bytes(),
         root_hash.hash(),
         root_hash.epoch(),
-        AkdLabel::from_utf8_str("hello"),
+        AkdLabel::from("hello"),
         key_history_proof,
         HistoryVerificationParams::default(),
     )?;
@@ -284,12 +269,12 @@ async fn test_small_key_history() -> Result<(), AkdError> {
             VerifyResult {
                 epoch: 2,
                 version: 2,
-                value: AkdValue::from_utf8_str("world2"),
+                value: AkdValue::from("world2"),
             },
             VerifyResult {
                 epoch: 1,
                 version: 1,
-                value: AkdValue::from_utf8_str("world"),
+                value: AkdValue::from("world"),
             },
         ]
     );
@@ -308,74 +293,44 @@ async fn test_simple_key_history() -> Result<(), AkdError> {
     let akd = Directory::<_, _>::new(storage, vrf, false).await?;
     // Epoch 1: Add labels "hello" and "hello2"
     akd.publish(vec![
-        (
-            AkdLabel::from_utf8_str("hello"),
-            AkdValue::from_utf8_str("world"),
-        ),
-        (
-            AkdLabel::from_utf8_str("hello2"),
-            AkdValue::from_utf8_str("world2"),
-        ),
+        (AkdLabel::from("hello"), AkdValue::from("world")),
+        (AkdLabel::from("hello2"), AkdValue::from("world2")),
     ])
     .await?;
     // Epoch 2: Update the values for both the labels to version 2
     akd.publish(vec![
-        (
-            AkdLabel::from_utf8_str("hello"),
-            AkdValue::from_utf8_str("world_2"),
-        ),
-        (
-            AkdLabel::from_utf8_str("hello2"),
-            AkdValue::from_utf8_str("world2_2"),
-        ),
+        (AkdLabel::from("hello"), AkdValue::from("world_2")),
+        (AkdLabel::from("hello2"), AkdValue::from("world2_2")),
     ])
     .await?;
     // Epoch 3: Update the values for both the labels again to version 3
     akd.publish(vec![
-        (
-            AkdLabel::from_utf8_str("hello"),
-            AkdValue::from_utf8_str("world3"),
-        ),
-        (
-            AkdLabel::from_utf8_str("hello2"),
-            AkdValue::from_utf8_str("world4"),
-        ),
+        (AkdLabel::from("hello"), AkdValue::from("world3")),
+        (AkdLabel::from("hello2"), AkdValue::from("world4")),
     ])
     .await?;
     // Epoch 4: Add two new labels
     akd.publish(vec![
-        (
-            AkdLabel::from_utf8_str("hello3"),
-            AkdValue::from_utf8_str("world"),
-        ),
-        (
-            AkdLabel::from_utf8_str("hello4"),
-            AkdValue::from_utf8_str("world2"),
-        ),
+        (AkdLabel::from("hello3"), AkdValue::from("world")),
+        (AkdLabel::from("hello4"), AkdValue::from("world2")),
     ])
     .await?;
     // Epoch 5: Updated "hello" to version 4
     akd.publish(vec![(
-        AkdLabel::from_utf8_str("hello"),
-        AkdValue::from_utf8_str("world_updated"),
+        AkdLabel::from("hello"),
+        AkdValue::from("world_updated"),
     )])
     .await?;
     // Epoch 6: Update the values for "hello3" and "hello4"
     // both two version 2.
     akd.publish(vec![
-        (
-            AkdLabel::from_utf8_str("hello3"),
-            AkdValue::from_utf8_str("world6"),
-        ),
-        (
-            AkdLabel::from_utf8_str("hello4"),
-            AkdValue::from_utf8_str("world12"),
-        ),
+        (AkdLabel::from("hello3"), AkdValue::from("world6")),
+        (AkdLabel::from("hello4"), AkdValue::from("world12")),
     ])
     .await?;
     // Get the key history proof for the label "hello". This should have 4 versions.
     let (key_history_proof, _) = akd
-        .key_history(&AkdLabel::from_utf8_str("hello"), HistoryParams::default())
+        .key_history(&AkdLabel::from("hello"), HistoryParams::default())
         .await?;
     // Check that the correct number of proofs are sent
     if key_history_proof.update_proofs.len() != 4 {
@@ -394,14 +349,14 @@ async fn test_simple_key_history() -> Result<(), AkdError> {
         vrf_pk.as_bytes(),
         root_hash,
         current_epoch,
-        AkdLabel::from_utf8_str("hello"),
+        AkdLabel::from("hello"),
         key_history_proof,
         HistoryVerificationParams::default(),
     )?;
 
     // Key history proof for "hello2"
     let (key_history_proof, _) = akd
-        .key_history(&AkdLabel::from_utf8_str("hello2"), HistoryParams::default())
+        .key_history(&AkdLabel::from("hello2"), HistoryParams::default())
         .await?;
     // Check that the correct number of proofs are sent
     if key_history_proof.update_proofs.len() != 3 {
@@ -414,14 +369,14 @@ async fn test_simple_key_history() -> Result<(), AkdError> {
         vrf_pk.as_bytes(),
         root_hash,
         current_epoch,
-        AkdLabel::from_utf8_str("hello2"),
+        AkdLabel::from("hello2"),
         key_history_proof,
         HistoryVerificationParams::default(),
     )?;
 
     // Key history proof for "hello3"
     let (key_history_proof, _) = akd
-        .key_history(&AkdLabel::from_utf8_str("hello3"), HistoryParams::default())
+        .key_history(&AkdLabel::from("hello3"), HistoryParams::default())
         .await?;
     // Check that the correct number of proofs are sent
     if key_history_proof.update_proofs.len() != 2 {
@@ -434,14 +389,14 @@ async fn test_simple_key_history() -> Result<(), AkdError> {
         vrf_pk.as_bytes(),
         root_hash,
         current_epoch,
-        AkdLabel::from_utf8_str("hello3"),
+        AkdLabel::from("hello3"),
         key_history_proof,
         HistoryVerificationParams::default(),
     )?;
 
     // Key history proof for "hello4"
     let (key_history_proof, _) = akd
-        .key_history(&AkdLabel::from_utf8_str("hello4"), HistoryParams::default())
+        .key_history(&AkdLabel::from("hello4"), HistoryParams::default())
         .await?;
     // Check that the correct number of proofs are sent
     if key_history_proof.update_proofs.len() != 2 {
@@ -454,7 +409,7 @@ async fn test_simple_key_history() -> Result<(), AkdError> {
         vrf_pk.as_bytes(),
         root_hash,
         current_epoch,
-        AkdLabel::from_utf8_str("hello4"),
+        AkdLabel::from("hello4"),
         key_history_proof.clone(),
         HistoryVerificationParams::default(),
     )?;
@@ -466,7 +421,7 @@ async fn test_simple_key_history() -> Result<(), AkdError> {
         vrf_pk.as_bytes(),
         root_hash,
         current_epoch,
-        AkdLabel::from_utf8_str("hello4"),
+        AkdLabel::from("hello4"),
         borked_proof,
         HistoryVerificationParams::default(),
     );
@@ -493,8 +448,8 @@ async fn test_complex_verification_many_versions() -> Result<(), AkdError> {
         let mut to_insert = vec![];
         for i in 0..num_labels {
             let index = 1 << i;
-            let label = AkdLabel::from_utf8_str(format!("{index}").as_str());
-            let value = AkdValue::from_utf8_str(format!("{index},{epoch}").as_str());
+            let label = AkdLabel::from(format!("{index}").as_str());
+            let value = AkdValue::from(format!("{index},{epoch}").as_str());
             if epoch % index == 0 {
                 to_insert.push((label, value));
             }
@@ -518,9 +473,8 @@ async fn test_complex_verification_many_versions() -> Result<(), AkdError> {
                 continue;
             }
             let latest_added_epoch = epoch_hash.epoch() - (epoch_hash.epoch() % index);
-            let label = AkdLabel::from_utf8_str(format!("{index}").as_str());
-            let lookup_value =
-                AkdValue::from_utf8_str(format!("{index},{latest_added_epoch}").as_str());
+            let label = AkdLabel::from(format!("{index}").as_str());
+            let lookup_value = AkdValue::from(format!("{index},{latest_added_epoch}").as_str());
 
             let (lookup_proof, epoch_hash_from_lookup) = akd.lookup(label.clone()).await?;
             assert_eq!(epoch_hash, epoch_hash_from_lookup);
@@ -548,8 +502,7 @@ async fn test_complex_verification_many_versions() -> Result<(), AkdError> {
             for (j, res) in history_results.iter().enumerate() {
                 let added_in_epoch =
                     epoch_hash.epoch() - (epoch_hash.epoch() % index) - (j as u64) * index;
-                let history_value =
-                    AkdValue::from_utf8_str(format!("{index},{added_in_epoch}").as_str());
+                let history_value = AkdValue::from(format!("{index},{added_in_epoch}").as_str());
                 assert_eq!(res.epoch, added_in_epoch);
                 assert_eq!(res.value, history_value);
                 assert_eq!(res.version, epoch / index - j as u64);
@@ -572,86 +525,50 @@ async fn test_limited_key_history() -> Result<(), AkdError> {
 
     // epoch 1
     akd.publish(vec![
-        (
-            AkdLabel::from_utf8_str("hello"),
-            AkdValue::from_utf8_str("world"),
-        ),
-        (
-            AkdLabel::from_utf8_str("hello2"),
-            AkdValue::from_utf8_str("world2"),
-        ),
+        (AkdLabel::from("hello"), AkdValue::from("world")),
+        (AkdLabel::from("hello2"), AkdValue::from("world2")),
     ])
     .await?;
 
     // epoch 2
     akd.publish(vec![
-        (
-            AkdLabel::from_utf8_str("hello"),
-            AkdValue::from_utf8_str("world_2"),
-        ),
-        (
-            AkdLabel::from_utf8_str("hello2"),
-            AkdValue::from_utf8_str("world2_2"),
-        ),
+        (AkdLabel::from("hello"), AkdValue::from("world_2")),
+        (AkdLabel::from("hello2"), AkdValue::from("world2_2")),
     ])
     .await?;
 
     // epoch 3
     akd.publish(vec![
-        (
-            AkdLabel::from_utf8_str("hello"),
-            AkdValue::from_utf8_str("world3"),
-        ),
-        (
-            AkdLabel::from_utf8_str("hello2"),
-            AkdValue::from_utf8_str("world4"),
-        ),
+        (AkdLabel::from("hello"), AkdValue::from("world3")),
+        (AkdLabel::from("hello2"), AkdValue::from("world4")),
     ])
     .await?;
 
     // epoch 4
     akd.publish(vec![
-        (
-            AkdLabel::from_utf8_str("hello3"),
-            AkdValue::from_utf8_str("world"),
-        ),
-        (
-            AkdLabel::from_utf8_str("hello4"),
-            AkdValue::from_utf8_str("world2"),
-        ),
+        (AkdLabel::from("hello3"), AkdValue::from("world")),
+        (AkdLabel::from("hello4"), AkdValue::from("world2")),
     ])
     .await?;
 
     // epoch 5
     akd.publish(vec![(
-        AkdLabel::from_utf8_str("hello"),
-        AkdValue::from_utf8_str("world_updated"),
+        AkdLabel::from("hello"),
+        AkdValue::from("world_updated"),
     )])
     .await?;
 
     // epoch 6
     akd.publish(vec![
-        (
-            AkdLabel::from_utf8_str("hello3"),
-            AkdValue::from_utf8_str("world6"),
-        ),
-        (
-            AkdLabel::from_utf8_str("hello4"),
-            AkdValue::from_utf8_str("world12"),
-        ),
+        (AkdLabel::from("hello3"), AkdValue::from("world6")),
+        (AkdLabel::from("hello4"), AkdValue::from("world12")),
     ])
     .await?;
 
     // epoch 7
     akd.publish(vec![
-        (
-            AkdLabel::from_utf8_str("hello3"),
-            AkdValue::from_utf8_str("world7"),
-        ),
-        (
-            AkdLabel::from_utf8_str("hello4"),
-            AkdValue::from_utf8_str("world13"),
-        ),
+        (AkdLabel::from("hello3"), AkdValue::from("world7")),
+        (AkdLabel::from("hello4"), AkdValue::from("world13")),
     ])
     .await?;
     // Get the VRF public key
@@ -663,10 +580,7 @@ async fn test_limited_key_history() -> Result<(), AkdError> {
 
     // "hello" was updated in epochs 1,2,3,5. Pull the latest item from the history (i.e. a lookup proof)
     let (history_proof, root_hash) = akd
-        .key_history(
-            &AkdLabel::from_utf8_str("hello"),
-            HistoryParams::MostRecent(1),
-        )
+        .key_history(&AkdLabel::from("hello"), HistoryParams::MostRecent(1))
         .await?;
     assert_eq!(1, history_proof.update_proofs.len());
     assert_eq!(5, history_proof.update_proofs[0].epoch);
@@ -676,17 +590,14 @@ async fn test_limited_key_history() -> Result<(), AkdError> {
         vrf_pk.as_bytes(),
         root_hash.hash(),
         current_epoch,
-        AkdLabel::from_utf8_str("hello"),
+        AkdLabel::from("hello"),
         history_proof,
         HistoryVerificationParams::default(),
     )?;
 
     // Take the top 3 results, and check that we're getting the right epoch updates
     let (history_proof, root_hash) = akd
-        .key_history(
-            &AkdLabel::from_utf8_str("hello"),
-            HistoryParams::MostRecent(3),
-        )
+        .key_history(&AkdLabel::from("hello"), HistoryParams::MostRecent(3))
         .await?;
     assert_eq!(3, history_proof.update_proofs.len());
     assert_eq!(5, history_proof.update_proofs[0].epoch);
@@ -698,17 +609,14 @@ async fn test_limited_key_history() -> Result<(), AkdError> {
         vrf_pk.as_bytes(),
         root_hash.hash(),
         current_epoch,
-        AkdLabel::from_utf8_str("hello"),
+        AkdLabel::from("hello"),
         history_proof,
         HistoryVerificationParams::default(),
     )?;
 
     // "hello" was updated in epochs 1,2,3,5. Pull the updates since epoch 3 (inclusive)
     let (history_proof, root_hash) = akd
-        .key_history(
-            &AkdLabel::from_utf8_str("hello"),
-            HistoryParams::SinceEpoch(3),
-        )
+        .key_history(&AkdLabel::from("hello"), HistoryParams::SinceEpoch(3))
         .await?;
     assert_eq!(2, history_proof.update_proofs.len());
     assert_eq!(5, history_proof.update_proofs[0].epoch);
@@ -719,7 +627,7 @@ async fn test_limited_key_history() -> Result<(), AkdError> {
         vrf_pk.as_bytes(),
         root_hash.hash(),
         current_epoch,
-        AkdLabel::from_utf8_str("hello"),
+        AkdLabel::from("hello"),
         history_proof,
         HistoryVerificationParams::default(),
     )?;
@@ -742,26 +650,20 @@ async fn test_malicious_key_history() -> Result<(), AkdError> {
     let akd = Directory::<_, _>::new(storage, vrf, false).await?;
     // Publish the first value for the label "hello"
     // Epoch here will be 1
-    akd.publish(vec![(
-        AkdLabel::from_utf8_str("hello"),
-        AkdValue::from_utf8_str("world"),
-    )])
-    .await?;
+    akd.publish(vec![(AkdLabel::from("hello"), AkdValue::from("world"))])
+        .await?;
     // Publish the second value for the label "hello" without marking the first value as stale
     // Epoch here will be 2
-    let corruption_2 = PublishCorruption::UnmarkedStaleVersion(AkdLabel::from_utf8_str("hello"));
+    let corruption_2 = PublishCorruption::UnmarkedStaleVersion(AkdLabel::from("hello"));
     akd.publish_malicious_update(
-        vec![(
-            AkdLabel::from_utf8_str("hello"),
-            AkdValue::from_utf8_str("world2"),
-        )],
+        vec![(AkdLabel::from("hello"), AkdValue::from("world2"))],
         corruption_2,
     )
     .await?;
 
     // Get the key_history_proof for the label "hello"
     let (key_history_proof, root_hash) = akd
-        .key_history(&AkdLabel::from_utf8_str("hello"), HistoryParams::default())
+        .key_history(&AkdLabel::from("hello"), HistoryParams::default())
         .await?;
     // Get the VRF public key
     let vrf_pk = akd.get_public_key().await?;
@@ -771,26 +673,23 @@ async fn test_malicious_key_history() -> Result<(), AkdError> {
         vrf_pk.as_bytes(),
         root_hash.hash(),
         root_hash.epoch(),
-        AkdLabel::from_utf8_str("hello"),
+        AkdLabel::from("hello"),
         key_history_proof,
         HistoryVerificationParams::default(),
     ).expect_err("The key history proof should fail here since the previous value was not marked stale at all");
 
     // Mark the first value for the label "hello" as stale
     // Epoch here will be 3
-    let corruption_3 = PublishCorruption::MarkVersionStale(AkdLabel::from_utf8_str("hello"), 1);
+    let corruption_3 = PublishCorruption::MarkVersionStale(AkdLabel::from("hello"), 1);
     akd.publish_malicious_update(
-        vec![(
-            AkdLabel::from_utf8_str("hello2"),
-            AkdValue::from_utf8_str("world"),
-        )],
+        vec![(AkdLabel::from("hello2"), AkdValue::from("world"))],
         corruption_3,
     )
     .await?;
 
     // Get the key_history_proof for the label "hello"
     let (key_history_proof, root_hash) = akd
-        .key_history(&AkdLabel::from_utf8_str("hello"), HistoryParams::default())
+        .key_history(&AkdLabel::from("hello"), HistoryParams::default())
         .await?;
     // Get the VRF public key
     let vrf_pk = akd.get_public_key().await?;
@@ -799,7 +698,7 @@ async fn test_malicious_key_history() -> Result<(), AkdError> {
         vrf_pk.as_bytes(),
         root_hash.hash(),
         root_hash.epoch(),
-        AkdLabel::from_utf8_str("hello"),
+        AkdLabel::from("hello"),
         key_history_proof,
         HistoryVerificationParams::default(),
     ).expect_err("The key history proof should fail here since the previous value was marked stale one epoch too late.");
@@ -817,14 +716,8 @@ async fn test_simple_audit() -> Result<(), AkdError> {
     let akd = Directory::<_, _>::new(storage, vrf, false).await?;
 
     akd.publish(vec![
-        (
-            AkdLabel::from_utf8_str("hello"),
-            AkdValue::from_utf8_str("world"),
-        ),
-        (
-            AkdLabel::from_utf8_str("hello2"),
-            AkdValue::from_utf8_str("world2"),
-        ),
+        (AkdLabel::from("hello"), AkdValue::from("world")),
+        (AkdLabel::from("hello2"), AkdValue::from("world2")),
     ])
     .await?;
 
@@ -834,14 +727,8 @@ async fn test_simple_audit() -> Result<(), AkdError> {
         .await?;
 
     akd.publish(vec![
-        (
-            AkdLabel::from_utf8_str("hello"),
-            AkdValue::from_utf8_str("world_2"),
-        ),
-        (
-            AkdLabel::from_utf8_str("hello2"),
-            AkdValue::from_utf8_str("world2_2"),
-        ),
+        (AkdLabel::from("hello"), AkdValue::from("world_2")),
+        (AkdLabel::from("hello2"), AkdValue::from("world2_2")),
     ])
     .await?;
 
@@ -851,14 +738,8 @@ async fn test_simple_audit() -> Result<(), AkdError> {
         .await?;
 
     akd.publish(vec![
-        (
-            AkdLabel::from_utf8_str("hello"),
-            AkdValue::from_utf8_str("world3"),
-        ),
-        (
-            AkdLabel::from_utf8_str("hello2"),
-            AkdValue::from_utf8_str("world4"),
-        ),
+        (AkdLabel::from("hello"), AkdValue::from("world3")),
+        (AkdLabel::from("hello2"), AkdValue::from("world4")),
     ])
     .await?;
 
@@ -868,14 +749,8 @@ async fn test_simple_audit() -> Result<(), AkdError> {
         .await?;
 
     akd.publish(vec![
-        (
-            AkdLabel::from_utf8_str("hello3"),
-            AkdValue::from_utf8_str("world"),
-        ),
-        (
-            AkdLabel::from_utf8_str("hello4"),
-            AkdValue::from_utf8_str("world2"),
-        ),
+        (AkdLabel::from("hello3"), AkdValue::from("world")),
+        (AkdLabel::from("hello4"), AkdValue::from("world2")),
     ])
     .await?;
 
@@ -885,8 +760,8 @@ async fn test_simple_audit() -> Result<(), AkdError> {
         .await?;
 
     akd.publish(vec![(
-        AkdLabel::from_utf8_str("hello"),
-        AkdValue::from_utf8_str("world_updated"),
+        AkdLabel::from("hello"),
+        AkdValue::from("world_updated"),
     )])
     .await?;
 
@@ -896,14 +771,8 @@ async fn test_simple_audit() -> Result<(), AkdError> {
         .await?;
 
     akd.publish(vec![
-        (
-            AkdLabel::from_utf8_str("hello3"),
-            AkdValue::from_utf8_str("world6"),
-        ),
-        (
-            AkdLabel::from_utf8_str("hello4"),
-            AkdValue::from_utf8_str("world12"),
-        ),
+        (AkdLabel::from("hello3"), AkdValue::from("world6")),
+        (AkdLabel::from("hello4"), AkdValue::from("world12")),
     ])
     .await?;
 
@@ -978,14 +847,8 @@ async fn test_read_during_publish() -> Result<(), AkdError> {
 
     // Publish once
     akd.publish(vec![
-        (
-            AkdLabel::from_utf8_str("hello"),
-            AkdValue::from_utf8_str("world"),
-        ),
-        (
-            AkdLabel::from_utf8_str("hello2"),
-            AkdValue::from_utf8_str("world2"),
-        ),
+        (AkdLabel::from("hello"), AkdValue::from("world")),
+        (AkdLabel::from("hello2"), AkdValue::from("world2")),
     ])
     .await?;
     // Get the root hash after the first publish
@@ -994,14 +857,8 @@ async fn test_read_during_publish() -> Result<(), AkdError> {
         .await?;
     // Publish updates for the same labels.
     akd.publish(vec![
-        (
-            AkdLabel::from_utf8_str("hello"),
-            AkdValue::from_utf8_str("world_2"),
-        ),
-        (
-            AkdLabel::from_utf8_str("hello2"),
-            AkdValue::from_utf8_str("world2_2"),
-        ),
+        (AkdLabel::from("hello"), AkdValue::from("world_2")),
+        (AkdLabel::from("hello2"), AkdValue::from("world2_2")),
     ])
     .await?;
 
@@ -1015,14 +872,8 @@ async fn test_read_during_publish() -> Result<(), AkdError> {
 
     // Publish for the third time
     akd.publish(vec![
-        (
-            AkdLabel::from_utf8_str("hello"),
-            AkdValue::from_utf8_str("world_3"),
-        ),
-        (
-            AkdLabel::from_utf8_str("hello2"),
-            AkdValue::from_utf8_str("world2_3"),
-        ),
+        (AkdLabel::from("hello"), AkdValue::from("world_3")),
+        (AkdLabel::from("hello2"), AkdValue::from("world2_3")),
     ])
     .await?;
 
@@ -1034,7 +885,7 @@ async fn test_read_during_publish() -> Result<(), AkdError> {
 
     // History proof should not contain the third epoch's update but still verify
     let (history_proof, root_hash) = akd
-        .key_history(&AkdLabel::from_utf8_str("hello"), HistoryParams::default())
+        .key_history(&AkdLabel::from("hello"), HistoryParams::default())
         .await?;
     // Get the VRF public key
     let vrf_pk = akd.get_public_key().await?;
@@ -1042,18 +893,18 @@ async fn test_read_during_publish() -> Result<(), AkdError> {
         vrf_pk.as_bytes(),
         root_hash.hash(),
         root_hash.epoch(),
-        AkdLabel::from_utf8_str("hello"),
+        AkdLabel::from("hello"),
         history_proof,
         HistoryVerificationParams::default(),
     )?;
 
     // Lookup proof should contain the checkpoint epoch's value and still verify
-    let (lookup_proof, root_hash) = akd.lookup(AkdLabel::from_utf8_str("hello")).await?;
-    assert_eq!(AkdValue::from_utf8_str("world_2"), lookup_proof.value);
+    let (lookup_proof, root_hash) = akd.lookup(AkdLabel::from("hello")).await?;
+    assert_eq!(AkdValue::from("world_2"), lookup_proof.value);
     lookup_verify(
         vrf_pk.as_bytes(),
         root_hash.hash(),
-        AkdLabel::from_utf8_str("hello"),
+        AkdLabel::from("hello"),
         lookup_proof,
     )?;
 
@@ -1104,14 +955,8 @@ async fn test_directory_polling_azks_change() -> Result<(), AkdError> {
 
     writer
         .publish(vec![
-            (
-                AkdLabel::from_utf8_str("hello"),
-                AkdValue::from_utf8_str("world"),
-            ),
-            (
-                AkdLabel::from_utf8_str("hello2"),
-                AkdValue::from_utf8_str("world2"),
-            ),
+            (AkdLabel::from("hello"), AkdValue::from("world")),
+            (AkdLabel::from("hello2"), AkdValue::from("world2")),
         ])
         .await?;
 
@@ -1131,19 +976,13 @@ async fn test_directory_polling_azks_change() -> Result<(), AkdError> {
     tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 
     // verify a lookup proof, which will populate the cache
-    async_poll_helper_proof(&reader, AkdValue::from_utf8_str("world")).await?;
+    async_poll_helper_proof(&reader, AkdValue::from("world")).await?;
 
     // publish epoch 2
     writer
         .publish(vec![
-            (
-                AkdLabel::from_utf8_str("hello"),
-                AkdValue::from_utf8_str("world_2"),
-            ),
-            (
-                AkdLabel::from_utf8_str("hello2"),
-                AkdValue::from_utf8_str("world2_2"),
-            ),
+            (AkdLabel::from("hello"), AkdValue::from("world_2")),
+            (AkdLabel::from("hello2"), AkdValue::from("world2_2")),
         ])
         .await?;
 
@@ -1151,7 +990,7 @@ async fn test_directory_polling_azks_change() -> Result<(), AkdError> {
     let notification = tokio::time::timeout(tokio::time::Duration::from_secs(10), rx.recv()).await;
     assert!(matches!(notification, Ok(Some(()))));
 
-    async_poll_helper_proof(&reader, AkdValue::from_utf8_str("world_2")).await?;
+    async_poll_helper_proof(&reader, AkdValue::from("world_2")).await?;
 
     Ok(())
 }
@@ -1165,39 +1004,24 @@ async fn test_tombstoned_key_history() -> Result<(), AkdError> {
     let akd = Directory::<_, _>::new(storage.clone(), vrf, false).await?;
 
     // epoch 1
-    akd.publish(vec![(
-        AkdLabel::from_utf8_str("hello"),
-        AkdValue::from_utf8_str("world"),
-    )])
-    .await?;
+    akd.publish(vec![(AkdLabel::from("hello"), AkdValue::from("world"))])
+        .await?;
 
     // epoch 2
-    akd.publish(vec![(
-        AkdLabel::from_utf8_str("hello"),
-        AkdValue::from_utf8_str("world2"),
-    )])
-    .await?;
+    akd.publish(vec![(AkdLabel::from("hello"), AkdValue::from("world2"))])
+        .await?;
 
     // epoch 3
-    akd.publish(vec![(
-        AkdLabel::from_utf8_str("hello"),
-        AkdValue::from_utf8_str("world3"),
-    )])
-    .await?;
+    akd.publish(vec![(AkdLabel::from("hello"), AkdValue::from("world3"))])
+        .await?;
 
     // epoch 4
-    akd.publish(vec![(
-        AkdLabel::from_utf8_str("hello"),
-        AkdValue::from_utf8_str("world4"),
-    )])
-    .await?;
+    akd.publish(vec![(AkdLabel::from("hello"), AkdValue::from("world4"))])
+        .await?;
 
     // epoch 5
-    akd.publish(vec![(
-        AkdLabel::from_utf8_str("hello"),
-        AkdValue::from_utf8_str("world5"),
-    )])
-    .await?;
+    akd.publish(vec![(AkdLabel::from("hello"), AkdValue::from("world5"))])
+        .await?;
 
     // Epochs 1-5, we're going to tombstone 1 & 2
 
@@ -1213,7 +1037,7 @@ async fn test_tombstoned_key_history() -> Result<(), AkdError> {
 
     // Now get a history proof for this key
     let (history_proof, root_hash) = akd
-        .key_history(&AkdLabel::from_utf8_str("hello"), HistoryParams::default())
+        .key_history(&AkdLabel::from("hello"), HistoryParams::default())
         .await?;
     assert_eq!(5, history_proof.update_proofs.len());
 
@@ -1222,7 +1046,7 @@ async fn test_tombstoned_key_history() -> Result<(), AkdError> {
         vrf_pk.as_bytes(),
         root_hash.hash(),
         root_hash.epoch(),
-        AkdLabel::from_utf8_str("hello"),
+        AkdLabel::from("hello"),
         history_proof.clone(),
         HistoryVerificationParams::default(),
     );
@@ -1234,7 +1058,7 @@ async fn test_tombstoned_key_history() -> Result<(), AkdError> {
         vrf_pk.as_bytes(),
         root_hash.hash(),
         root_hash.epoch(),
-        AkdLabel::from_utf8_str("hello"),
+        AkdLabel::from("hello"),
         history_proof,
         HistoryVerificationParams::AllowMissingValues,
     )?;
@@ -1359,7 +1183,7 @@ async fn test_simple_lookup_for_small_tree_blake() -> Result<(), AkdError> {
         VerifyResult {
             epoch: 1,
             version: 1,
-            value: AkdValue::from_utf8_str("hello10"),
+            value: AkdValue::from("hello10"),
         },
     );
 
@@ -1432,13 +1256,13 @@ async fn async_poll_helper_proof<T: Database + 'static, V: VRFKeyStorage>(
     value: AkdValue,
 ) -> Result<(), AkdError> {
     // reader should read "hello" and this will populate the "cache" a log
-    let (lookup_proof, root_hash) = reader.lookup(AkdLabel::from_utf8_str("hello")).await?;
+    let (lookup_proof, root_hash) = reader.lookup(AkdLabel::from("hello")).await?;
     assert_eq!(value, lookup_proof.value);
     let pk = reader.get_public_key().await?;
     lookup_verify(
         pk.as_bytes(),
         root_hash.hash(),
-        AkdLabel::from_utf8_str("hello"),
+        AkdLabel::from("hello"),
         lookup_proof,
     )?;
     Ok(())

--- a/akd/src/tree_node.rs
+++ b/akd/src/tree_node.rs
@@ -522,7 +522,7 @@ fn optional_child_state_label_hash(input: &Option<TreeNode>, hash_mode: NodeHash
             if let (TreeNodeType::Leaf, NodeHashingMode::WithLeafEpoch) =
                 (child_state.node_type, hash_mode)
             {
-                hash = crate::hash::merge_with_int(hash, child_state.last_epoch);
+                hash = crate::hash::merge_with_u64(hash, child_state.last_epoch);
             }
             merge_digest_with_label_hash(&hash, child_state.label)
         }
@@ -534,7 +534,7 @@ pub(crate) fn optional_child_state_hash(input: &Option<TreeNode>) -> Digest {
     match input {
         Some(child_state) => {
             if child_state.node_type == TreeNodeType::Leaf {
-                crate::hash::merge_with_int(child_state.hash, child_state.last_epoch)
+                crate::hash::merge_with_u64(child_state.hash, child_state.last_epoch)
             } else {
                 child_state.hash
             }
@@ -720,12 +720,12 @@ mod tests {
 
         // Calculate expected root hash.
         let leaf_0_hash = crate::hash::merge(&[
-            crate::hash::merge_with_int(crate::hash::hash(&EMPTY_VALUE), 0),
+            crate::hash::merge_with_u64(crate::hash::hash(&EMPTY_VALUE), 0),
             hash_label(leaf_0.label),
         ]);
 
         let leaf_1_hash = crate::hash::merge(&[
-            crate::hash::merge_with_int(crate::hash::hash(&[1u8]), 0),
+            crate::hash::merge_with_u64(crate::hash::hash(&[1u8]), 0),
             hash_label(leaf_1.label),
         ]);
 
@@ -796,17 +796,17 @@ mod tests {
         root.write_to_storage(&db, false).await?;
 
         let leaf_0_hash = crate::hash::merge(&[
-            crate::hash::merge_with_int(crate::hash::hash(&EMPTY_VALUE), 1),
+            crate::hash::merge_with_u64(crate::hash::hash(&EMPTY_VALUE), 1),
             hash_label(leaf_0.label),
         ]);
 
         let leaf_1_hash = crate::hash::merge(&[
-            crate::hash::merge_with_int(crate::hash::hash(&[0b1u8]), 2),
+            crate::hash::merge_with_u64(crate::hash::hash(&[0b1u8]), 2),
             hash_label(leaf_1.label),
         ]);
 
         let leaf_2_hash = crate::hash::merge(&[
-            crate::hash::merge_with_int(crate::hash::hash(&[1u8, 1u8]), 3),
+            crate::hash::merge_with_u64(crate::hash::hash(&[1u8, 1u8]), 3),
             hash_label(leaf_2.label),
         ]);
 
@@ -899,21 +899,21 @@ mod tests {
         root.write_to_storage(&db, false).await?;
 
         let leaf_0_hash = crate::hash::merge(&[
-            crate::hash::merge_with_int(crate::hash::hash(&EMPTY_VALUE), 1),
+            crate::hash::merge_with_u64(crate::hash::hash(&EMPTY_VALUE), 1),
             hash_label(leaf_0.label),
         ]);
 
         let leaf_1_hash = crate::hash::merge(&[
-            crate::hash::merge_with_int(crate::hash::hash(&[1u8]), 2),
+            crate::hash::merge_with_u64(crate::hash::hash(&[1u8]), 2),
             hash_label(leaf_1.label),
         ]);
         let leaf_2_hash = crate::hash::merge(&[
-            crate::hash::merge_with_int(crate::hash::hash(&[1u8, 1u8]), 3),
+            crate::hash::merge_with_u64(crate::hash::hash(&[1u8, 1u8]), 3),
             hash_label(leaf_2.label),
         ]);
 
         let leaf_3_hash = crate::hash::merge(&[
-            crate::hash::merge_with_int(crate::hash::hash(&[0u8, 1u8]), 4),
+            crate::hash::merge_with_u64(crate::hash::hash(&[0u8, 1u8]), 4),
             hash_label(leaf_3.label),
         ]);
 
@@ -964,7 +964,7 @@ mod tests {
                 7 - i,
             );
             leaf_hashes.push(crate::hash::merge(&[
-                crate::hash::merge_with_int(crate::hash::hash(&leaf_u64.to_be_bytes()), 7 - i),
+                crate::hash::merge_with_u64(crate::hash::hash(&leaf_u64.to_be_bytes()), 7 - i),
                 hash_label(new_leaf.label),
             ]));
             leaves.push(new_leaf);

--- a/akd_client/src/lib.rs
+++ b/akd_client/src/lib.rs
@@ -24,7 +24,7 @@
 //! 5. sha3_512: SHA3 512-bit hashing
 //!
 //! which dictate which hashing function is used by the verification components. Blake3 256-bit hashing is the default
-//! implementation and utilizes the [`blake3`] crate. Features sha256 and sha512 both utilize SHA2 cryptographic functions
+//! implementation and utilizes the `blake3` crate. Features sha256 and sha512 both utilize SHA2 cryptographic functions
 //! from the [`sha2`](https://crates.io/crates/sha2) crate. Lastly sha3_256 and sha3_512 features utilize the
 //! [`sha3`](https://crates.io/crates/sha3) crate for their hashing implementations.
 //! To utilize a hash implementation other than blake3, you should compile with

--- a/akd_client/src/wasm.rs
+++ b/akd_client/src/wasm.rs
@@ -159,15 +159,12 @@ pub mod tests {
             .await
             .expect("Failed to construct directory");
 
-        let target_label = AkdLabel::from_utf8_str("hello");
+        let target_label = AkdLabel::from("hello");
 
         // Add two labels and corresponding values to the akd
         akd.publish(vec![
-            (target_label.clone(), AkdValue::from_utf8_str("world")),
-            (
-                AkdLabel::from_utf8_str("hello2"),
-                AkdValue::from_utf8_str("world2"),
-            ),
+            (target_label.clone(), AkdValue::from("world")),
+            (AkdLabel::from("hello2"), AkdValue::from("world2")),
         ])
         .await
         .expect("Failed to publish test data");

--- a/akd_core/Cargo.toml
+++ b/akd_core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "akd_core"
 version = "0.8.6"
-authors = ["Sean Lawlor <seanlawlor@fb.com>"]
+authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Core utilities for the auditable-key-directory suite of crates (akd and akd_client)"
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/akd_core/benches/parallel_vrfs.rs
+++ b/akd_core/benches/parallel_vrfs.rs
@@ -10,6 +10,7 @@
 extern crate criterion;
 use self::criterion::*;
 use akd_core::ecvrf::{VRFExpandedPrivateKey, VRFPublicKey};
+use akd_core::VersionFreshness;
 use akd_core::{ecvrf::VRFKeyStorage, AkdLabel};
 use rand::distributions::Alphanumeric;
 use rand::Rng;
@@ -18,7 +19,7 @@ fn bench_single_vrf(c: &mut Criterion) {
     let rng = rand::rngs::OsRng;
 
     // Generate a random label
-    let label = AkdLabel::from_utf8_str(
+    let label = AkdLabel::from(
         &rng.sample_iter(&Alphanumeric)
             .take(32)
             .map(char::from)
@@ -38,7 +39,7 @@ fn bench_single_vrf(c: &mut Criterion) {
                 &expanded_key,
                 &pk,
                 &label,
-                false,
+                VersionFreshness::Fresh,
                 1,
             );
         })
@@ -59,7 +60,7 @@ fn bench_parallel_vrfs(c: &mut Criterion) {
         .into_iter()
         .map(|i| {
             let name = format!("user {}", i);
-            (AkdLabel::from_utf8_str(&name), false, i as u64)
+            (AkdLabel::from(&name), VersionFreshness::Fresh, i as u64)
         })
         .collect::<Vec<_>>();
     let labels_clone = labels.clone();

--- a/akd_core/src/hash/tests.rs
+++ b/akd_core/src/hash/tests.rs
@@ -110,7 +110,7 @@ fn test_merge_validity() {
 fn test_merge_int_validity() {
     let random_epoch = thread_rng().gen::<u64>();
     let random_hash = random_hash();
-    let merged = merge_with_int(random_hash, random_epoch);
+    let merged = merge_with_u64(random_hash, random_epoch);
 
     let data = vec![random_hash.to_vec(), random_epoch.to_be_bytes().to_vec()].concat();
     let expected = hash(&data);

--- a/akd_core/src/lib.rs
+++ b/akd_core/src/lib.rs
@@ -15,50 +15,161 @@
 //! or `default-features = false` in your Cargo.toml import to disable all the default features
 //! which you can then enable one-by-one as you wish.
 //!
-//! # Incorporating label-value pairs into the tree
+//! In the following, we will cover the protocol-level implementation details behind:
+//! - The setup parameters for an AKD
+//! - How the tree (and its root hash) is constructed from a set of `([AkdLabel], [AkdValue])` pairs
+//! - How lookup, history, and audit proofs work
 //!
-//! When inserting a ([AkdLabel], [AkdValue]) pair into the tree, the server commits to the [AkdValue]
-//! and invokes a VRF on the [AkdLabel]. Together, these two processes form what is actually stored
-//! as a node in the tree.
+//! # Setup parameters
 //!
-//! ## VRF on the [AkdLabel]
+//! An AKD is configured by a set of parameters, which are set by the server when it is initialized. The server
+//! picks a random VRF private key `vsk` and derives (and distributes) a public key `vpk` to its clients. The server also
+//! produces a commitment key (`commitment_key`) by hashing the VRF private key. The VRF private key will be used to provide
+//! selective privacy of the database's inserted labels to auditors and other clients, while the commitment key
+//! will be used to provide privacy over the database's inserted values. Hence, both `vsk` and `commitment_key` must be kept
+//! private to the server and not leaked to any clients.
 //!
-//! The position in which this value lies is determined by the [NodeLabel], which is the output
-//! of a VRF evaluation of the [AkdLabel] and the current epoch. This is computed by the
-//! `get_hash_from_label_input` function, which sets the node label to be the output of a VRF, with
+//! # Inserting into the Merkle Tree
+//!
+//! The [Merkle Patricia Tree](https://eprint.iacr.org/2016/683.pdf) is a perfect binary tree consisting
+//! of nodes that are associated with a [NodeLabel] and a 32-byte value (its hash). There are three types
+//! of nodes in the tree: the root node, the interior nodes, and the leaf nodes.
+//! The leaf nodes of the tree are positioned based on their [NodeLabel], with a hash derived from the
+//! leaf node's value and the epoch it was inserted into the tree. The interior nodes of the tree each consist
+//! of two child nodes, with their [NodeLabel] being the longest common prefix of their two children's [NodeLabel]s.
+//! The hash of an interior node is derived as the concatenation of the hashes of its two children along with their
+//! labels. The root node always has a label of 0, and its hash is the hash of its two children's labels.
+//!
+//! There are multiple steps for inserting a single ([AkdLabel], [AkdValue]) pair into the tree:
+//!
+//! ## Step 1: Deriving the NodeLabel
+//!
+//! The server computes a VRF on [AkdLabel] to derive a [NodeLabel] which determines the leaf's position in the tree.
+//! This is computed by the
+//! `[akd::utils::get_hash_from_label_input]` function, which sets the node label to be the output of a VRF, with
 //! the input to the VRF computed as:
-//! `vrf_input = H(label, stale, version)`
+//! `vrf_input = Hash(label, staleness, version)`
 //!
 //! Specifically, we concatenate the following together:
-//! - `I2OSP(len(label) as u64, label)`
+//! - `I2OSP(len(label) as u64)`
+//! - The label in bytes
 //! - A single byte encoded as `0u8` if "stale", `1u8` if "fresh"
-//! - A `u64` representing the version
-//! The resulting values are hashed together and used as the bytestring (truncated to 256 bits,
-//! if necessary) that determines the exact location of the node in the tree.
+//! - A `u64` representing the version (starting at 1 for newly inserted labels, and incremented by 1 for each update)
+//! The resulting values are hashed together and used as the bytestring (truncated to 256 bits) that is stored
+//! as the [NodeLabel]'s value.
 //!
-//! In the event that the label already exists in the tree, an additional stale label will be
-//! added to the tree, with an empty value associated with it.
+//! The server then computes a VRF on the [NodeLabel] to derive a value for the leaf node. This is computed as:
+//! `node_label = VRF(vsk, vrf_input)`.
 //!
-//! ## Committing to an [AkdValue]
+//! Once the node label for this entry is derived (as `node_label`), the function [utils::commit_value]
+//! is used to commit the [AkdValue] to the tree. The actual value
+//! that is stored in the node is a commitment, generated using the server's commitment key as follows:
+//! - `commitment_nonce = Hash(commitment_key, node_label, version, I2OSP(len(value) as u64), value)`
+//! - `commmitment = Hash(I2OSP(len(value) as u64), value, I2OSP(len(commitment_nonce) as u64), commitment_nonce)`
 //!
-//! The function [akd_core::commit_value] is used to commit the [AkdValue] to the tree. The actual value
-//! that is stored in the node is a commitment, generated as follows:
-//! - `nonce = H(commitment_key, label, version, i2osp_array(value))`
-//! - `commmitment = H(i2osp_array(value), i2osp_array(nonce))`
+//! Finally, the commitment is hashed together with the epoch that it ends up being inserted into the tree,
+//! computed as: `node_value = Hash(commitment, epoch)`
 //!
-//! Finally, the commitment is hashed together with the epoch that it ends up being inserted into the tree
-//! computed as: `value_stored_in_node = H(commitment, epoch)`
+//! For each entry, the server constructs `node_label` and `node_value` in the above-described manner with staleness set to [VersionFreshness::Fresh] and
+//! `version` to `1`. If this is the `n`th time the label is being inserted into the tree where `n > 1`, then the server constructs two
+//! (`node_label`, `node_value`) pairs,
+//! one with `version` set to `n-1` and freshness set to [VersionFreshness::Stale] with `node_value = Hash(0u8)`, and the other
+//! with `version` set to `n` and freshness set to [VersionFreshness::Fresh], and `node_value` derived as above.
 //!
-//! Here, `commitment_key` is a secret random value held by the server for the purposes of generating
-//! these commitments.
+//! ## Step 2: Inserting a node label and value pair into the tree
 //!
-//! A client can then verify that the value stored in the tree is the same as the value they are expecting
-//! upon requesting a [LookupProof] or [HistoryProof] which includes this commitment prononceof, and can then
-//! insert their expected value and verify that it matches the node's value (indirectly, through an inclusion
-//! proof in the Merkle tree). Note that without the commitment nonce, a value cannot be verified, which
-//! is a privacy feature that prevents an auditor from learning the value of a node.
+//! In order to insert a single node label and value pair into the tree, the server constructs a leaf node `new_node` with this
+//! [NodeLabel] and commitment value, and identifies the leaf node `lcp_node` with the longest common prefix with this node in the tree.
+//! It creates an interior node with this prefix as its label, and makes `new_node` and `lcp_node` siblings based on the ordering of
+//! their [NodeLabel]s. The hash for this interior node is computed as the concatenation of the hashes of its two children along with
+//! their labels, explicitly as:
+//! `interior_node.label = longest_common_prefix(lcp_node.label, new_node.label)`
+//! `interior_node.hash = Hash(Hash(lcp_node.hash, lcp_node.label), Hash(new_node.hash, new_node.label))`.
+//! The server then traverses up the tree, updating the hashes of all the interior nodes it encounters, until it reaches the root.
 //!
+//! In the case of the root node, which may have only one child (or zero children in the event of an empty database), for the
+//! purposes of deriving the root node's hash, the missing child's hash is set to `Hash(`[EMPTY_VALUE]`)`, and the label is set to [EMPTY_LABEL].
+//! The final root hash output by the tree is then computed as: `Hash(root_node.hash, `[NodeLabel::root()]`)`.
 //!
+//! Conceptually, to insert multiple entries into the tree, the above process is repeated iteratively for each entry. In the implementation
+//! of the tree, however, the entries are inserted in batches, and the tree is updated in a single pass.
+//!
+//! # Generating and verifying proofs
+//!
+//! AKD supports three types of proofs: lookup proofs, history proofs, and audit proofs. A lookup proof is used to prove that
+//! a given label and value are present in the database. A history proof returns all the history of all values corresponding to
+//! a given label, and an audit proof is used to prove to an auditor that the database is being maintained in a consistent
+//! and append-only manner. The first two types of proofs rely on the ability to provide membership and non-membership proofs
+//! for the tree.
+//!
+//! ### Membership and non-membership proofs
+//!
+//! A Merkle Patricia Tree supports membership and non-membership proofs for its leaf nodes. For a given [NodeLabel] and value,
+//! the server can produce a membership proof by traversing the tree from the root node to the leaf node corresponding to the
+//! target `node_label`. A [MembershipProof] for a `node_label` and value consists of the following:
+//! - The `node_label` of the leaf node
+//! - The hashed value of the leaf node (hash of the `node_value` and the epoch that the node was inserted in)
+//! - The hashes and labels of the sibling nodes along the path to the root
+//!
+//! A client verifies this proof by iteratively traversing up the tree and computing the hash of the sibling nodes along the
+//! path from the leaf node to the root node. If the computed root hash matches
+//! the client's expected root hash, the proof is considered valid.
+//!
+//! A [NonMembershipProof] for a `node_label` consists of the following:
+//! - The node in the tree with the longest common prefix with the target label
+//! - A membership proof for this node
+//! - The two children of this node
+//!
+//! A client verifies this proof by verifying the membership proof for the node with the longest common prefix, verifying that
+//! the two children's hashes will hash to the node, and finally that the target label is not equal to either of the children's
+//! node labels.
+//!
+//! ## Lookup proofs
+//!
+//! A client is able to query for the stored [AkdValue] corresponding to the [AkdLabel] and a target root hash. The server
+//! returns a [LookupProof] which can be verified to extract a [VerifyResult], which contains
+//! the corresponding [AkdValue], along with the epoch it was inserted in and the version
+//! for the label.
+//!
+//! Let `n` be the current version, and let `m` be the largest power
+//! of 2 that is at most `n`. The [LookupProof] consists of:
+//! - The `commitment_nonce` corresponding to the value, which the client
+//! can hash together with the value to reconstruct the commitment
+//! - A membership and VRF proof for version `n` being marked as fresh
+//! - A non-membership and VRF proof for version `n` being marked as stale
+//! - A membership and VRF proof for version `m` being marked as fresh
+//!
+//! The client can then verify that `commitment_nonce` produces the proof's hash value, and that the
+//! three subproofs are valid.
+//!
+//! ## History proofs
+//!
+//! A client can query for a history of all of the versions associated with a given [AkdLabel].
+//! The server returns a [HistoryProof] which can be verified to extract a list of [VerifyResult]s, one for each
+//! version.
+//!
+//! Let `n` be the latest version, `n_next_pow` the next power of 2 after `n`, and `epoch_prev_pow` be the power of 2 that
+//! is at most the current epoch. The [HistoryProof] consists of:
+//! - A list of [UpdateProof]s, one for each version, which each contain a membership proof for the version `n` being fresh,
+//! and a membership proof for the version `n-1` being stale
+//! - A series of non-membership proofs for each version in the range `[n+1, n_next_pow]`
+//! - A series of non-membership proofs for each power of 2 in the range `[n_next_pow, epoch_prev_pow]`
+//!
+//! A client verifies this proof by first verifying each of the update proofs, checking that they are in decreasing
+//! consecutive order by version. Then, it verifies the remaining non-membership proofs.
+//!
+//! ## Audit proofs
+//!
+//! An audit proof allows for an auditor to verify, given two root hashes corresponding to consecutive epochs, that the first
+//! root hash corresponds to a tree that contains a subset of the values of the tree for the second root hash. In particular,
+//! no values were deleted or history altered betweeen the two epochs. The [AppendOnlyProof] consists of:
+//! - The hashes of each value that was added to the tree between the two epochs
+//! - The corresponding sibling nodes along the path from each of these added nodes to the root of the tree
+//!
+//! The client first verifies that the corresponding sibling nodes can be used to reconstruct the first epoch's root hash.
+//! Then, the client hashes each of the provided hash values with the epoch, and then verifies that the computed hashes can be used,
+//! alongside the sibling nodes, to reconstruct the second epoch's root hash. For audit proofs that span multiple epochs and root hashes,
+//! these checks are repeated iteratively.
 //!
 
 #![warn(missing_docs)]

--- a/akd_core/src/types/mod.rs
+++ b/akd_core/src/types/mod.rs
@@ -141,16 +141,25 @@ impl core::ops::DerefMut for AkdLabel {
     }
 }
 
-impl AkdLabel {
-    /// Build an [`AkdLabel`] struct from an UTF8 string
-    pub fn from_utf8_str(value: &str) -> Self {
-        Self(value.as_bytes().to_vec())
+impl core::convert::From<&str> for AkdLabel {
+    fn from(s: &str) -> Self {
+        Self(s.as_bytes().to_vec())
     }
+}
 
+impl core::convert::From<&String> for AkdLabel {
+    fn from(s: &String) -> Self {
+        Self(s.as_bytes().to_vec())
+    }
+}
+
+impl AkdLabel {
     #[cfg(feature = "rand")]
-    /// Gets a random value for a AKD
+    /// Gets a random label
     pub fn random<R: CryptoRng + Rng>(rng: &mut R) -> Self {
-        Self::from_utf8_str(&crate::utils::get_random_str(rng))
+        let mut bytes = [0u8; 32];
+        rng.fill_bytes(&mut bytes);
+        Self(bytes.to_vec())
     }
 }
 
@@ -192,16 +201,25 @@ impl core::ops::DerefMut for AkdValue {
     }
 }
 
-impl AkdValue {
-    /// Build an [`AkdValue`] struct from an UTF8 string
-    pub fn from_utf8_str(value: &str) -> Self {
-        Self(value.as_bytes().to_vec())
+impl core::convert::From<&str> for AkdValue {
+    fn from(s: &str) -> Self {
+        Self(s.as_bytes().to_vec())
     }
+}
 
+impl core::convert::From<&String> for AkdValue {
+    fn from(s: &String) -> Self {
+        Self(s.as_bytes().to_vec())
+    }
+}
+
+impl AkdValue {
     #[cfg(feature = "rand")]
     /// Gets a random value for a AKD
     pub fn random<R: CryptoRng + Rng>(rng: &mut R) -> Self {
-        Self::from_utf8_str(&crate::utils::get_random_str(rng))
+        let mut bytes = [0u8; 32];
+        rng.fill_bytes(&mut bytes);
+        Self(bytes.to_vec())
     }
 }
 
@@ -221,10 +239,10 @@ pub const TOMBSTONE: &[u8] = &[];
 
 /// Represents an element to be inserted into the AZKS. This
 /// is a pair consisting of a label ([NodeLabel]) and a value.
-/// The purpose of [Directory::publish] is to convert an
+/// The purpose of the directory publish is to convert an
 /// insertion set of ([AkdLabel], [AkdValue]) tuples into a
 /// set of [AzksElement]s, which are then inserted into
-/// the [Azks::batch_insert_leaves] function.
+/// the AZKS.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde_serialization",

--- a/akd_core/src/types/node_label/mod.rs
+++ b/akd_core/src/types/node_label/mod.rs
@@ -196,8 +196,8 @@ impl NodeLabel {
     /// except its last bit is flipped (e.g., 000 and 001 are siblings).
     /// This function returns the sibling prefix of a specified length.
     /// The rest of the node label after the flipped bit is padded with zeroes.
-    /// For instance, 010100 (length = 6) with sibling prefix length = 3 is 01[1]000 (length = 3)
-    /// -- [bit] denoting flipped bit.
+    /// For instance, 010100 (length = 6) with sibling prefix length = 3 is 01{1}000 (length = 3)
+    /// -- {bit} denoting flipped bit.
     pub fn get_sibling_prefix(&self, mut len: u32) -> Self {
         if len > self.get_len() {
             len = self.get_len();

--- a/akd_core/src/utils.rs
+++ b/akd_core/src/utils.rs
@@ -12,8 +12,6 @@ use crate::{AkdLabel, AkdValue, NodeLabel, VersionFreshness};
 
 #[cfg(feature = "nostd")]
 use alloc::vec::Vec;
-#[cfg(feature = "rand")]
-use rand::{distributions::Alphanumeric, CryptoRng, Rng};
 
 /// Retrieve log_2 of the marker version, referring to the exponent
 /// of the largest power of two that is at most the input version
@@ -41,7 +39,12 @@ pub(crate) fn generate_commitment_from_nonce_client(
 /// Hash a leaf epoch and proof with a given [AkdValue]
 pub(crate) fn hash_leaf_with_value(value: &crate::AkdValue, epoch: u64, proof: &[u8]) -> Digest {
     let commitment = crate::utils::generate_commitment_from_nonce_client(value, proof);
-    crate::hash::merge_with_int(commitment, epoch)
+    hash_leaf_with_commitment(commitment, epoch)
+}
+
+/// Hash a leaf epoch and proof with a given [AkdValue]
+pub(crate) fn hash_leaf_with_commitment(commitment: Digest, epoch: u64) -> Digest {
+    crate::hash::merge_with_u64(commitment, epoch)
 }
 
 /// Used by the server to produce a commitment proof for an AkdLabel, version, and AkdValue.
@@ -107,14 +110,6 @@ pub fn commit_value(
 ) -> Digest {
     let nonce = get_commitment_nonce(commitment_key, label, version, value);
     crate::hash::hash(&[i2osp_array(value), i2osp_array(&nonce)].concat())
-}
-
-#[cfg(feature = "rand")]
-pub(crate) fn get_random_str<R: CryptoRng + Rng>(rng: &mut R) -> String {
-    rng.sample_iter(&Alphanumeric)
-        .take(32)
-        .map(char::from)
-        .collect()
 }
 
 /// Serde serialization helpers

--- a/akd_local_auditor/src/common_test.rs
+++ b/akd_local_auditor/src/common_test.rs
@@ -76,21 +76,15 @@ pub async fn generate_audit_proofs(
                 .map(|item| {
                     let user = format!("user{}", item);
                     let value = format!("value{}_{}", _epoch, item);
-                    (
-                        AkdLabel::from_utf8_str(&user),
-                        AkdValue::from_utf8_str(&value),
-                    )
+                    (AkdLabel::from(&user), AkdValue::from(&value))
                 })
                 .collect::<Vec<(AkdLabel, AkdValue)>>();
             akd.publish(data).await?;
         } else {
             // generate (n) epochs of updates on the same user
             let t_value = format!("certificate{}", _epoch);
-            akd.publish(vec![(
-                AkdLabel::from_utf8_str("user"),
-                AkdValue::from_utf8_str(&t_value),
-            )])
-            .await?;
+            akd.publish(vec![(AkdLabel::from("user"), AkdValue::from(&t_value))])
+                .await?;
         }
         // generate the append-only proof
         let proof = akd.audit((_epoch - 1) as u64, _epoch as u64).await?;

--- a/akd_test_tools/src/fixture_generator/parser.rs
+++ b/akd_test_tools/src/fixture_generator/parser.rs
@@ -122,7 +122,7 @@ fn parse_user_events(s: &str) -> Result<User, String> {
                 let value: Option<AkdValue>;
                 if event.get(1).is_some() {
                     epoch = event.get(2).unwrap().as_str().parse().unwrap();
-                    value = Some(AkdValue::from_utf8_str(event.get(3).unwrap().as_str()));
+                    value = Some(AkdValue::from(event.get(3).unwrap().as_str()));
                 } else {
                     epoch = event.get(0).unwrap().as_str().parse().unwrap();
                     value = None;
@@ -135,7 +135,7 @@ fn parse_user_events(s: &str) -> Result<User, String> {
     };
 
     Ok(User {
-        label: AkdLabel::from_utf8_str(username),
+        label: AkdLabel::from(username),
         events,
     })
 }

--- a/akd_test_tools/src/test_suites.rs
+++ b/akd_test_tools/src/test_suites.rs
@@ -48,7 +48,7 @@ pub async fn directory_test_suite<S: Database + 'static, V: VRFKeyStorage>(
                 let mut data = Vec::new();
                 for value in users.iter() {
                     data.push((
-                        AkdLabel::from_utf8_str(value),
+                        AkdLabel::from(value),
                         AkdValue(format!("{}", i).as_bytes().to_vec()),
                     ));
                 }
@@ -62,7 +62,7 @@ pub async fn directory_test_suite<S: Database + 'static, V: VRFKeyStorage>(
 
             // Perform 10 random lookup proofs on the published users
             for user in users.iter().choose_multiple(&mut rng, 10) {
-                let key = AkdLabel::from_utf8_str(user);
+                let key = AkdLabel::from(user);
                 match dir.lookup(key.clone()).await {
                     Err(error) => panic!("Error looking up user information {:?}", error),
                     Ok((proof, root_hash)) => {
@@ -81,7 +81,7 @@ pub async fn directory_test_suite<S: Database + 'static, V: VRFKeyStorage>(
 
             // Perform 2 random history proofs on the published material
             for user in users.iter().choose_multiple(&mut rng, 2) {
-                let key = AkdLabel::from_utf8_str(user);
+                let key = AkdLabel::from(user);
                 match dir.key_history(&key, HistoryParams::default()).await {
                     Err(error) => panic!("Error performing key history retrieval {:?}", error),
                     Ok((proof, root_hash)) => {

--- a/integration_tests/src/test_util.rs
+++ b/integration_tests/src/test_util.rs
@@ -153,7 +153,7 @@ pub(crate) async fn test_lookups<S: Database + 'static, V: VRFKeyStorage>(
                 let mut data = Vec::new();
                 for value in users.iter() {
                     data.push((
-                        AkdLabel::from_utf8_str(value),
+                        AkdLabel::from(value),
                         AkdValue(format!("{}", i).as_bytes().to_vec()),
                     ));
                 }
@@ -170,7 +170,7 @@ pub(crate) async fn test_lookups<S: Database + 'static, V: VRFKeyStorage>(
             // Pick a set of users to lookup
             let mut labels = Vec::new();
             for user in users.iter().choose_multiple(&mut rng, num_lookups) {
-                let label = AkdLabel::from_utf8_str(user);
+                let label = AkdLabel::from(user);
                 labels.push(label);
             }
 

--- a/poc/src/directory_host.rs
+++ b/poc/src/directory_host.rs
@@ -60,10 +60,7 @@ where
             (DirectoryCommand::Publish(a, b), Some(response)) => {
                 let tic = Instant::now();
                 match directory
-                    .publish(vec![(
-                        AkdLabel::from_utf8_str(&a),
-                        AkdValue::from_utf8_str(&b),
-                    )])
+                    .publish(vec![(AkdLabel::from(&a), AkdValue::from(&b))])
                     .await
                 {
                     Ok(EpochHash(epoch, hash)) => {
@@ -91,12 +88,7 @@ where
                     .publish(
                         batches
                             .into_iter()
-                            .map(|(key, value)| {
-                                (
-                                    AkdLabel::from_utf8_str(&key),
-                                    AkdValue::from_utf8_str(&value),
-                                )
-                            })
+                            .map(|(key, value)| (AkdLabel::from(&key), AkdValue::from(&value)))
                             .collect(),
                     )
                     .await
@@ -113,13 +105,13 @@ where
                 }
             }
             (DirectoryCommand::Lookup(a), Some(response)) => {
-                match directory.lookup(AkdLabel::from_utf8_str(&a)).await {
+                match directory.lookup(AkdLabel::from(&a)).await {
                     Ok((proof, root_hash)) => {
                         let vrf_pk = directory.get_public_key().await.unwrap();
                         let verification = akd::client::lookup_verify(
                             vrf_pk.as_bytes(),
                             root_hash.hash(),
-                            AkdLabel::from_utf8_str(&a),
+                            AkdLabel::from(&a),
                             proof,
                         );
                         if verification.is_err() {
@@ -138,7 +130,7 @@ where
             }
             (DirectoryCommand::KeyHistory(a), Some(response)) => {
                 match directory
-                    .key_history(&AkdLabel::from_utf8_str(&a), HistoryParams::default())
+                    .key_history(&AkdLabel::from(&a), HistoryParams::default())
                     .await
                 {
                     Ok(_proof) => {

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -1,5 +1,13 @@
 This package is included here to support the automatic reporting of code coverage on 
-Github. To view code coverage locally:
+Github.
+
+## Current code coverage
+
+[![codecov](https://codecov.io/gh/facebook/akd/branch/main/graph/badge.svg?token=VFE82QWLTK)](https://codecov.io/gh/facebook/akd)
+
+<img src="https://codecov.io/gh/facebook/akd/branch/main/graphs/sunburst.svg?token=VFE82QWLTK">
+
+## Viewing code coverage locally
 
 Do this once to set it up:
 ```


### PR DESCRIPTION
- Adds CI tests for benchmarks and making docs
- Renames `from_utf8_str()` to `str()`
- Adds documentation for the `akd_core` crate to describe the cryptographic operations for inserting elements into the merkle tree and generating proofs
- Cleanups and reorganization around proof verification logic