### PR TITLE
Use dashmap for in-memory DB to improve audit verification perf

### DIFF
--- a/akd/benches/azks.rs
+++ b/akd/benches/azks.rs
@@ -65,7 +65,7 @@ fn batch_insertion(c: &mut Criterion) {
     });
 }
 
-fn audit(c: &mut Criterion) {
+fn audit_verify(c: &mut Criterion) {
     let num_initial_leaves = 10000;
     let num_inserted_leaves = 10000;
 
@@ -136,5 +136,5 @@ fn gen_nodes(rng: &mut impl Rng, num_nodes: usize) -> Vec<AzksElement> {
         .collect()
 }
 
-criterion_group!(azks_benches, batch_insertion, audit);
+criterion_group!(azks_benches, batch_insertion, audit_verify);
 criterion_main!(azks_benches);

--- a/akd/benches/azks.rs
+++ b/akd/benches/azks.rs
@@ -9,12 +9,13 @@
 extern crate criterion;
 
 use akd::append_only_zks::InsertMode;
+use akd::auditor;
 use akd::storage::manager::StorageManager;
 use akd::storage::memory::AsyncInMemoryDatabase;
 use akd::{Azks, AzksElement, NodeLabel};
 use criterion::{BatchSize, Criterion};
 use rand::rngs::StdRng;
-use rand::{RngCore, SeedableRng};
+use rand::{Rng, SeedableRng};
 
 fn batch_insertion(c: &mut Criterion) {
     let num_initial_leaves = 10000;
@@ -24,24 +25,10 @@ fn batch_insertion(c: &mut Criterion) {
     let runtime = tokio::runtime::Builder::new_multi_thread().build().unwrap();
 
     // prepare node set for initial leaves
-    let mut initial_node_set = vec![];
-    for _ in 0..num_initial_leaves {
-        let label = random_label(&mut rng);
-        let mut input = [0u8; 32];
-        rng.fill_bytes(&mut input);
-        let hash = akd_core::hash::hash(&input);
-        initial_node_set.push(AzksElement { label, value: hash });
-    }
+    let initial_node_set = gen_nodes(&mut rng, num_initial_leaves);
 
     // prepare node set for batch insertion
-    let mut node_set = vec![];
-    for _ in 0..num_inserted_leaves {
-        let label = random_label(&mut rng);
-        let mut input = [0u8; 32];
-        rng.fill_bytes(&mut input);
-        let hash = akd_core::hash::hash(&input);
-        node_set.push(AzksElement { label, value: hash });
-    }
+    let node_set = gen_nodes(&mut rng, num_inserted_leaves);
 
     // benchmark batch insertion
     let id = format!(
@@ -78,12 +65,76 @@ fn batch_insertion(c: &mut Criterion) {
     });
 }
 
-fn random_label(rng: &mut impl rand::Rng) -> NodeLabel {
-    NodeLabel {
-        label_val: rng.gen::<[u8; 32]>(),
-        label_len: 256,
-    }
+fn audit(c: &mut Criterion) {
+    let num_initial_leaves = 10000;
+    let num_inserted_leaves = 10000;
+
+    let mut rng = StdRng::seed_from_u64(42);
+    let runtime = tokio::runtime::Builder::new_multi_thread().build().unwrap();
+
+    // prepare node sets for start and end epochs
+    let initial_node_set = gen_nodes(&mut rng, num_initial_leaves);
+    let node_set = gen_nodes(&mut rng, num_inserted_leaves);
+
+    // benchmark audit verify
+    let id = format!(
+        "Audit verify (epoch 1: {} leaves, epoch 2: {} leaves)",
+        num_initial_leaves, num_inserted_leaves
+    );
+    c.bench_function(&id, move |b| {
+        b.iter_batched(
+            || {
+                let database = AsyncInMemoryDatabase::new();
+                let db = StorageManager::new(database, None, None, None);
+                let mut azks = runtime.block_on(Azks::new(&db)).unwrap();
+
+                // epoch 1
+                runtime
+                    .block_on(azks.batch_insert_nodes(
+                        &db,
+                        initial_node_set.clone(),
+                        InsertMode::Directory,
+                    ))
+                    .unwrap();
+
+                let start_hash = runtime.block_on(azks.get_root_hash(&db)).unwrap();
+
+                // epoch 2
+                runtime
+                    .block_on(azks.batch_insert_nodes(&db, node_set.clone(), InsertMode::Directory))
+                    .unwrap();
+
+                let end_hash = runtime.block_on(azks.get_root_hash(&db)).unwrap();
+                let proof = runtime
+                    .block_on(azks.get_append_only_proof(&db, 1, 2))
+                    .unwrap();
+
+                (start_hash, end_hash, proof)
+            },
+            |(start_hash, end_hash, proof)| {
+                runtime
+                    .block_on(auditor::audit_verify(vec![start_hash, end_hash], proof))
+                    .unwrap();
+            },
+            BatchSize::PerIteration,
+        );
+    });
 }
 
-criterion_group!(azks_benches, batch_insertion);
+fn gen_nodes(rng: &mut impl Rng, num_nodes: usize) -> Vec<AzksElement> {
+    (0..num_nodes)
+        .map(|_| {
+            let label = NodeLabel {
+                label_val: rng.gen::<[u8; 32]>(),
+                label_len: 256,
+            };
+            let mut input = [0u8; 32];
+            rng.fill_bytes(&mut input);
+            let value = akd_core::hash::hash(&input);
+            AzksElement { label, value }
+        })
+        .collect()
+}
+
+criterion_group!(azks_benches, batch_insertion, audit);
 criterion_main!(azks_benches);

--- a/akd/src/storage/manager/tests.rs
+++ b/akd/src/storage/manager/tests.rs
@@ -162,7 +162,7 @@ async fn test_storage_manager_cache_populated_by_batch_set() {
         .expect("Failed to set batch of records");
 
     // flush the database
-    storage_manager.db.clear().await;
+    storage_manager.db.clear();
 
     // test a retrieval still gets data (from the cache)
     let key = NodeKey(NodeLabel {
@@ -262,7 +262,7 @@ async fn test_storage_manager_cache_populated_by_batch_get() {
         .expect("Failed to get a batch of records");
 
     // flush the database
-    storage_manager.db.clear().await;
+    storage_manager.db.clear();
 
     // test a retrieval still gets data (from the cache)
     let key = NodeKey(NodeLabel {


### PR DESCRIPTION
# Overview
The audit verify flow relies on an in-memory DB without a transaction object to build up a tree. As the in-memory DB is a RwLocked hashmap, this results in significant contention during the newly parallelized batch insert process. By moving the in-memory DB to a dashmap, we minimize this contention and unlock significant perf gains for the audit verify flow.

# Benchmark

Ran the `azks.rs` benchmark and observed the `audit_verify` function, which performs a verification of a publish from epoch 1 (10K leaves) to epoch 2 (10K leaves).

```console
$ cargo bench -p akd --bench azks -F bench
```

## Before
<img width="387" alt="image" src="https://user-images.githubusercontent.com/20502803/211405549-ed75375c-104f-43ac-a420-c1ba7a817a7e.png">


## After
<img width="476" alt="image" src="https://user-images.githubusercontent.com/20502803/211405585-9e544fe7-4939-4672-aed5-1009cf7ce9f6.png">
