### PR TITLE
General cleanups and reorganization (part 2)

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,7 @@
+ignore:
+  - "akd_local_auditor"
+  - "akd_mysql"
+  - "akd_test_tools"
+  - "integration_tests"
+  - "poc"
+  - "xtask"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: bench
-          args: -F bench
+          args: -F bench --no-run
 
   docs:
     name: docs

--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -64,6 +64,7 @@ tokio-test = "0.4"
 tokio = { version = "1.21", features = ["rt", "sync", "time", "macros"] }
 mockall = "0.11"
 futures = "0.3"
+itertools = "0.10"
 
 # To enable the public-test feature in tests
 akd = { path = ".", features = ["public-tests"], default-features = false }

--- a/akd/src/tree_node.rs
+++ b/akd/src/tree_node.rs
@@ -468,6 +468,8 @@ impl TreeNode {
                         )))),
                     }
                 } else {
+                    // klewi: This actually cannot happen because direction will never be None.
+                    // We should rewrite this to be cleaner
                     Ok(None)
                 }
             }

--- a/akd_core/benches/parallel_vrfs.rs
+++ b/akd_core/benches/parallel_vrfs.rs
@@ -11,7 +11,7 @@ extern crate criterion;
 use self::criterion::*;
 use akd_core::ecvrf::{VRFExpandedPrivateKey, VRFPublicKey};
 use akd_core::VersionFreshness;
-use akd_core::{ecvrf::VRFKeyStorage, AkdLabel};
+use akd_core::{ecvrf::VRFKeyStorage, AkdLabel, AkdValue};
 use rand::distributions::Alphanumeric;
 use rand::Rng;
 
@@ -60,7 +60,12 @@ fn bench_parallel_vrfs(c: &mut Criterion) {
         .into_iter()
         .map(|i| {
             let name = format!("user {}", i);
-            (AkdLabel::from(&name), VersionFreshness::Fresh, i as u64)
+            (
+                AkdLabel::from(&name),
+                VersionFreshness::Fresh,
+                i as u64,
+                AkdValue::from(&name),
+            )
         })
         .collect::<Vec<_>>();
     let labels_clone = labels.clone();
@@ -72,7 +77,7 @@ fn bench_parallel_vrfs(c: &mut Criterion) {
                 .unwrap();
             let expanded_key = VRFExpandedPrivateKey::from(&key);
             let pk = VRFPublicKey::from(&key);
-            for (label, stale, version) in labels.iter() {
+            for (label, stale, version, _) in labels.iter() {
                 akd_core::ecvrf::HardCodedAkdVRF::get_node_label_with_expanded_key(
                     &expanded_key,
                     &pk,

--- a/akd_core/src/types/mod.rs
+++ b/akd_core/src/types/mod.rs
@@ -103,6 +103,17 @@ impl core::convert::TryFrom<u8> for Direction {
     }
 }
 
+impl Direction {
+    /// Returns the opposite of the direction
+    pub fn other(&self) -> Self {
+        match self {
+            Direction::Left => Direction::Right,
+            Direction::Right => Direction::Left,
+            Direction::None => Direction::None,
+        }
+    }
+}
+
 /// The label of a particular entry in the AKD
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(


### PR DESCRIPTION
- Reorganizing Directory::publish VRF computations to iterate over the VRF map instead of the update set
- Refactored (but didn't change) logic for generating membership proofs, fixing a flaky get_sibling_node() test that I had previously introduced
- Made CI run benches with `--no-run` parameter so they just check for compilation errors