### PR TITLE
Removing `unwrap()` calls in production code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,6 @@ jobs:
 
           - name: Test the base library, with default features
             package: akd
-            flags:
 
           - name: Test the base library, without parallelism
             package: akd
@@ -52,11 +51,9 @@ jobs:
 
           - name: Test the local auditor, with default features
             package: akd_local_auditor
-            flags:
 
           - name: Test the base client library, with default features
             package: akd_client
-            flags:
 
           - name: Test the client for wasm and SHA3-256 hashing
             package: akd_client
@@ -144,11 +141,17 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: Run benches
+      - name: Run akd_core benches
         uses: actions-rs/cargo@v1
         with:
           command: bench
-          args: -F bench --no-run
+          args: -p akd_core -F bench --no-run
+
+      - name: Run akd benches
+        uses: actions-rs/cargo@v1
+        with:
+          command: bench
+          args: -p akd -F bench --no-run
 
   docs:
     name: docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,18 @@ jobs:
   benches:
     name: benches
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: Build the akd_core benches
+            package: akd_core
+            flags: -F bench
+          - name: Build the akd benches
+            package: akd
+            flags: -F bench
+
+            
+
     steps:
       - uses: actions/checkout@main
       - name: Install rust
@@ -140,18 +152,11 @@ jobs:
         with:
           toolchain: stable
           override: true
-
-      - name: Run akd_core benches
+      - name: Run test
         uses: actions-rs/cargo@v1
         with:
           command: bench
-          args: -p akd_core -F bench --no-run
-
-      - name: Run akd benches
-        uses: actions-rs/cargo@v1
-        with:
-          command: bench
-          args: -p akd -F bench --no-run
+          args: --package ${{matrix.package}} ${{matrix.flags}}
 
   docs:
     name: docs

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -900,10 +900,15 @@ impl Azks {
             });
 
             prev_node = curr_node.clone();
-            curr_node = curr_node
-                .get_child_node(storage, dir, latest_epoch)
-                .await?
-                .unwrap();
+            match curr_node.get_child_node(storage, dir, latest_epoch).await? {
+                Some(n) => curr_node = n,
+                None => {
+                    return Err(AkdError::TreeNode(TreeNodeError::NoChildAtEpoch(
+                        latest_epoch,
+                        dir,
+                    )));
+                }
+            }
             dir = curr_node.label.get_dir(label);
             equal = label == curr_node.label;
         }

--- a/akd_core/src/ecvrf/tests.rs
+++ b/akd_core/src/ecvrf/tests.rs
@@ -27,6 +27,17 @@ use rand::rngs::StdRng;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
+impl Clone for VRFPrivateKey {
+    fn clone(&self) -> Self {
+        // In theory, creating a key from bytes could be a DecodingError, except
+        // we just copied these bytes out of the source key, so ...
+        Self(
+            ed25519_PrivateKey::from_bytes(self.0.as_bytes())
+                .expect("Copied bytes from source key should be valid"),
+        )
+    }
+}
+
 /// A type family for schemes which know how to generate key material from
 /// a cryptographically-secure [`CryptoRng`][::rand::CryptoRng].
 pub trait Uniform {

--- a/akd_core/src/types/node_label/mod.rs
+++ b/akd_core/src/types/node_label/mod.rs
@@ -15,7 +15,7 @@ use crate::{Direction, SizeOf};
 use crate::utils::serde_helpers::{bytes_deserialize_hex, bytes_serialize_hex};
 #[cfg(feature = "nostd")]
 use alloc::vec::Vec;
-use core::convert::{TryFrom, TryInto};
+use core::convert::TryFrom;
 
 #[cfg(test)]
 mod tests;
@@ -137,7 +137,7 @@ impl NodeLabel {
             return 0;
         }
 
-        let usize_index: usize = index.try_into().unwrap();
+        let usize_index: usize = index as usize;
         let index_full_blocks = usize_index / 8;
         let index_remainder = usize_index % 8;
         (self.label_val[index_full_blocks] >> (7 - index_remainder)) & 1
@@ -155,7 +155,7 @@ impl NodeLabel {
             };
         }
 
-        let usize_len: usize = (len - 1).try_into().unwrap();
+        let usize_len: usize = (len - 1) as usize;
         let len_remainder = usize_len % 8;
         let len_div = usize_len / 8;
 
@@ -207,7 +207,7 @@ impl NodeLabel {
             return Self::new([0u8; 32], 0);
         }
 
-        let usize_len: usize = (len - 1).try_into().unwrap();
+        let usize_len: usize = (len - 1) as usize;
         let byte_index = usize_len / 8;
         let bit_index = usize_len % 8;
 

--- a/akd_core/src/types/node_label/tests.rs
+++ b/akd_core/src/types/node_label/tests.rs
@@ -144,7 +144,7 @@ pub fn test_get_bit_at_large() {
     }
     // Everything after the first 24 indixes is 0
     for index in 24..256 {
-        let index_32: u32 = index.try_into().unwrap();
+        let index_32 = index as u32;
         assert!(
             0 == label.get_bit_at(index_32),
             "get_bit_at({}) wrong for the 256 digit label 0000 0000 0000 0000 1010 0000! Expected {:?} and got {:?}",

--- a/akd_mysql/src/mysql_db_tests.rs
+++ b/akd_mysql/src/mysql_db_tests.rs
@@ -38,7 +38,8 @@ async fn test_mysql_db() {
             Option::from(8001),
             200,
         )
-        .await;
+        .await
+        .expect("Failed to create async mysql db");
 
         if let Err(error) = mysql_db.delete_data().await {
             println!("Error cleaning mysql prior to test suite: {}", error);

--- a/integration_tests/src/mysql_tests.rs
+++ b/integration_tests/src/mysql_tests.rs
@@ -39,7 +39,8 @@ async fn test_directory_operations() {
             Option::from(8001),
             200,
         )
-        .await;
+        .await
+        .expect("Failed to create async mysql db");
 
         // delete all data from the db
         if let Err(error) = mysql_db.delete_data().await {
@@ -101,7 +102,8 @@ async fn test_directory_operations_with_caching() {
             Option::from(8001),
             200,
         )
-        .await;
+        .await
+        .expect("Failed to create async mysql db");
 
         // delete all data from the db
         if let Err(error) = mysql_db.delete_data().await {
@@ -163,7 +165,8 @@ async fn test_lookups() {
             Option::from(8001),
             200,
         )
-        .await;
+        .await
+        .expect("Failed to create async mysql db");
 
         // delete all data from the db
         if let Err(error) = mysql_db.delete_data().await {

--- a/poc/src/main.rs
+++ b/poc/src/main.rs
@@ -160,7 +160,8 @@ async fn main() {
             Option::from(8001),
             cli.mysql_insert_depth,
         )
-        .await;
+        .await
+        .expect("Failed to create async mysql db");
         if let Some(()) = pre_process_input(&cli, &tx, Some(&mysql_db)).await {
             return;
         }


### PR DESCRIPTION
This change removes a lot of calls to `unwrap()` in runtime code in order to minimize the risk of panic. We generally don't want to risk panicking in runtime, and want to return a graceful error when possible.

Related to #294