### PR TITLE
General cleanups and refactoring crypto components into akd_core (part 3)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,6 @@
+codecov:
+  require_ci_to_pass: false
+
 ignore:
   - "akd_local_auditor"
   - "akd_mysql"

--- a/akd/src/auditor.rs
+++ b/akd/src/auditor.rs
@@ -7,6 +7,8 @@
 
 //! Code for an auditor of a authenticated key directory
 
+use crate::crypto::hash_leaf_with_commitment;
+
 use crate::{
     append_only_zks::InsertMode,
     errors::{AkdError, AuditorError, AzksError},
@@ -65,7 +67,7 @@ pub async fn verify_consecutive_append_only(
         .iter()
         .map(|x| {
             let mut y = *x;
-            y.value = akd_core::hash::merge_with_u64(x.value, end_epoch);
+            y.value = hash_leaf_with_commitment(x.value, end_epoch);
             y
         })
         .collect();

--- a/akd/src/utils.rs
+++ b/akd/src/utils.rs
@@ -9,12 +9,6 @@
 // 2. For each node in current_nodes set, check if each child is in prefix hashmap
 // 3. If so, add child label to batch set
 
-use crate::{EMPTY_LABEL, EMPTY_VALUE};
-
-pub(crate) fn empty_node_hash() -> crate::Digest {
-    crate::hash::merge(&[crate::hash::hash(&EMPTY_VALUE), EMPTY_LABEL.hash()])
-}
-
 // Creates a byte array of 32 bytes from a u64
 // Note that this representation is big-endian, and
 // places the bits to the front of the output byte_array.

--- a/akd_core/src/crypto.rs
+++ b/akd_core/src/crypto.rs
@@ -1,0 +1,165 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree and the Apache
+// License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+// of this source tree.
+
+//! Functions for performing the core cryptographic operations for AKD
+
+use crate::hash::{hash, Digest, DIGEST_BYTES};
+use crate::utils::i2osp_array;
+use crate::{AkdLabel, AkdValue, NodeLabel, VersionFreshness, EMPTY_LABEL, EMPTY_VALUE};
+
+#[cfg(feature = "nostd")]
+use alloc::vec::Vec;
+
+/// The value stored in the root node upon initialization, with no children
+pub fn empty_root_value() -> Digest {
+    // FIXME(#344) Change this to:
+    // [0u8; 32]
+    hash(&crate::EMPTY_VALUE)
+}
+
+/// AZKS value corresponding to an empty node
+pub fn empty_node_hash() -> Digest {
+    // FIXME(#344) Change this to:
+    // [0u8; 32]
+    hash(&[hash(&EMPTY_VALUE).to_vec(), EMPTY_LABEL.hash()].concat())
+}
+
+/// Used by the client to supply a commitment nonce and value to reconstruct the commitment, via:
+/// commitment = H(i2osp_array(value), i2osp_array(nonce))
+pub(crate) fn generate_commitment_from_nonce_client(
+    value: &crate::AkdValue,
+    nonce: &[u8],
+) -> crate::hash::Digest {
+    hash(&[i2osp_array(value), i2osp_array(nonce)].concat())
+}
+
+/// Hash a leaf epoch and nonce with a given [AkdValue]
+pub(crate) fn hash_leaf_with_value(value: &crate::AkdValue, epoch: u64, nonce: &[u8]) -> Digest {
+    let commitment = generate_commitment_from_nonce_client(value, nonce);
+    hash_leaf_with_commitment(commitment, epoch)
+}
+
+/// Hash a commit and epoch together to get the leaf's hash value
+pub fn hash_leaf_with_commitment(commitment: Digest, epoch: u64) -> Digest {
+    let mut data = [0; DIGEST_BYTES + 8];
+    data[..DIGEST_BYTES].copy_from_slice(&commitment);
+    data[DIGEST_BYTES..].copy_from_slice(&epoch.to_be_bytes());
+    hash(&data)
+}
+
+/// Used by the server to produce a commitment nonce for an AkdLabel, version, and AkdValue.
+/// Computes nonce = H(commitment key || label)
+pub fn get_commitment_nonce(
+    commitment_key: &[u8],
+    label: &NodeLabel,
+    version: u64,
+    value: &AkdValue,
+) -> Digest {
+    // FIXME(#344) Change this to:
+    // hash(
+    //    &[
+    //        commitment_key,
+    //        &label.to_bytes(),
+    //    ]
+    //    .concat(),
+    //)
+    hash(
+        &[
+            commitment_key,
+            &label.to_bytes(),
+            &version.to_be_bytes(),
+            &i2osp_array(value),
+        ]
+        .concat(),
+    )
+}
+
+/// To convert a regular label (arbitrary string of bytes) into a [NodeLabel], we compute the
+/// output as: H(label || freshness || version)
+///
+/// Specifically, we concatenate the following together:
+/// - I2OSP(len(label) as u64, label)
+/// - A single byte encoded as 0u8 if "stale", 1u8 if "fresh"
+/// - A u64 representing the version
+/// These are all interpreted as a single byte array and hashed together, with the output
+/// of the hash returned.
+pub(crate) fn get_hash_from_label_input(
+    label: &AkdLabel,
+    freshness: VersionFreshness,
+    version: u64,
+) -> Vec<u8> {
+    let freshness_bytes = [freshness as u8];
+    let hashed_label = hash(
+        &[
+            &crate::utils::i2osp_array(label)[..],
+            &freshness_bytes,
+            &version.to_be_bytes(),
+        ]
+        .concat(),
+    );
+    hashed_label.to_vec()
+}
+
+/// Computes the parent hash from the children hashes and labels
+pub fn compute_parent_hash_from_children(
+    left_val: &[u8],
+    left_label: &[u8],
+    right_val: &[u8],
+    right_label: &[u8],
+) -> Digest {
+    // FIXME(#344) Change this to:
+    // hash(
+    //    &[
+    //        left_val,
+    //        left_label,
+    //        right_val,
+    //        right_label,
+    //    ].concat()
+    // )
+    hash(
+        &[
+            hash(&[left_val.to_vec(), left_label.to_vec()].concat()),
+            hash(&[right_val.to_vec(), right_label.to_vec()].concat()),
+        ]
+        .concat(),
+    )
+}
+
+/// Given the top-level hash, compute the "actual" root hash that is published
+/// by the directory maintainer
+pub fn compute_root_hash_from_val(root_val: &[u8]) -> Digest {
+    // FIXME(#344) Change this to:
+    // root_val
+    hash(&[root_val, &NodeLabel::root().hash()].concat())
+}
+
+/// Used by the server to produce a commitment for an AkdLabel, version, and AkdValue
+///
+/// nonce = H(commitment_key, label, version, i2osp_array(value))
+/// commmitment = H(i2osp_array(value), i2osp_array(nonce))
+///
+/// The nonce value is used to create a hiding and binding commitment using a
+/// cryptographic hash function. Note that it is derived from the label, version, and
+/// value (even though the binding to value is somewhat optional).
+///
+/// Note that this commitment needs to be a hash function (random oracle) output
+pub fn commit_fresh_value(
+    commitment_key: &[u8],
+    label: &NodeLabel,
+    version: u64,
+    value: &AkdValue,
+) -> Digest {
+    let nonce = get_commitment_nonce(commitment_key, label, version, value);
+    hash(&[i2osp_array(value), i2osp_array(&nonce)].concat())
+}
+
+/// Similar to commit_fresh_value, but used for stale values.
+pub fn commit_stale_value() -> Digest {
+    // FIXME(#344) Change this to:
+    // crate::hash::EMPTY_DIGEST
+    hash(&EMPTY_VALUE)
+}

--- a/akd_core/src/ecvrf/traits.rs
+++ b/akd_core/src/ecvrf/traits.rs
@@ -8,6 +8,7 @@
 //! This module implements traits for managing ECVRF, mainly pertaining to storage
 //! of public and private keys
 use super::{Output, Proof, VRFExpandedPrivateKey, VRFPrivateKey, VRFPublicKey, VrfError};
+use crate::crypto::get_hash_from_label_input;
 use crate::{AkdLabel, AkdValue, NodeLabel, VersionFreshness};
 
 #[cfg(feature = "nostd")]
@@ -114,7 +115,7 @@ pub trait VRFKeyStorage: Clone + Sync + Send {
         freshness: VersionFreshness,
         version: u64,
     ) -> Proof {
-        let hashed_label = crate::utils::get_hash_from_label_input(label, freshness, version);
+        let hashed_label = get_hash_from_label_input(label, freshness, version);
         key.prove(&hashed_label)
     }
 
@@ -126,7 +127,7 @@ pub trait VRFKeyStorage: Clone + Sync + Send {
         freshness: VersionFreshness,
         version: u64,
     ) -> Output {
-        let hashed_label = crate::utils::get_hash_from_label_input(label, freshness, version);
+        let hashed_label = get_hash_from_label_input(label, freshness, version);
         expanded_private_key.evaluate(pk, &hashed_label)
     }
 

--- a/akd_core/src/hash/mod.rs
+++ b/akd_core/src/hash/mod.rs
@@ -12,7 +12,6 @@
 use alloc::format;
 #[cfg(feature = "nostd")]
 use alloc::string::String;
-use core::slice;
 
 /// A hash digest of a specified number of bytes
 pub type Digest = [u8; DIGEST_BYTES];
@@ -52,22 +51,6 @@ pub use crate::hash::sha3::DIGEST_BYTES;
 #[cfg(test)]
 mod tests;
 
-/// An error occurred while hashing data
-#[derive(Debug, Eq, PartialEq)]
-pub enum HashError {
-    /// No direction was present when expected
-    NoDirection(String),
-}
-
-impl core::fmt::Display for HashError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let code = match &self {
-            HashError::NoDirection(msg) => format!("(No Direction) - {}", msg),
-        };
-        write!(f, "Hashing error: {}", code)
-    }
-}
-
 /// Try and parse a digest from an unknown length of bytes. Helpful for converting a `Vec<u8>`
 /// to a [Digest]
 pub fn try_parse_digest(value: &[u8]) -> Result<Digest, String> {
@@ -82,20 +65,4 @@ pub fn try_parse_digest(value: &[u8]) -> Result<Digest, String> {
         arr.copy_from_slice(value);
         Ok(arr)
     }
-}
-
-/// Merge N hashes into a single Digest
-pub fn merge(items: &[Digest]) -> Digest {
-    let p = items.as_ptr();
-    let len = items.len() * DIGEST_BYTES;
-    let data: &[u8] = unsafe { slice::from_raw_parts(p as *const u8, len) };
-    hash(data)
-}
-
-/// Takes the hash of a value and merges it with a `u64`, hashing the result.
-pub fn merge_with_u64(digest: Digest, value: u64) -> Digest {
-    let mut data = [0; DIGEST_BYTES + 8];
-    data[..DIGEST_BYTES].copy_from_slice(&digest);
-    data[DIGEST_BYTES..].copy_from_slice(&value.to_be_bytes());
-    hash(&data)
 }

--- a/akd_core/src/lib.rs
+++ b/akd_core/src/lib.rs
@@ -6,13 +6,14 @@
 // of this source tree.
 
 //! Core utilities for the auditable key directory `akd` and `akd_client` crates.
-//! Mainly contains (1) hashing utilities and (2) type definitions as well as (3)
+//! Mainly contains (1) hashing utilities for the core cryptographic operations
+//! involved in building an AKD and issuing proofs, (2) type definitions, and (3)
 //! protobuf specifications for all external types
 //!
 //! The default configuration is to utilize the standard library (`std`) along with
 //! blake3 hashing (from the [blake3] crate). If you wish to customize which hash and
-//! which features are utilized, you can pass --no-default-features on the command line
-//! or `default-features = false` in your Cargo.toml import to disable all the default features
+//! which features are utilized, you can pass `--no-default-features` on the command line
+//! or `default-features = false` in your Cargo.toml import to disable all of the default features
 //! which you can then enable one-by-one as you wish.
 //!
 //! In the following, we will cover the protocol-level implementation details behind:
@@ -22,7 +23,7 @@
 //!
 //! # Setup parameters
 //!
-//! An AKD is configured by a set of parameters, which are set by the server when it is initialized. The server
+//! An AKD is configured by a set of parameters which are set by the server when it is initialized. The server
 //! picks a random VRF private key `vsk` and derives (and distributes) a public key `vpk` to its clients. The server also
 //! produces a commitment key (`commitment_key`) by hashing the VRF private key. The VRF private key will be used to provide
 //! selective privacy of the database's inserted labels to auditors and other clients, while the commitment key
@@ -61,8 +62,9 @@
 //! The server then computes a VRF on the [NodeLabel] to derive a value for the leaf node. This is computed as:
 //! `node_label = VRF(vsk, vrf_input)`.
 //!
-//! Once the node label for this entry is derived (as `node_label`), the function [utils::commit_value]
-//! is used to commit the [AkdValue] to the tree. The actual value
+//! Once the node label for this entry is derived (as `node_label`), the functions [crypto::commit_fresh_value()]
+//! and [crypto::commit_stale_value()]
+//! are used to commit the [AkdValue] to the tree. The actual value
 //! that is stored in the node is a commitment, generated using the server's commitment key as follows:
 //! - `commitment_nonce = Hash(commitment_key, node_label, version, I2OSP(len(value) as u64), value)`
 //! - `commmitment = Hash(I2OSP(len(value) as u64), value, I2OSP(len(commitment_nonce) as u64), commitment_nonce)`
@@ -180,6 +182,7 @@ extern crate alloc;
 #[cfg(all(feature = "protobuf", not(feature = "nostd")))]
 pub mod proto;
 
+pub mod crypto;
 pub mod ecvrf;
 pub mod hash;
 pub mod utils;

--- a/akd_core/src/types/node_label/mod.rs
+++ b/akd_core/src/types/node_label/mod.rs
@@ -8,7 +8,6 @@
 //! This module contains the specifics for NodeLabel only, other types don't have the
 //! same level of detail and aren't broken into sub-modules
 
-use crate::hash::Digest;
 use crate::{Direction, SizeOf};
 
 #[cfg(feature = "serde_serialization")]
@@ -22,7 +21,7 @@ mod tests;
 
 /// The label used for an empty node
 pub const EMPTY_LABEL: NodeLabel = NodeLabel {
-    label_val: [1u8; 32],
+    label_val: [1u8; 32], // FIXME(#344): Let's use a more concise value here, like [1u8, 0u8, ..., 0u8]
     label_len: 0,
 };
 
@@ -79,8 +78,10 @@ impl core::fmt::Display for NodeLabel {
 
 impl NodeLabel {
     /// Hash a [NodeLabel] into a digest, length-prefixing the label's value
-    pub fn hash(&self) -> Digest {
-        crate::hash::hash(&self.to_bytes())
+    pub fn hash(&self) -> Vec<u8> {
+        // FIXME(#344): We souldn't need to actually hash the label, it is redundant. Change this to:
+        // self.to_bytes()
+        crate::hash::hash(&self.to_bytes()).to_vec()
     }
 
     pub(crate) fn to_bytes(self) -> Vec<u8> {

--- a/akd_core/src/utils.rs
+++ b/akd_core/src/utils.rs
@@ -7,9 +7,6 @@
 
 //! Utility functions
 
-use crate::hash::Digest;
-use crate::{AkdLabel, AkdValue, NodeLabel, VersionFreshness};
-
 #[cfg(feature = "nostd")]
 use alloc::vec::Vec;
 
@@ -25,91 +22,6 @@ pub fn get_marker_version_log2(version: u64) -> u64 {
 /// Input byte array cannot be > 2^64-1 in length
 pub fn i2osp_array(input: &[u8]) -> Vec<u8> {
     [&(input.len() as u64).to_be_bytes(), input].concat()
-}
-
-/// Used by the client to supply a commitment nonce and value to reconstruct the commitment, via:
-/// commitment = H(i2osp_array(value), i2osp_array(nonce))
-pub(crate) fn generate_commitment_from_nonce_client(
-    value: &crate::AkdValue,
-    nonce: &[u8],
-) -> crate::hash::Digest {
-    crate::hash::hash(&[i2osp_array(value), i2osp_array(nonce)].concat())
-}
-
-/// Hash a leaf epoch and proof with a given [AkdValue]
-pub(crate) fn hash_leaf_with_value(value: &crate::AkdValue, epoch: u64, proof: &[u8]) -> Digest {
-    let commitment = crate::utils::generate_commitment_from_nonce_client(value, proof);
-    hash_leaf_with_commitment(commitment, epoch)
-}
-
-/// Hash a leaf epoch and proof with a given [AkdValue]
-pub(crate) fn hash_leaf_with_commitment(commitment: Digest, epoch: u64) -> Digest {
-    crate::hash::merge_with_u64(commitment, epoch)
-}
-
-/// Used by the server to produce a commitment proof for an AkdLabel, version, and AkdValue.
-/// Computes nonce = H(commitment key || label || version || i2osp_array(value))
-pub fn get_commitment_nonce(
-    commitment_key: &[u8],
-    label: &NodeLabel,
-    version: u64,
-    value: &AkdValue,
-) -> Digest {
-    crate::hash::hash(
-        &[
-            commitment_key,
-            &label.to_bytes(),
-            &version.to_be_bytes(),
-            &i2osp_array(value),
-        ]
-        .concat(),
-    )
-}
-
-/// To convert a regular label (arbitrary string of bytes) into a [NodeLabel], we compute the
-/// output as: H(label || liveness || version)
-///
-/// Specifically, we concatenate the following together:
-/// - I2OSP(len(label) as u64, label)
-/// - A single byte encoded as 0u8 if "stale", 1u8 if "fresh"
-/// - A u64 representing the version
-/// These are all interpreted as a single byte array and hashed together, with the output
-/// of the hash returned.
-pub(crate) fn get_hash_from_label_input(
-    label: &AkdLabel,
-    freshness: VersionFreshness,
-    version: u64,
-) -> Vec<u8> {
-    let freshness_bytes = [freshness as u8];
-    let hashed_label = crate::hash::hash(
-        &[
-            &crate::utils::i2osp_array(label)[..],
-            &freshness_bytes,
-            &version.to_be_bytes(),
-        ]
-        .concat(),
-    );
-    hashed_label.to_vec()
-}
-
-/// Used by the server to produce a commitment for an AkdLabel, version, and AkdValue
-///
-/// nonce = H(commitment_key, label, version, i2osp_array(value))
-/// commmitment = H(i2osp_array(value), i2osp_array(nonce))
-///
-/// The nonce value is used to create a hiding and binding commitment using a
-/// cryptographic hash function. Note that it is derived from the label, version, and
-/// value (even though the binding to value is somewhat optional).
-///
-/// Note that this commitment needs to be a hash function (random oracle) output
-pub fn commit_value(
-    commitment_key: &[u8],
-    label: &NodeLabel,
-    version: u64,
-    value: &AkdValue,
-) -> Digest {
-    let nonce = get_commitment_nonce(commitment_key, label, version, value);
-    crate::hash::hash(&[i2osp_array(value), i2osp_array(&nonce)].concat())
 }
 
 /// Serde serialization helpers

--- a/akd_core/src/verify/history.rs
+++ b/akd_core/src/verify/history.rs
@@ -13,7 +13,8 @@ use super::base::{
 };
 use super::VerificationError;
 
-use crate::hash::{hash, Digest};
+use crate::crypto::commit_stale_value;
+use crate::hash::Digest;
 use crate::{AkdLabel, HistoryProof, UpdateProof, VerifyResult, VersionFreshness};
 #[cfg(feature = "nostd")]
 use alloc::format;
@@ -209,7 +210,7 @@ fn verify_single_update_proof(
         vrf_public_key,
         root_hash,
         akd_label,
-        hash(&crate::EMPTY_VALUE),
+        commit_stale_value(),
         proof.epoch,
         VersionFreshness::Stale,
         proof.version - 1,

--- a/akd_core/src/verify/mod.rs
+++ b/akd_core/src/verify/mod.rs
@@ -29,8 +29,6 @@ pub enum VerificationError {
     LookupProof(String),
     /// Error verifying a history proof
     HistoryProof(String),
-    /// Error hashing during verification
-    Hash(crate::hash::HashError),
     /// Error verifying a VRF proof
     #[cfg(feature = "vrf")]
     Vrf(crate::ecvrf::VrfError),
@@ -48,7 +46,6 @@ impl core::fmt::Display for VerificationError {
             }
             VerificationError::LookupProof(err) => format!("(Lookup proof) - {}", err),
             VerificationError::HistoryProof(err) => format!("(History proof) - {}", err),
-            VerificationError::Hash(hash) => hash.to_string(),
             #[cfg(feature = "vrf")]
             VerificationError::Vrf(vrf) => vrf.to_string(),
             #[cfg(feature = "protobuf")]
@@ -62,12 +59,6 @@ impl core::fmt::Display for VerificationError {
 impl From<crate::ecvrf::VrfError> for VerificationError {
     fn from(input: crate::ecvrf::VrfError) -> Self {
         VerificationError::Vrf(input)
-    }
-}
-
-impl From<crate::hash::HashError> for VerificationError {
-    fn from(input: crate::hash::HashError) -> Self {
-        VerificationError::Hash(input)
     }
 }
 


### PR DESCRIPTION
1. Factors out common logic that is repeated in a couple of places between akd_core and akd into a crypto.rs module in akd_core. Including: `compute_root_hash_from_val`, `hash_leaf_with_commitment`, `empty_node_hash`. This will make it easier to change these core functionalities if we need to adjust them in the future (in one place instead of multiple places)
2. Renames some functions in tree_node.rs and consolidated some logic