### PR TITLE
Deterministic fixture generation

### DIFF
--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -108,7 +108,7 @@ impl<S: Database + 'static, V: VRFKeyStorage> Directory<S, V> {
             .map(|(akd_label, _val)| akd_label.clone())
             .collect();
         // sort the keys, as inserting in primary-key order is more efficient for MySQL
-        keys.sort_by(|a, b| a.cmp(b));
+        keys.sort();
 
         // we're only using the maximum "version" of the user's state at the last epoch
         // they were seen in the directory. Therefore we've minimized the call to only

--- a/akd/src/storage/transaction.rs
+++ b/akd/src/storage/transaction.rs
@@ -290,7 +290,7 @@ mod tests {
     use crate::tree_node::*;
     use crate::utils::byte_arr_from_u64;
     use crate::{AkdLabel, AkdValue};
-    use rand::{rngs::OsRng, seq::SliceRandom};
+    use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
 
     #[test]
     fn test_commit_order() -> Result<(), StorageError> {
@@ -334,7 +334,7 @@ mod tests {
         });
 
         let records = vec![azks, node1, node2, value1, value2];
-        let mut rng = OsRng;
+        let mut rng = StdRng::seed_from_u64(42);
 
         for _ in 1..10 {
             let txn = Transaction::new();

--- a/akd/src/storage/types.rs
+++ b/akd/src/storage/types.rs
@@ -35,7 +35,7 @@ pub enum StorageType {
 pub struct ValueStateKey(pub Vec<u8>, pub u64);
 
 /// The state of the value for a given key, starting at a particular epoch.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(
     feature = "serde_serialization",
     derive(serde::Deserialize, serde::Serialize)
@@ -147,7 +147,7 @@ pub enum ValueStateRetrievalFlag {
 
 /// This needs to be PUBLIC public, since anyone implementing a data-layer will need
 /// to be able to access this and all the internal types
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(
     feature = "serde_serialization",
     derive(serde::Deserialize, serde::Serialize)

--- a/akd/src/tree_node.rs
+++ b/akd/src/tree_node.rs
@@ -22,7 +22,7 @@ use std::marker::Sync;
 
 /// There are three types of nodes: root, leaf and interior.
 /// This enum is used to mark the type of a [TreeNode].
-#[derive(Eq, PartialEq, Debug, Copy, Clone, Hash)]
+#[derive(Eq, PartialEq, Debug, Copy, Clone, Hash, PartialOrd, Ord)]
 #[cfg_attr(
     feature = "serde_serialization",
     derive(serde::Deserialize, serde::Serialize)
@@ -70,7 +70,7 @@ impl TreeNodeType {
 /// that a new epoch is available, flush their caches, and retrieve data from storage directly again.
 ///
 /// This structure holds the label along with the current value & epoch - 1
-#[derive(Debug, Eq, PartialEq, Clone, Hash)]
+#[derive(Debug, Eq, PartialEq, Clone, Hash, PartialOrd, Ord)]
 #[cfg_attr(
     feature = "serde_serialization",
     derive(serde::Deserialize, serde::Serialize)
@@ -217,7 +217,7 @@ impl TreeNodeWithPreviousValue {
 /// At a later time, we may need to access older sub-trees of the tree built with these nodes.
 /// To facilitate this, we require this struct to include the last time a node was updated
 /// as well as the oldest descendant it holds.
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 #[cfg_attr(
     feature = "serde_serialization",
     derive(serde::Deserialize, serde::Serialize)

--- a/akd_core/src/types/mod.rs
+++ b/akd_core/src/types/mod.rs
@@ -115,7 +115,7 @@ impl Direction {
 }
 
 /// The label of a particular entry in the AKD
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(
     feature = "serde_serialization",
     derive(serde::Serialize, serde::Deserialize)
@@ -175,7 +175,7 @@ impl AkdLabel {
 }
 
 /// The value of a particular entry in the AKD
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(
     feature = "serde_serialization",
     derive(serde::Serialize, serde::Deserialize)

--- a/akd_test_tools/src/fixture_generator/examples/test.yaml
+++ b/akd_test_tools/src/fixture_generator/examples/test.yaml
@@ -6,7 +6,7 @@
 #   --max_updates 5 \
 #   --capture_states 9 10 \
 #   --capture_deltas 10 \
-#   --out src/fixture_generator/examples/test.yaml \
+#   --out akd_test_tools/src/fixture_generator/examples/test.yaml \
 
 # Metadata
 ---
@@ -20,7 +20,7 @@ args:
     - 10
   capture_deltas:
     - 10
-  out: src/fixture_generator/examples/test.yaml
+  out: akd_test_tools/src/fixture_generator/examples/test.yaml
   no_generated_updates: false
 version: 0.8.6
 
@@ -28,1399 +28,9 @@ version: 0.8.6
 ---
 epoch: 9
 records:
-  - TreeNode:
-      label:
-        label_val: 40B7654182ACF470672602DCE7186CEA1DB59738D7C9F1D607A9B24C362BE6C0
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 40B7654182ACF470672602DCE7186CEA1DB59738D7C9F1D607A9B24C362BE6C0
-          label_len: 256
-        last_epoch: 1
-        min_descendant_epoch: 1
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 6
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: D46E3C909F32721265EF6071FCE64DCA908A62F3F71ABD67F439A47921A9FC46
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 2
-      latest_node:
-        label:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        last_epoch: 7
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        right_child:
-          label_val: 398E7F16B6562B76B5A9E5B1F9B584263DA97CA6F4D06220A0EF2C2F1A95AB12
-          label_len: 256
-        hash: A0318F4B4DEB30690D39EB391FFF9A8499CDA168EDCED649A7DF43162D54C23D
-      previous_node:
-        label:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        last_epoch: 1
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: 06DEEEE0508C6152127EEBA6B13C7EF8E78DD54126A36B27E6AA1D7C8AF297DE
-          label_len: 256
-        right_child:
-          label_val: 398E7F16B6562B76B5A9E5B1F9B584263DA97CA6F4D06220A0EF2C2F1A95AB12
-          label_len: 256
-        hash: 35507B39883CE485CF2FEA949FE4805508ABC9C5D82C02A74B97886E44421125
-  - TreeNode:
-      label:
-        label_val: "7800000000000000000000000000000000000000000000000000000000000000"
-        label_len: 5
-      latest_node:
-        label:
-          label_val: "7800000000000000000000000000000000000000000000000000000000000000"
-          label_len: 5
-        last_epoch: 3
-        min_descendant_epoch: 2
-        parent:
-          label_val: "7000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        node_type: Interior
-        left_child:
-          label_val: 7948F1797F2C5BDE543241EDD4F6D826AAA9F65331493ED8D6D96BFE6BC9507C
-          label_len: 256
-        right_child:
-          label_val: 7EC32D61A61F3D8C53F1B3F312F3AE60E153AB552FC46E94091F89C35A0E1341
-          label_len: 256
-        hash: C4D95421B1B98792217BD9C141F9A4D8CF6CE172704803A744FB749981657B4C
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: E6B42CD9ABDFBE613158800BF70011C56F9D17F001BBD0C7CA0EA900FD4845DF
-        label_len: 256
-      latest_node:
-        label:
-          label_val: E6B42CD9ABDFBE613158800BF70011C56F9D17F001BBD0C7CA0EA900FD4845DF
-          label_len: 256
-        last_epoch: 6
-        min_descendant_epoch: 6
-        parent:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 5
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: FCE19AB15447C3AAC5C3F34294CD6D7B93C44136ABA76FDDE2692E0273086B1C
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 7948F1797F2C5BDE543241EDD4F6D826AAA9F65331493ED8D6D96BFE6BC9507C
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 7948F1797F2C5BDE543241EDD4F6D826AAA9F65331493ED8D6D96BFE6BC9507C
-          label_len: 256
-        last_epoch: 2
-        min_descendant_epoch: 2
-        parent:
-          label_val: "7800000000000000000000000000000000000000000000000000000000000000"
-          label_len: 5
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: E0D68F634ED5C06DAB0EA8DF51AC4B4182AB0DEC2DC11C0821F1C4E491525196
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: C7BAF6ABCDCC44429E4FD296B3E506F3BBC9BAE0CCCAF3D51C052FD3EA12A643
-        label_len: 256
-      latest_node:
-        label:
-          label_val: C7BAF6ABCDCC44429E4FD296B3E506F3BBC9BAE0CCCAF3D51C052FD3EA12A643
-          label_len: 256
-        last_epoch: 2
-        min_descendant_epoch: 2
-        parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: FDB008ED88BDE9A12D86608DC80201AFB31C5EF9182B3062CA0CFD1E93E3FB1A
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 97B2F1F86164C236771A8CC90D192CD7D99A3016C5A5C1D912EAD392BC94AE20
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 97B2F1F86164C236771A8CC90D192CD7D99A3016C5A5C1D912EAD392BC94AE20
-          label_len: 256
-        last_epoch: 5
-        min_descendant_epoch: 5
-        parent:
-          label_val: "9000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 16705337F7867CEF5D8CB2D48D274E31EBB0C976EF40BDCF23C44F995F319909
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: E963B4F8460FFD1F7D93D4DE499B11AAC91030B2AD59EC45AE63C4479A45A133
-        label_len: 256
-      latest_node:
-        label:
-          label_val: E963B4F8460FFD1F7D93D4DE499B11AAC91030B2AD59EC45AE63C4479A45A133
-          label_len: 256
-        last_epoch: 5
-        min_descendant_epoch: 5
-        parent:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 79EE6AD0FF9BD73A07986F40011FD3759E4C91FCD47D6F06E35C245A1F14CFB9
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: E000000000000000000000000000000000000000000000000000000000000000
-        label_len: 4
-      latest_node:
-        label:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        last_epoch: 6
-        min_descendant_epoch: 4
-        parent:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        node_type: Interior
-        left_child:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 5
-        right_child:
-          label_val: E963B4F8460FFD1F7D93D4DE499B11AAC91030B2AD59EC45AE63C4479A45A133
-          label_len: 256
-        hash: 8084B8304AEECE6920B40F935247662C53450C38F458F70E15117F522A0056AD
-      previous_node:
-        label:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        last_epoch: 5
-        min_descendant_epoch: 4
-        parent:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        node_type: Interior
-        left_child:
-          label_val: E1E2366C30A2E8246783077E6AD13599563448038C78C0B9E492AC365614DEB7
-          label_len: 256
-        right_child:
-          label_val: E963B4F8460FFD1F7D93D4DE499B11AAC91030B2AD59EC45AE63C4479A45A133
-          label_len: 256
-        hash: C020D10B09DC6551292B9A4C4FEA692238EF07132D5311F3AFF68740263EBF08
-  - TreeNode:
-      label:
-        label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 0
-      latest_node:
-        label:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 0
-        last_epoch: 7
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 0
-        node_type: Root
-        left_child:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        right_child:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        hash: 0B7F32D70650E5113548BB6EA7464A48B3C6EB847421B148E0910E95FCB933FC
-      previous_node:
-        label:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 0
-        last_epoch: 6
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 0
-        node_type: Root
-        left_child:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        right_child:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        hash: E61E54194BCC3AC7476DAF7AF7875FEF93C5B05590BF247A9C0ABDA5D649E0B3
-  - TreeNode:
-      label:
-        label_val: 74F6AB77F795C02E81A82D318C73EEF444C184E8A6D994E0F4B64F91553351DA
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 74F6AB77F795C02E81A82D318C73EEF444C184E8A6D994E0F4B64F91553351DA
-          label_len: 256
-        last_epoch: 6
-        min_descendant_epoch: 6
-        parent:
-          label_val: "7000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: CDE1E79EFC56AAF9FF7774912836B5A32E6C145B5AA0D53303ADB9D37617024B
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 3
-      latest_node:
-        label:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        last_epoch: 7
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: 06DEEEE0508C6152127EEBA6B13C7EF8E78DD54126A36B27E6AA1D7C8AF297DE
-          label_len: 256
-        right_child:
-          label_val: 1B3197016C32205D6B4768770B19A563B0E204CA0F291071A4B5690FDE5D5E9F
-          label_len: 256
-        hash: 13001B6E41A82103B6DD1CA5706D098228EEF8F8882F58EF605B76A3CB003027
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: AEBC771586C4265DAB54EBC4629AB9BFD382BE30FDC67FDBA7FB067E3B51D8B7
-        label_len: 256
-      latest_node:
-        label:
-          label_val: AEBC771586C4265DAB54EBC4629AB9BFD382BE30FDC67FDBA7FB067E3B51D8B7
-          label_len: 256
-        last_epoch: 3
-        min_descendant_epoch: 3
-        parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: E01C1A1008385C4E202CFBF866C5476E442A21393D6C7F76597603A58B43CF0A
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "9000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 4
-      latest_node:
-        label:
-          label_val: "9000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        last_epoch: 5
-        min_descendant_epoch: 5
-        parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        node_type: Interior
-        left_child:
-          label_val: 97B2F1F86164C236771A8CC90D192CD7D99A3016C5A5C1D912EAD392BC94AE20
-          label_len: 256
-        right_child:
-          label_val: 9EC4B36008568F3A571EE4BDE03E76611E51BBE7D7C6D2777CCA71B0BDF31E7F
-          label_len: 256
-        hash: EEF38B64D48863F92ADDF92317B3E56C1D29BD59A39EC15D71288238710863D9
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 398E7F16B6562B76B5A9E5B1F9B584263DA97CA6F4D06220A0EF2C2F1A95AB12
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 398E7F16B6562B76B5A9E5B1F9B584263DA97CA6F4D06220A0EF2C2F1A95AB12
-          label_len: 256
-        last_epoch: 1
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 2DC2E4EDB446FFC7683FE23D5E4E9ABE78373B19FB1BE5B2C337E54CE1D810EF
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 4DF787D51E8E649F935F4DBBDEF0AE7E79C12A4ADBB250DEEAD4FE9E8D983756
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 4DF787D51E8E649F935F4DBBDEF0AE7E79C12A4ADBB250DEEAD4FE9E8D983756
-          label_len: 256
-        last_epoch: 1
-        min_descendant_epoch: 1
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: B2B00BD1FD3F45C450E492A634F305A43D5EE9A665834A49A1AD1BC81E3D0E57
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 7EC32D61A61F3D8C53F1B3F312F3AE60E153AB552FC46E94091F89C35A0E1341
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 7EC32D61A61F3D8C53F1B3F312F3AE60E153AB552FC46E94091F89C35A0E1341
-          label_len: 256
-        last_epoch: 3
-        min_descendant_epoch: 3
-        parent:
-          label_val: "7800000000000000000000000000000000000000000000000000000000000000"
-          label_len: 5
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 86C886D0733EDEEAF5E5C9FC8B7A26369AAB1A91CC27593E0881A7487D69FA29
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 2
-      latest_node:
-        label:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        last_epoch: 5
-        min_descendant_epoch: 3
-        parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        right_child:
-          label_val: AEBC771586C4265DAB54EBC4629AB9BFD382BE30FDC67FDBA7FB067E3B51D8B7
-          label_len: 256
-        hash: 57F5F89B1B02EE45700F1CE1C7FF3C071EBA6F456E06E35BE57C6BBF9297B144
-      previous_node:
-        label:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        last_epoch: 3
-        min_descendant_epoch: 3
-        parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: 8E2DF8905DE002AD29677FEF43C369E0D0504F9A7E3CB3F221E65E1AA9554A8B
-          label_len: 256
-        right_child:
-          label_val: AEBC771586C4265DAB54EBC4629AB9BFD382BE30FDC67FDBA7FB067E3B51D8B7
-          label_len: 256
-        hash: A8B214D604FF4F2CB6A6764BBD9784D0CC3960A4A6FB634C800C2BBF7388A4E2
-  - TreeNode:
-      label:
-        label_val: F30D287863718B9C41B6318D293C68D6B2D7F10A106EECA37A4411A41759AAD3
-        label_len: 256
-      latest_node:
-        label:
-          label_val: F30D287863718B9C41B6318D293C68D6B2D7F10A106EECA37A4411A41759AAD3
-          label_len: 256
-        last_epoch: 2
-        min_descendant_epoch: 2
-        parent:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 9CE6DAF35CB1EE1BFE3EA244FCFB8AEA9DA36E43F0EC803694122E989576AD55
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 57BDA197268698B8CBB74D80A5510AC869EEB21D80810BAD3FEABD26F258B52B
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 57BDA197268698B8CBB74D80A5510AC869EEB21D80810BAD3FEABD26F258B52B
-          label_len: 256
-        last_epoch: 6
-        min_descendant_epoch: 6
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: C01B322B0EFD793157C858ED5FB761C0A487A7A303EF2394FBD151E93B18FCB0
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 06DEEEE0508C6152127EEBA6B13C7EF8E78DD54126A36B27E6AA1D7C8AF297DE
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 06DEEEE0508C6152127EEBA6B13C7EF8E78DD54126A36B27E6AA1D7C8AF297DE
-          label_len: 256
-        last_epoch: 1
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: A9873E9802E830CB3F25F0CE69405F7C891CE40EB301AE1658B3D657A0E72A5E
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: E000000000000000000000000000000000000000000000000000000000000000
-        label_len: 5
-      latest_node:
-        label:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 5
-        last_epoch: 6
-        min_descendant_epoch: 4
-        parent:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        node_type: Interior
-        left_child:
-          label_val: E1E2366C30A2E8246783077E6AD13599563448038C78C0B9E492AC365614DEB7
-          label_len: 256
-        right_child:
-          label_val: E6B42CD9ABDFBE613158800BF70011C56F9D17F001BBD0C7CA0EA900FD4845DF
-          label_len: 256
-        hash: 307FC535938EA908B3DF094277EE8E1ED5813FBA5B9D0D1615C7567B5E19304F
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: E1E2366C30A2E8246783077E6AD13599563448038C78C0B9E492AC365614DEB7
-        label_len: 256
-      latest_node:
-        label:
-          label_val: E1E2366C30A2E8246783077E6AD13599563448038C78C0B9E492AC365614DEB7
-          label_len: 256
-        last_epoch: 4
-        min_descendant_epoch: 4
-        parent:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 5
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 01C5F16CC625193DEA287DAE19DB5EE2686C8D15DB3B4843DEC49EB0F62E4FBE
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "6000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 3
-      latest_node:
-        label:
-          label_val: "6000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        last_epoch: 6
-        min_descendant_epoch: 2
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: 6AB612EBC1965816ECCDD704B2D9AF25269ABC0E0D02990FED0B2BCE6C06C389
-          label_len: 256
-        right_child:
-          label_val: "7000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        hash: BFB9BAD32CCC7D57FC347D0B30E15B31233B4F72204DB357FE07625AC4CAAC74
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 4
-      latest_node:
-        label:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        last_epoch: 5
-        min_descendant_epoch: 1
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        node_type: Interior
-        left_child:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 6
-        right_child:
-          label_val: 4DF787D51E8E649F935F4DBBDEF0AE7E79C12A4ADBB250DEEAD4FE9E8D983756
-          label_len: 256
-        hash: 9C8BE6689D023806C211BE990A8E4DF848AC9D4AC695A170F283C999CF8088F6
-      previous_node:
-        label:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        last_epoch: 1
-        min_descendant_epoch: 1
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: 40B7654182ACF470672602DCE7186CEA1DB59738D7C9F1D607A9B24C362BE6C0
-          label_len: 256
-        right_child:
-          label_val: 4DF787D51E8E649F935F4DBBDEF0AE7E79C12A4ADBB250DEEAD4FE9E8D983756
-          label_len: 256
-        hash: A013AAEBF9C1B54B8513B90A62953DC2A0776457C71B84E7665078FF128D8D03
-  - TreeNode:
-      label:
-        label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 1
-      latest_node:
-        label:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        last_epoch: 7
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 0
-        node_type: Interior
-        left_child:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        right_child:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        hash: 38A7EB89FDBBB2A2DB4E8E120C79F729A9D0AE6515B7E26AF4C5B937D755DC7A
-      previous_node:
-        label:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        last_epoch: 6
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 0
-        node_type: Interior
-        left_child:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        right_child:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        hash: 745681934FD31751D6C7226970C82AD034E44359515561FD2D78CDDF5EE4C6E9
   - Azks:
       latest_epoch: 7
-      num_nodes: 41
-  - TreeNode:
-      label:
-        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 3
-      latest_node:
-        label:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        last_epoch: 6
-        min_descendant_epoch: 1
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        right_child:
-          label_val: 57BDA197268698B8CBB74D80A5510AC869EEB21D80810BAD3FEABD26F258B52B
-          label_len: 256
-        hash: F16C3BA290E76296FA4F7E4702C2CB3CC4C726867C904D145B4D30232EB4AB2E
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: CA3A8FB4749A2F7C6FC2C0BEEBD5D4270758E7A06D9D92D2928D1AFCB5E7F648
-        label_len: 256
-      latest_node:
-        label:
-          label_val: CA3A8FB4749A2F7C6FC2C0BEEBD5D4270758E7A06D9D92D2928D1AFCB5E7F648
-          label_len: 256
-        last_epoch: 2
-        min_descendant_epoch: 2
-        parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 806BAC5DC57EBCEAFE9B6461B817415E1BDBB0E0FB8B5B6A7C66FBF36205591B
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: C000000000000000000000000000000000000000000000000000000000000000
-        label_len: 2
-      latest_node:
-        label:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        last_epoch: 6
-        min_descendant_epoch: 2
-        parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        right_child:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        hash: 92D33A2244593647B3018A132C5175EA811D20E3C77A22514257F25FA6731B53
-      previous_node:
-        label:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        last_epoch: 5
-        min_descendant_epoch: 2
-        parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        right_child:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        hash: CEE2BAFCBFD6600DE9DEAA86D402A1147581C7C35716AB098B4CEB6027F7C11D
-  - TreeNode:
-      label:
-        label_val: 426B148EEF56E37D269EFC61247411446CE289AA5D167BD32CCFEC877765FCB2
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 426B148EEF56E37D269EFC61247411446CE289AA5D167BD32CCFEC877765FCB2
-          label_len: 256
-        last_epoch: 5
-        min_descendant_epoch: 5
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 6
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 2F2A621AD1F7BCD1BA26EEE24CF076A0A88B6D4D77CDB4F06191C27A857F1629
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 3
-      latest_node:
-        label:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        last_epoch: 5
-        min_descendant_epoch: 3
-        parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: 8E2DF8905DE002AD29677FEF43C369E0D0504F9A7E3CB3F221E65E1AA9554A8B
-          label_len: 256
-        right_child:
-          label_val: "9000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        hash: 149E9A9B04E072C0B682DFE0E6370F2E5E8CB9CBAB465E4A15D0F7DB555D21B0
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 8E2DF8905DE002AD29677FEF43C369E0D0504F9A7E3CB3F221E65E1AA9554A8B
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 8E2DF8905DE002AD29677FEF43C369E0D0504F9A7E3CB3F221E65E1AA9554A8B
-          label_len: 256
-        last_epoch: 3
-        min_descendant_epoch: 3
-        parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 795E3424A3DF236DCBAA461600BA4F0719974B638A2BC3DF0721626093B02818
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 6AB612EBC1965816ECCDD704B2D9AF25269ABC0E0D02990FED0B2BCE6C06C389
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 6AB612EBC1965816ECCDD704B2D9AF25269ABC0E0D02990FED0B2BCE6C06C389
-          label_len: 256
-        last_epoch: 6
-        min_descendant_epoch: 6
-        parent:
-          label_val: "6000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: FD5808558FD229CA27E68F61076ED0D9C37E8E50FAD97592ACCE5ED30CC51AB2
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 6
-      latest_node:
-        label:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 6
-        last_epoch: 5
-        min_descendant_epoch: 1
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        node_type: Interior
-        left_child:
-          label_val: 40B7654182ACF470672602DCE7186CEA1DB59738D7C9F1D607A9B24C362BE6C0
-          label_len: 256
-        right_child:
-          label_val: 426B148EEF56E37D269EFC61247411446CE289AA5D167BD32CCFEC877765FCB2
-          label_len: 256
-        hash: 6B3419C7C423D84C7B07EDE63A174BB163A67222C6A4FAF1E2C77527A7684F8A
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 2
-      latest_node:
-        label:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        last_epoch: 6
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        right_child:
-          label_val: "6000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        hash: A857119636BF4BDA061A5AF477DA9D05CFDA9BDCB164B42AC50E2AD68003D174
-      previous_node:
-        label:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        last_epoch: 5
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        right_child:
-          label_val: "7800000000000000000000000000000000000000000000000000000000000000"
-          label_len: 5
-        hash: 9CF75C2B55AAC473E0C21B3FA587700F7F10B745B656AAB94227058FA3505FB8
-  - TreeNode:
-      label:
-        label_val: "7000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 4
-      latest_node:
-        label:
-          label_val: "7000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        last_epoch: 6
-        min_descendant_epoch: 2
-        parent:
-          label_val: "6000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        node_type: Interior
-        left_child:
-          label_val: 74F6AB77F795C02E81A82D318C73EEF444C184E8A6D994E0F4B64F91553351DA
-          label_len: 256
-        right_child:
-          label_val: "7800000000000000000000000000000000000000000000000000000000000000"
-          label_len: 5
-        hash: 22C6EAF3539F43F0B6A493C3D6813FB06777C7365713E634645E8E8F166B2317
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 9EC4B36008568F3A571EE4BDE03E76611E51BBE7D7C6D2777CCA71B0BDF31E7F
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 9EC4B36008568F3A571EE4BDE03E76611E51BBE7D7C6D2777CCA71B0BDF31E7F
-          label_len: 256
-        last_epoch: 5
-        min_descendant_epoch: 5
-        parent:
-          label_val: "9000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: FD1EB17D43CAD8D453C2C8A38E00D9A00BAE17E0C00E4D19DA646D887E3A8DBB
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: C000000000000000000000000000000000000000000000000000000000000000
-        label_len: 4
-      latest_node:
-        label:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        last_epoch: 2
-        min_descendant_epoch: 2
-        parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: C7BAF6ABCDCC44429E4FD296B3E506F3BBC9BAE0CCCAF3D51C052FD3EA12A643
-          label_len: 256
-        right_child:
-          label_val: CA3A8FB4749A2F7C6FC2C0BEEBD5D4270758E7A06D9D92D2928D1AFCB5E7F648
-          label_len: 256
-        hash: AB87A500A9DA1FE84837DFEFC72529CAABE2A0EF2A2C693778D9DF54B172DF31
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 1
-      latest_node:
-        label:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        last_epoch: 6
-        min_descendant_epoch: 2
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 0
-        node_type: Interior
-        left_child:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        right_child:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        hash: EA0B4997CD2435F434F46AC1D7B0AD4DC5860BB83EC6A10F8EB0463A950B5510
-      previous_node:
-        label:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        last_epoch: 5
-        min_descendant_epoch: 2
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 0
-        node_type: Interior
-        left_child:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        right_child:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        hash: 9CD58CF3FA36641084A1D114E82B94376C36BAB8CBE008787ED1AD3CC021350B
-  - TreeNode:
-      label:
-        label_val: E000000000000000000000000000000000000000000000000000000000000000
-        label_len: 3
-      latest_node:
-        label:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        last_epoch: 6
-        min_descendant_epoch: 2
-        parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        right_child:
-          label_val: F30D287863718B9C41B6318D293C68D6B2D7F10A106EECA37A4411A41759AAD3
-          label_len: 256
-        hash: FE55F5CC713923396B9C4B88CF1075D2CCB04270E7D0F8680EF2189850ABAC8F
-      previous_node:
-        label:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        last_epoch: 5
-        min_descendant_epoch: 2
-        parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        right_child:
-          label_val: F30D287863718B9C41B6318D293C68D6B2D7F10A106EECA37A4411A41759AAD3
-          label_len: 256
-        hash: 4BB78E7180A19BF15294290CE178B589532412A6C9528A44B6E21D53CBB142FC
-  - TreeNode:
-      label:
-        label_val: 1B3197016C32205D6B4768770B19A563B0E204CA0F291071A4B5690FDE5D5E9F
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 1B3197016C32205D6B4768770B19A563B0E204CA0F291071A4B5690FDE5D5E9F
-          label_len: 256
-        last_epoch: 7
-        min_descendant_epoch: 7
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 6A8C04B3FB065A530FD6A1D8B4EDAE0A27864A92EF5F33FD8DB728DDA04D4082
-      previous_node: ~
-  - ValueState:
-      value: 334146627651746464545A4E4338326A353968706A744C4D4665356974717366
-      version: 1
-      label:
-        label_val: E1E2366C30A2E8246783077E6AD13599563448038C78C0B9E492AC365614DEB7
-        label_len: 256
-      epoch: 4
-      username: 736C7959594437396856435531627164426668746167537163624259736E3130
-  - ValueState:
-      value: 745A517042743972666B50436F36734F6A54495A6872635A6A574D6247715633
-      version: 1
-      label:
-        label_val: 8E2DF8905DE002AD29677FEF43C369E0D0504F9A7E3CB3F221E65E1AA9554A8B
-        label_len: 256
-      epoch: 3
-      username: 4765526F3841636563306E7769367A39346B766F5541443951355470794D3862
-  - ValueState:
-      value: 7851725473327746684A56703548514136706A7A714A426E5251316D326D7853
-      version: 1
-      label:
-        label_val: CA3A8FB4749A2F7C6FC2C0BEEBD5D4270758E7A06D9D92D2928D1AFCB5E7F648
-        label_len: 256
-      epoch: 2
-      username: 6B6F50796B564C414D726C7277395367426C72376A4D4B56304F5035504F4F35
-  - ValueState:
-      value: 6E65787774725065716547767A77504853704E73686C4644675A77715857746E
-      version: 1
-      label:
-        label_val: 426B148EEF56E37D269EFC61247411446CE289AA5D167BD32CCFEC877765FCB2
-        label_len: 256
-      epoch: 5
-      username: 6C36684E777569306D6F454D71714865555A6132335769516E6470633066564C
-  - ValueState:
-      value: 4D626971477730574A4F6639615379424E7A357438764353576B487753596548
-      version: 1
-      label:
-        label_val: 9EC4B36008568F3A571EE4BDE03E76611E51BBE7D7C6D2777CCA71B0BDF31E7F
-        label_len: 256
-      epoch: 5
-      username: 35637332787368554B4950575A57536D3435526F657A514A324246705542674B
-  - ValueState:
-      value: 44395942376C7361446A356A776F74746D5864375176425341484D65694F4167
-      version: 1
-      label:
-        label_val: 97B2F1F86164C236771A8CC90D192CD7D99A3016C5A5C1D912EAD392BC94AE20
-        label_len: 256
-      epoch: 5
-      username: 526372714F4D574A4A7278676C47644841566865374E654479567561744F7975
-  - ValueState:
-      value: 795871456A5371334935704D57775A5451744743695848566F50517575465A51
-      version: 1
-      label:
-        label_val: C7BAF6ABCDCC44429E4FD296B3E506F3BBC9BAE0CCCAF3D51C052FD3EA12A643
-        label_len: 256
-      epoch: 2
-      username: 673448775A58634162733235734D496D3851787271776F4B7730746A53384249
-  - ValueState:
-      value: 3550397A6F364B6A666D565A624B36784E504A6661556C4E5974696353717277
-      version: 1
-      label:
-        label_val: 40B7654182ACF470672602DCE7186CEA1DB59738D7C9F1D607A9B24C362BE6C0
-        label_len: 256
-      epoch: 1
-      username: 64534A635475736B6D59617155384C693779776F4141494832426D6E49554259
-  - ValueState:
-      value: 5A6F456D6E48624A62626F3636715A554971703631644A6C656E556C64377953
-      version: 1
-      label:
-        label_val: AEBC771586C4265DAB54EBC4629AB9BFD382BE30FDC67FDBA7FB067E3B51D8B7
-        label_len: 256
-      epoch: 3
-      username: 6E30374D356341694C664665746A317137447861665850644C4E59724D627A66
-  - ValueState:
-      value: 6C5779574964696D3176315359424B524E4F3343723533456B736F737143746D
-      version: 1
-      label:
-        label_val: E963B4F8460FFD1F7D93D4DE499B11AAC91030B2AD59EC45AE63C4479A45A133
-        label_len: 256
-      epoch: 5
-      username: 533545636F7530467532586A704B634A4258774B79764570734D33416F377462
-  - ValueState:
-      value: 6E4473387A65663370756B4D676F6254534F663455426D334A7A734C4D627342
-      version: 1
-      label:
-        label_val: 57BDA197268698B8CBB74D80A5510AC869EEB21D80810BAD3FEABD26F258B52B
-        label_len: 256
-      epoch: 6
-      username: 5A306B4F56696230477739355131666B4C53586E3057397A33544B67746B5768
-  - ValueState:
-      value: 6E4C4E636A7371787665307345513455436E7075634D33304A6B515A4567504A
-      version: 1
-      label:
-        label_val: 1B3197016C32205D6B4768770B19A563B0E204CA0F291071A4B5690FDE5D5E9F
-        label_len: 256
-      epoch: 7
-      username: 79593474675A6B346E6261416D3550333363467431307639574F376C64436B4D
-  - ValueState:
-      value: 496E5870394F544351646B57794B32345A786B3555746E62594A4D31784C5330
-      version: 1
-      label:
-        label_val: 398E7F16B6562B76B5A9E5B1F9B584263DA97CA6F4D06220A0EF2C2F1A95AB12
-        label_len: 256
-      epoch: 1
-      username: 674F733959655638316E5976736D743367714978424372755052493551357A30
-  - ValueState:
-      value: 4B336F51544563567A3431564A354B6E33385A7335534B6A486667316662754A
-      version: 1
-      label:
-        label_val: 7948F1797F2C5BDE543241EDD4F6D826AAA9F65331493ED8D6D96BFE6BC9507C
-        label_len: 256
-      epoch: 2
-      username: 6C786E4664624D384D394E386166704B744B75536631696359367036426D7333
-  - ValueState:
-      value: 48516F694A6F75564271476D624C5166626E5A6D3462326E484863444D377254
-      version: 1
-      label:
-        label_val: E6B42CD9ABDFBE613158800BF70011C56F9D17F001BBD0C7CA0EA900FD4845DF
-        label_len: 256
-      epoch: 6
-      username: 467A6E72444E484178547A6D4A6F466C655A70694B74326365597269464F6579
-  - ValueState:
-      value: 537A4334624577464C33595848437977746D5A3933495672725867475950526A
-      version: 1
-      label:
-        label_val: 06DEEEE0508C6152127EEBA6B13C7EF8E78DD54126A36B27E6AA1D7C8AF297DE
-        label_len: 256
-      epoch: 1
-      username: 62736A34657A44596C4938534E7A304A3737316755506D394D75434861457A42
-  - ValueState:
-      value: 347474734845695A517947357165716E616D5957674445634258663757554E35
-      version: 1
-      label:
-        label_val: 7EC32D61A61F3D8C53F1B3F312F3AE60E153AB552FC46E94091F89C35A0E1341
-        label_len: 256
-      epoch: 3
-      username: 79426866585A39794B5541434C5737464C484B656E64326B3831747454723578
-  - ValueState:
-      value: 68444139424F674447374A50736964334F6B4F4655424C385547594F62733466
-      version: 1
-      label:
-        label_val: 4DF787D51E8E649F935F4DBBDEF0AE7E79C12A4ADBB250DEEAD4FE9E8D983756
-        label_len: 256
-      epoch: 1
-      username: 33464C395674314C58416661634E507574416A75636F7242587A724765316147
-  - ValueState:
-      value: 675A5A74764D564D336D6D494F577678423962777A3231565131515A72374173
-      version: 1
-      label:
-        label_val: 74F6AB77F795C02E81A82D318C73EEF444C184E8A6D994E0F4B64F91553351DA
-        label_len: 256
-      epoch: 6
-      username: 753264484171355A71763463557150444779346C6E6B48737043685645646F43
-  - ValueState:
-      value: 51307267667034654B646E6273795A384835356A42374D61377645726A78716C
-      version: 1
-      label:
-        label_val: F30D287863718B9C41B6318D293C68D6B2D7F10A106EECA37A4411A41759AAD3
-        label_len: 256
-      epoch: 2
-      username: 533453507445775379383938534549706D3939756234586C5967304961706265
-  - ValueState:
-      value: 55505061453078335168596F78536B566D596E4C72324352426A626B6C633249
-      version: 1
-      label:
-        label_val: 6AB612EBC1965816ECCDD704B2D9AF25269ABC0E0D02990FED0B2BCE6C06C389
-        label_len: 256
-      epoch: 6
-      username: 7A5139346E6C4C5A465A6147386D5057546A4B67756F445632326B3232494741
-
-# Delta - Epoch 10
----
-epoch: 10
-updates:
-  - - 324F4F5241506F5273514B38565250765839777A6E6972704C5470626765655A
-    - 4575636F65396269526B364E64675663316C464F6F6D77414368713662697377
-  - - 3956733254734748744F664F55386C687144366F6C614D36784A31494B384851
-    - 6F67553448504F3145585754324B706945396172594C514E383267775378526D
-  - - 736C4E386A4833483468456330624D395A6C6772356537716D68744B33627037
-    - 436D6331766332374376305273534E524D44707A337430454E68786976434650
-
-# State - Epoch 10
----
-epoch: 10
-records:
-  - TreeNode:
-      label:
-        label_val: "5000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 4
-      latest_node:
-        label:
-          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        last_epoch: 8
-        min_descendant_epoch: 6
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        node_type: Interior
-        left_child:
-          label_val: 57BDA197268698B8CBB74D80A5510AC869EEB21D80810BAD3FEABD26F258B52B
-          label_len: 256
-        right_child:
-          label_val: 5D6D3BC6F72784D580BE798EF5816FB519485E184405F3BB517D7E1E11BE84B3
-          label_len: 256
-        hash: 06093EABD28C915F731E88679216F627DB7FBC9BF0DFA26D9DA9793BD8C251AD
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 40B7654182ACF470672602DCE7186CEA1DB59738D7C9F1D607A9B24C362BE6C0
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 40B7654182ACF470672602DCE7186CEA1DB59738D7C9F1D607A9B24C362BE6C0
-          label_len: 256
-        last_epoch: 1
-        min_descendant_epoch: 1
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 6
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: D46E3C909F32721265EF6071FCE64DCA908A62F3F71ABD67F439A47921A9FC46
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 2
-      latest_node:
-        label:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        last_epoch: 8
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        right_child:
-          label_val: 398E7F16B6562B76B5A9E5B1F9B584263DA97CA6F4D06220A0EF2C2F1A95AB12
-          label_len: 256
-        hash: 57A6A7DF092D2148F2CEF4EA7915AD45159986C5DAB074A65351A30C985013F0
-      previous_node:
-        label:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        last_epoch: 7
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        right_child:
-          label_val: 398E7F16B6562B76B5A9E5B1F9B584263DA97CA6F4D06220A0EF2C2F1A95AB12
-          label_len: 256
-        hash: A0318F4B4DEB30690D39EB391FFF9A8499CDA168EDCED649A7DF43162D54C23D
-  - TreeNode:
-      label:
-        label_val: "7800000000000000000000000000000000000000000000000000000000000000"
-        label_len: 5
-      latest_node:
-        label:
-          label_val: "7800000000000000000000000000000000000000000000000000000000000000"
-          label_len: 5
-        last_epoch: 3
-        min_descendant_epoch: 2
-        parent:
-          label_val: "7000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        node_type: Interior
-        left_child:
-          label_val: 7948F1797F2C5BDE543241EDD4F6D826AAA9F65331493ED8D6D96BFE6BC9507C
-          label_len: 256
-        right_child:
-          label_val: 7EC32D61A61F3D8C53F1B3F312F3AE60E153AB552FC46E94091F89C35A0E1341
-          label_len: 256
-        hash: C4D95421B1B98792217BD9C141F9A4D8CF6CE172704803A744FB749981657B4C
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: E6B42CD9ABDFBE613158800BF70011C56F9D17F001BBD0C7CA0EA900FD4845DF
-        label_len: 256
-      latest_node:
-        label:
-          label_val: E6B42CD9ABDFBE613158800BF70011C56F9D17F001BBD0C7CA0EA900FD4845DF
-          label_len: 256
-        last_epoch: 6
-        min_descendant_epoch: 6
-        parent:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 5
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: FCE19AB15447C3AAC5C3F34294CD6D7B93C44136ABA76FDDE2692E0273086B1C
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 7948F1797F2C5BDE543241EDD4F6D826AAA9F65331493ED8D6D96BFE6BC9507C
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 7948F1797F2C5BDE543241EDD4F6D826AAA9F65331493ED8D6D96BFE6BC9507C
-          label_len: 256
-        last_epoch: 2
-        min_descendant_epoch: 2
-        parent:
-          label_val: "7800000000000000000000000000000000000000000000000000000000000000"
-          label_len: 5
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: E0D68F634ED5C06DAB0EA8DF51AC4B4182AB0DEC2DC11C0821F1C4E491525196
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: C7BAF6ABCDCC44429E4FD296B3E506F3BBC9BAE0CCCAF3D51C052FD3EA12A643
-        label_len: 256
-      latest_node:
-        label:
-          label_val: C7BAF6ABCDCC44429E4FD296B3E506F3BBC9BAE0CCCAF3D51C052FD3EA12A643
-          label_len: 256
-        last_epoch: 2
-        min_descendant_epoch: 2
-        parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: FDB008ED88BDE9A12D86608DC80201AFB31C5EF9182B3062CA0CFD1E93E3FB1A
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 97B2F1F86164C236771A8CC90D192CD7D99A3016C5A5C1D912EAD392BC94AE20
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 97B2F1F86164C236771A8CC90D192CD7D99A3016C5A5C1D912EAD392BC94AE20
-          label_len: 256
-        last_epoch: 5
-        min_descendant_epoch: 5
-        parent:
-          label_val: "9000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 16705337F7867CEF5D8CB2D48D274E31EBB0C976EF40BDCF23C44F995F319909
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: E963B4F8460FFD1F7D93D4DE499B11AAC91030B2AD59EC45AE63C4479A45A133
-        label_len: 256
-      latest_node:
-        label:
-          label_val: E963B4F8460FFD1F7D93D4DE499B11AAC91030B2AD59EC45AE63C4479A45A133
-          label_len: 256
-        last_epoch: 5
-        min_descendant_epoch: 5
-        parent:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 79EE6AD0FF9BD73A07986F40011FD3759E4C91FCD47D6F06E35C245A1F14CFB9
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: E000000000000000000000000000000000000000000000000000000000000000
-        label_len: 4
-      latest_node:
-        label:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        last_epoch: 6
-        min_descendant_epoch: 4
-        parent:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        node_type: Interior
-        left_child:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 5
-        right_child:
-          label_val: E963B4F8460FFD1F7D93D4DE499B11AAC91030B2AD59EC45AE63C4479A45A133
-          label_len: 256
-        hash: 8084B8304AEECE6920B40F935247662C53450C38F458F70E15117F522A0056AD
-      previous_node:
-        label:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        last_epoch: 5
-        min_descendant_epoch: 4
-        parent:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        node_type: Interior
-        left_child:
-          label_val: E1E2366C30A2E8246783077E6AD13599563448038C78C0B9E492AC365614DEB7
-          label_len: 256
-        right_child:
-          label_val: E963B4F8460FFD1F7D93D4DE499B11AAC91030B2AD59EC45AE63C4479A45A133
-          label_len: 256
-        hash: C020D10B09DC6551292B9A4C4FEA692238EF07132D5311F3AFF68740263EBF08
+      num_nodes: 35
   - TreeNode:
       label:
         label_val: "0000000000000000000000000000000000000000000000000000000000000000"
@@ -1429,23 +39,6 @@ records:
         label:
           label_val: "0000000000000000000000000000000000000000000000000000000000000000"
           label_len: 0
-        last_epoch: 8
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 0
-        node_type: Root
-        left_child:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        right_child:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        hash: FC899BCF7E43E3719CB5A1734663645462BF54F1CFE972BB83FAE52790C7E538
-      previous_node:
-        label:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 0
         last_epoch: 7
         min_descendant_epoch: 1
         parent:
@@ -1458,25 +51,214 @@ records:
         right_child:
           label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 1
-        hash: 0B7F32D70650E5113548BB6EA7464A48B3C6EB847421B148E0910E95FCB933FC
+        hash: 4F6A7FA6555ABB366EEB50AB610F5AD6AF26E4155C317D7A678C7AEFCA509083
+      previous_node:
+        label:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 0
+        last_epoch: 6
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 0
+        node_type: Root
+        left_child:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        right_child:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        hash: 6C84E02C12EAC329B08D25BB2B1E31BD5445C42A3FFEDDC6B35126F5AF8E55F4
   - TreeNode:
       label:
-        label_val: 74F6AB77F795C02E81A82D318C73EEF444C184E8A6D994E0F4B64F91553351DA
-        label_len: 256
+        label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 1
       latest_node:
         label:
-          label_val: 74F6AB77F795C02E81A82D318C73EEF444C184E8A6D994E0F4B64F91553351DA
-          label_len: 256
-        last_epoch: 6
-        min_descendant_epoch: 6
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        last_epoch: 7
+        min_descendant_epoch: 1
         parent:
-          label_val: "7000000000000000000000000000000000000000000000000000000000000000"
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 0
+        node_type: Interior
+        left_child:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        right_child:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        hash: F344EA4084A239866253B518B2E7B4344AE177D4C325A1348624BD4BB339B070
+      previous_node:
+        label:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        last_epoch: 6
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 0
+        node_type: Interior
+        left_child:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        right_child:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        hash: 03A536754CDCE7DC649B95CB41651280FB7962428F1BF4C97DC8B77DBD7BFF67
+  - TreeNode:
+      label:
+        label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 1
+      latest_node:
+        label:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        last_epoch: 7
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 0
+        node_type: Interior
+        left_child:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        right_child:
+          label_val: C56CFAEFB7763D8BE2AEC18A25EBFC294DCC6C2230AEEAF7C1FE9B3FD52EB5D3
+          label_len: 256
+        hash: 9B4A979F8E949ECB0FB3A71CF86C174AB657C042A359EA3553FFA55954516C1C
+      previous_node:
+        label:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        last_epoch: 4
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 0
+        node_type: Interior
+        left_child:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        right_child:
+          label_val: C56CFAEFB7763D8BE2AEC18A25EBFC294DCC6C2230AEEAF7C1FE9B3FD52EB5D3
+          label_len: 256
+        hash: 3240D8D04E3240A263847DEFBE8B120D96A88A605889D4AC3A6373E8088AC008
+  - TreeNode:
+      label:
+        label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 2
+      latest_node:
+        label:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        last_epoch: 7
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        right_child:
+          label_val: 2FE1876847F44393AE2DA7BE4E090E6F1FA26E0B6F7BAC746DBDF81FFAC66989
+          label_len: 256
+        hash: 21FB739CF36BF1E5E6D7E3389BE03B89598CADD2187FCA3285CEEE8218F67995
+      previous_node:
+        label:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        last_epoch: 6
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: "1000000000000000000000000000000000000000000000000000000000000000"
           label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: CDE1E79EFC56AAF9FF7774912836B5A32E6C145B5AA0D53303ADB9D37617024B
-      previous_node: ~
+        right_child:
+          label_val: 2FE1876847F44393AE2DA7BE4E090E6F1FA26E0B6F7BAC746DBDF81FFAC66989
+          label_len: 256
+        hash: C678A14A14E89CFEDA6FC4365FC4E1747C61D98923028FFC2ED18F60007D38C1
+  - TreeNode:
+      label:
+        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 2
+      latest_node:
+        label:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        last_epoch: 7
+        min_descendant_epoch: 3
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        right_child:
+          label_val: "7000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        hash: 23F9E2C9A006D874E65F1D18CBE432F79E61FA5CA1C5EC79BB04C9CD0250DABF
+      previous_node:
+        label:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        last_epoch: 5
+        min_descendant_epoch: 3
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        right_child:
+          label_val: "7600000000000000000000000000000000000000000000000000000000000000"
+          label_len: 7
+        hash: E3E8D12CE7551B75963D1A804C061B9DBB01D62CC2717070848A989AC32A0461
+  - TreeNode:
+      label:
+        label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 2
+      latest_node:
+        label:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        last_epoch: 7
+        min_descendant_epoch: 1
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        right_child:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        hash: 7E7FB832223530BBD4A2969D8A479F6B195172C735AD175C0FBD9AD9589153A6
+      previous_node:
+        label:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        last_epoch: 4
+        min_descendant_epoch: 1
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        right_child:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        hash: F67DFF587B70193FBDC116527047A0ADA9D0B012811D13F5D0CC1652FA8A3BA1
   - TreeNode:
       label:
         label_val: "0000000000000000000000000000000000000000000000000000000000000000"
@@ -1485,23 +267,6 @@ records:
         label:
           label_val: "0000000000000000000000000000000000000000000000000000000000000000"
           label_len: 3
-        last_epoch: 8
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: 06DEEEE0508C6152127EEBA6B13C7EF8E78DD54126A36B27E6AA1D7C8AF297DE
-          label_len: 256
-        right_child:
-          label_val: "1000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        hash: A6BE4FF2CAE66DF9A1E0231E59A28397ED27AE230BE167EC5396A818D6AEE279
-      previous_node:
-        label:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
         last_epoch: 7
         min_descendant_epoch: 1
         parent:
@@ -1509,30 +274,73 @@ records:
           label_len: 2
         node_type: Interior
         left_child:
-          label_val: 06DEEEE0508C6152127EEBA6B13C7EF8E78DD54126A36B27E6AA1D7C8AF297DE
+          label_val: 0C3119F4E4B887BD0829B51036AE825336491BA4404775A443E691D88A3B0FD4
           label_len: 256
         right_child:
-          label_val: 1B3197016C32205D6B4768770B19A563B0E204CA0F291071A4B5690FDE5D5E9F
-          label_len: 256
-        hash: 13001B6E41A82103B6DD1CA5706D098228EEF8F8882F58EF605B76A3CB003027
-  - TreeNode:
-      label:
-        label_val: 1542AECD490E66E32D92BA6068843407531D99DE5C195A94EE7D229294431944
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 1542AECD490E66E32D92BA6068843407531D99DE5C195A94EE7D229294431944
-          label_len: 256
-        last_epoch: 8
-        min_descendant_epoch: 8
-        parent:
           label_val: "1000000000000000000000000000000000000000000000000000000000000000"
           label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 736C1913C079A62F8C486C2324B499A1ADAD1AB623AD949B2EE78CD4758057F3
+        hash: 8E7B67A809275F3603AE294EFC84220A196384F36C5BADE3F28DE90326CB3E58
       previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 3
+      latest_node:
+        label:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        last_epoch: 7
+        min_descendant_epoch: 4
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: 43CCBE8BA4A4A59C932BC7C34DCE84A1AE68A7F4C67CB4B9554E8F3B14E9BB86
+          label_len: 256
+        right_child:
+          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        hash: 27A8F45251A4F77C43C37F7DC2DCAAAE89AD97B52DF36B3E0B0EBCF4EA2DC39C
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 3
+      latest_node:
+        label:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        last_epoch: 7
+        min_descendant_epoch: 2
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        right_child:
+          label_val: 97702376D7DD777A9DE17B56D0C82A0B3205FB075737B40027EB63B831508676
+          label_len: 256
+        hash: AF63DA27C9C73234B67A8139DDC7D47C64F0B182C214A98BB1B1424FFCE7BDFA
+      previous_node:
+        label:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        last_epoch: 4
+        min_descendant_epoch: 2
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        right_child:
+          label_val: 97702376D7DD777A9DE17B56D0C82A0B3205FB075737B40027EB63B831508676
+          label_len: 256
+        hash: 2CCF33B386814AEDB52A6E74DA7DC66C6C37815C273AF31DAC5F3714B494B586
   - TreeNode:
       label:
         label_val: "1000000000000000000000000000000000000000000000000000000000000000"
@@ -1541,534 +349,63 @@ records:
         label:
           label_val: "1000000000000000000000000000000000000000000000000000000000000000"
           label_len: 4
-        last_epoch: 8
-        min_descendant_epoch: 7
+        last_epoch: 6
+        min_descendant_epoch: 1
         parent:
           label_val: "0000000000000000000000000000000000000000000000000000000000000000"
           label_len: 3
         node_type: Interior
         left_child:
-          label_val: 1542AECD490E66E32D92BA6068843407531D99DE5C195A94EE7D229294431944
-          label_len: 256
+          label_val: "1000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
         right_child:
-          label_val: 1B3197016C32205D6B4768770B19A563B0E204CA0F291071A4B5690FDE5D5E9F
+          label_val: 1EDF80D70B304EE674025E88C07E188DBDDB131AB70F94C42519674C2C8E37D8
           label_len: 256
-        hash: 55FC509C998D39443D3F909CC4E54709678CF1612D22C2DF47F50D035CC90937
+        hash: A4F41FF1EF9D814AC4F54A542502A3D6DA488630841A3B11D1282E253AFE04E2
       previous_node: ~
   - TreeNode:
       label:
-        label_val: AEBC771586C4265DAB54EBC4629AB9BFD382BE30FDC67FDBA7FB067E3B51D8B7
-        label_len: 256
-      latest_node:
-        label:
-          label_val: AEBC771586C4265DAB54EBC4629AB9BFD382BE30FDC67FDBA7FB067E3B51D8B7
-          label_len: 256
-        last_epoch: 3
-        min_descendant_epoch: 3
-        parent:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: E01C1A1008385C4E202CFBF866C5476E442A21393D6C7F76597603A58B43CF0A
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "9000000000000000000000000000000000000000000000000000000000000000"
+        label_val: "5000000000000000000000000000000000000000000000000000000000000000"
         label_len: 4
       latest_node:
         label:
-          label_val: "9000000000000000000000000000000000000000000000000000000000000000"
+          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
           label_len: 4
         last_epoch: 5
-        min_descendant_epoch: 5
+        min_descendant_epoch: 4
         parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
           label_len: 3
         node_type: Interior
         left_child:
-          label_val: 97B2F1F86164C236771A8CC90D192CD7D99A3016C5A5C1D912EAD392BC94AE20
+          label_val: 55406EA0A875AD8CEA804D34E74A26728C6DF07F76BC8F76AFECFE8A58EDD821
           label_len: 256
         right_child:
-          label_val: 9EC4B36008568F3A571EE4BDE03E76611E51BBE7D7C6D2777CCA71B0BDF31E7F
+          label_val: 5EDDBD26F1ADEF9ED0A0CAE9E4D943F492E28B98D8181C96A834614FA40396FE
           label_len: 256
-        hash: EEF38B64D48863F92ADDF92317B3E56C1D29BD59A39EC15D71288238710863D9
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 398E7F16B6562B76B5A9E5B1F9B584263DA97CA6F4D06220A0EF2C2F1A95AB12
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 398E7F16B6562B76B5A9E5B1F9B584263DA97CA6F4D06220A0EF2C2F1A95AB12
-          label_len: 256
-        last_epoch: 1
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 2DC2E4EDB446FFC7683FE23D5E4E9ABE78373B19FB1BE5B2C337E54CE1D810EF
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 4DF787D51E8E649F935F4DBBDEF0AE7E79C12A4ADBB250DEEAD4FE9E8D983756
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 4DF787D51E8E649F935F4DBBDEF0AE7E79C12A4ADBB250DEEAD4FE9E8D983756
-          label_len: 256
-        last_epoch: 1
-        min_descendant_epoch: 1
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: B2B00BD1FD3F45C450E492A634F305A43D5EE9A665834A49A1AD1BC81E3D0E57
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 7EC32D61A61F3D8C53F1B3F312F3AE60E153AB552FC46E94091F89C35A0E1341
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 7EC32D61A61F3D8C53F1B3F312F3AE60E153AB552FC46E94091F89C35A0E1341
-          label_len: 256
-        last_epoch: 3
-        min_descendant_epoch: 3
-        parent:
-          label_val: "7800000000000000000000000000000000000000000000000000000000000000"
-          label_len: 5
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 86C886D0733EDEEAF5E5C9FC8B7A26369AAB1A91CC27593E0881A7487D69FA29
+        hash: 475A3FCE53462DE70FD443C3B9B295FB0A57BA89160E1A4299AB624A2EAC868D
       previous_node: ~
   - TreeNode:
       label:
         label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 2
-      latest_node:
-        label:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        last_epoch: 8
-        min_descendant_epoch: 3
-        parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        right_child:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        hash: 222E23DC085C30B086F1DCBDAADAEC05984CF6E0D13805D3F07DFCCB8D3F59AC
-      previous_node:
-        label:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        last_epoch: 5
-        min_descendant_epoch: 3
-        parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        right_child:
-          label_val: AEBC771586C4265DAB54EBC4629AB9BFD382BE30FDC67FDBA7FB067E3B51D8B7
-          label_len: 256
-        hash: 57F5F89B1B02EE45700F1CE1C7FF3C071EBA6F456E06E35BE57C6BBF9297B144
-  - TreeNode:
-      label:
-        label_val: F30D287863718B9C41B6318D293C68D6B2D7F10A106EECA37A4411A41759AAD3
-        label_len: 256
-      latest_node:
-        label:
-          label_val: F30D287863718B9C41B6318D293C68D6B2D7F10A106EECA37A4411A41759AAD3
-          label_len: 256
-        last_epoch: 2
-        min_descendant_epoch: 2
-        parent:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 9CE6DAF35CB1EE1BFE3EA244FCFB8AEA9DA36E43F0EC803694122E989576AD55
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 57BDA197268698B8CBB74D80A5510AC869EEB21D80810BAD3FEABD26F258B52B
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 57BDA197268698B8CBB74D80A5510AC869EEB21D80810BAD3FEABD26F258B52B
-          label_len: 256
-        last_epoch: 6
-        min_descendant_epoch: 6
-        parent:
-          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: C01B322B0EFD793157C858ED5FB761C0A487A7A303EF2394FBD151E93B18FCB0
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 06DEEEE0508C6152127EEBA6B13C7EF8E78DD54126A36B27E6AA1D7C8AF297DE
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 06DEEEE0508C6152127EEBA6B13C7EF8E78DD54126A36B27E6AA1D7C8AF297DE
-          label_len: 256
-        last_epoch: 1
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: A9873E9802E830CB3F25F0CE69405F7C891CE40EB301AE1658B3D657A0E72A5E
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: E000000000000000000000000000000000000000000000000000000000000000
-        label_len: 5
-      latest_node:
-        label:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 5
-        last_epoch: 6
-        min_descendant_epoch: 4
-        parent:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        node_type: Interior
-        left_child:
-          label_val: E1E2366C30A2E8246783077E6AD13599563448038C78C0B9E492AC365614DEB7
-          label_len: 256
-        right_child:
-          label_val: E6B42CD9ABDFBE613158800BF70011C56F9D17F001BBD0C7CA0EA900FD4845DF
-          label_len: 256
-        hash: 307FC535938EA908B3DF094277EE8E1ED5813FBA5B9D0D1615C7567B5E19304F
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 5D6D3BC6F72784D580BE798EF5816FB519485E184405F3BB517D7E1E11BE84B3
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 5D6D3BC6F72784D580BE798EF5816FB519485E184405F3BB517D7E1E11BE84B3
-          label_len: 256
-        last_epoch: 8
-        min_descendant_epoch: 8
-        parent:
-          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 553647B0596DF12C041504B33817A2F1EFB9D908B66EE92F36B7AA9E78992DDF
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: E1E2366C30A2E8246783077E6AD13599563448038C78C0B9E492AC365614DEB7
-        label_len: 256
-      latest_node:
-        label:
-          label_val: E1E2366C30A2E8246783077E6AD13599563448038C78C0B9E492AC365614DEB7
-          label_len: 256
-        last_epoch: 4
-        min_descendant_epoch: 4
-        parent:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 5
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 01C5F16CC625193DEA287DAE19DB5EE2686C8D15DB3B4843DEC49EB0F62E4FBE
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "6000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 3
-      latest_node:
-        label:
-          label_val: "6000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        last_epoch: 6
-        min_descendant_epoch: 2
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: 6AB612EBC1965816ECCDD704B2D9AF25269ABC0E0D02990FED0B2BCE6C06C389
-          label_len: 256
-        right_child:
-          label_val: "7000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        hash: BFB9BAD32CCC7D57FC347D0B30E15B31233B4F72204DB357FE07625AC4CAAC74
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
         label_len: 4
       latest_node:
         label:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 4
-        last_epoch: 5
-        min_descendant_epoch: 1
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        node_type: Interior
-        left_child:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 6
-        right_child:
-          label_val: 4DF787D51E8E649F935F4DBBDEF0AE7E79C12A4ADBB250DEEAD4FE9E8D983756
-          label_len: 256
-        hash: 9C8BE6689D023806C211BE990A8E4DF848AC9D4AC695A170F283C999CF8088F6
-      previous_node:
-        label:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        last_epoch: 1
-        min_descendant_epoch: 1
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: 40B7654182ACF470672602DCE7186CEA1DB59738D7C9F1D607A9B24C362BE6C0
-          label_len: 256
-        right_child:
-          label_val: 4DF787D51E8E649F935F4DBBDEF0AE7E79C12A4ADBB250DEEAD4FE9E8D983756
-          label_len: 256
-        hash: A013AAEBF9C1B54B8513B90A62953DC2A0776457C71B84E7665078FF128D8D03
-  - TreeNode:
-      label:
-        label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 1
-      latest_node:
-        label:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        last_epoch: 8
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 0
-        node_type: Interior
-        left_child:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        right_child:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        hash: A4A91E7E947147C473E29A78ADD36E7164D53C1A3F019E1222DF535427F089EC
-      previous_node:
-        label:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
         last_epoch: 7
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 0
-        node_type: Interior
-        left_child:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        right_child:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        hash: 38A7EB89FDBBB2A2DB4E8E120C79F729A9D0AE6515B7E26AF4C5B937D755DC7A
-  - TreeNode:
-      label:
-        label_val: A4D9DDD2ED43F51B4123A55FC47610B129B7DB8B521248F4DAC92258AB960EF9
-        label_len: 256
-      latest_node:
-        label:
-          label_val: A4D9DDD2ED43F51B4123A55FC47610B129B7DB8B521248F4DAC92258AB960EF9
-          label_len: 256
-        last_epoch: 8
-        min_descendant_epoch: 8
-        parent:
-          label_val: A000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 0691523E9E7C825AA161AC49066A9FB92EB30AF57321ED7F594D167DC1FE5C36
-      previous_node: ~
-  - Azks:
-      latest_epoch: 8
-      num_nodes: 47
-  - TreeNode:
-      label:
-        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 3
-      latest_node:
-        label:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        last_epoch: 8
-        min_descendant_epoch: 1
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        right_child:
-          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        hash: A1B2870FB1DA6E0F139FA01EEB45BA0CB826E2AE5A7FFFE922ABB287D0DA36AB
-      previous_node:
-        label:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        last_epoch: 6
-        min_descendant_epoch: 1
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        right_child:
-          label_val: 57BDA197268698B8CBB74D80A5510AC869EEB21D80810BAD3FEABD26F258B52B
-          label_len: 256
-        hash: F16C3BA290E76296FA4F7E4702C2CB3CC4C726867C904D145B4D30232EB4AB2E
-  - TreeNode:
-      label:
-        label_val: CA3A8FB4749A2F7C6FC2C0BEEBD5D4270758E7A06D9D92D2928D1AFCB5E7F648
-        label_len: 256
-      latest_node:
-        label:
-          label_val: CA3A8FB4749A2F7C6FC2C0BEEBD5D4270758E7A06D9D92D2928D1AFCB5E7F648
-          label_len: 256
-        last_epoch: 2
-        min_descendant_epoch: 2
-        parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 806BAC5DC57EBCEAFE9B6461B817415E1BDBB0E0FB8B5B6A7C66FBF36205591B
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: C000000000000000000000000000000000000000000000000000000000000000
-        label_len: 2
-      latest_node:
-        label:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        last_epoch: 6
         min_descendant_epoch: 2
         parent:
           label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
+          label_len: 3
         node_type: Interior
         left_child:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
         right_child:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        hash: 92D33A2244593647B3018A132C5175EA811D20E3C77A22514257F25FA6731B53
-      previous_node:
-        label:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        last_epoch: 5
-        min_descendant_epoch: 2
-        parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        right_child:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        hash: CEE2BAFCBFD6600DE9DEAA86D402A1147581C7C35716AB098B4CEB6027F7C11D
-  - TreeNode:
-      label:
-        label_val: 426B148EEF56E37D269EFC61247411446CE289AA5D167BD32CCFEC877765FCB2
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 426B148EEF56E37D269EFC61247411446CE289AA5D167BD32CCFEC877765FCB2
+          label_val: 8DD2ECC135DD951442104A7FB071734D51C5585104EDC0B70FF33247DEBD7E97
           label_len: 256
-        last_epoch: 5
-        min_descendant_epoch: 5
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 6
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 2F2A621AD1F7BCD1BA26EEE24CF076A0A88B6D4D77CDB4F06191C27A857F1629
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 3
-      latest_node:
-        label:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        last_epoch: 5
-        min_descendant_epoch: 3
-        parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: 8E2DF8905DE002AD29677FEF43C369E0D0504F9A7E3CB3F221E65E1AA9554A8B
-          label_len: 256
-        right_child:
-          label_val: "9000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        hash: 149E9A9B04E072C0B682DFE0E6370F2E5E8CB9CBAB465E4A15D0F7DB555D21B0
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 8E2DF8905DE002AD29677FEF43C369E0D0504F9A7E3CB3F221E65E1AA9554A8B
-        label_len: 256
-      latest_node:
-        label:
-          label_val: 8E2DF8905DE002AD29677FEF43C369E0D0504F9A7E3CB3F221E65E1AA9554A8B
-          label_len: 256
-        last_epoch: 3
-        min_descendant_epoch: 3
-        parent:
-          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        node_type: Leaf
-        left_child: ~
-        right_child: ~
-        hash: 795E3424A3DF236DCBAA461600BA4F0719974B638A2BC3DF0721626093B02818
+        hash: A7F8B4473492886191B685BC6E1B0B1ABF5FEFBEC9BE413736B7BF40482C580B
       previous_node: ~
   - TreeNode:
       label:
@@ -2078,160 +415,665 @@ records:
         label:
           label_val: A000000000000000000000000000000000000000000000000000000000000000
           label_len: 4
-        last_epoch: 8
-        min_descendant_epoch: 3
+        last_epoch: 2
+        min_descendant_epoch: 1
         parent:
           label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 2
         node_type: Interior
         left_child:
-          label_val: A4D9DDD2ED43F51B4123A55FC47610B129B7DB8B521248F4DAC92258AB960EF9
+          label_val: A2F95664E2D6E4FE6FE6640664F9B1CDFAA4482365D581FADA34C1D7A36BE455
           label_len: 256
         right_child:
-          label_val: AEBC771586C4265DAB54EBC4629AB9BFD382BE30FDC67FDBA7FB067E3B51D8B7
+          label_val: A918CC35D187E0F6C349A70D154A88C4B5509895EC1030EEBB0F4BB57D9097D8
           label_len: 256
-        hash: D0D4236D5B92692E870E16601C2AAC5D5989CE48EEA4E9AD45088F638C862723
+        hash: 2449203C480837D98F0A03AA18078E789BD3DB67E09BC406E4B192D9A0925A9A
       previous_node: ~
   - TreeNode:
       label:
-        label_val: 6AB612EBC1965816ECCDD704B2D9AF25269ABC0E0D02990FED0B2BCE6C06C389
+        label_val: "1000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 5
+      latest_node:
+        label:
+          label_val: "1000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        last_epoch: 2
+        min_descendant_epoch: 1
+        parent:
+          label_val: "1000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        node_type: Interior
+        left_child:
+          label_val: 135C0227DC8DA44BEC49816ADB703777386065DDE54D1676FA4C3617FBFF38C9
+          label_len: 256
+        right_child:
+          label_val: 15D593AE830FBC02DC517894CCDBFB7F1BA579E624198DE46A7A819FAABAA309
+          label_len: 256
+        hash: 6EEE7DC3BAF3258E652779CDEC51CD2572B932564B25EE909E17438782F78414
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "7000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 5
+      latest_node:
+        label:
+          label_val: "7000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        last_epoch: 7
+        min_descendant_epoch: 3
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: 7174C888D9A49B2527981950D34769A58F2C082903FDB232515107B0EC0F1D0F
+          label_len: 256
+        right_child:
+          label_val: "7600000000000000000000000000000000000000000000000000000000000000"
+          label_len: 7
+        hash: 5E6ED36E528DB7C1A99C74150945A1F81D4A11EAED9545C9F9E0D2CC606F3081
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 5
+      latest_node:
+        label:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        last_epoch: 4
+        min_descendant_epoch: 2
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        node_type: Interior
+        left_child:
+          label_val: 8200E25CF621883F9924829AC1AE41EEBB577BC83F4A5AFF7CCD8B8512D0DCC8
+          label_len: 256
+        right_child:
+          label_val: 86B837789865B058126EBC012AA52F1D83E76AB517390431196D1F7DB2FC8648
+          label_len: 256
+        hash: C44B701497AD38194F0069EB6532DD3480BC6E302398C13F85647770AE019C25
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "7600000000000000000000000000000000000000000000000000000000000000"
+        label_len: 7
+      latest_node:
+        label:
+          label_val: "7600000000000000000000000000000000000000000000000000000000000000"
+          label_len: 7
+        last_epoch: 5
+        min_descendant_epoch: 3
+        parent:
+          label_val: "7000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        node_type: Interior
+        left_child:
+          label_val: 76B4E057390179DC53787FE517C20150AE40EF0F49C312307E9612141C10963B
+          label_len: 256
+        right_child:
+          label_val: 77AF0D50803929DCCD4156C815A714DCEC3D77265156798E6BE20F194F14189D
+          label_len: 256
+        hash: 553E2E8843FB17C36F1A4168B93F628E21B397BB3471B35EDE41F7C6D970B979
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 0C3119F4E4B887BD0829B51036AE825336491BA4404775A443E691D88A3B0FD4
         label_len: 256
       latest_node:
         label:
-          label_val: 6AB612EBC1965816ECCDD704B2D9AF25269ABC0E0D02990FED0B2BCE6C06C389
+          label_val: 0C3119F4E4B887BD0829B51036AE825336491BA4404775A443E691D88A3B0FD4
+          label_len: 256
+        last_epoch: 7
+        min_descendant_epoch: 7
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: C6E14E32FDF8B8EF40EE5D168A4EF303132454550D15C30A30B751E842CEBD31
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 135C0227DC8DA44BEC49816ADB703777386065DDE54D1676FA4C3617FBFF38C9
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 135C0227DC8DA44BEC49816ADB703777386065DDE54D1676FA4C3617FBFF38C9
+          label_len: 256
+        last_epoch: 1
+        min_descendant_epoch: 1
+        parent:
+          label_val: "1000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 0F8341865FFB77A40BFAC873A97595CF511E5B3E9E205B5F6EC086964979F90F
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 15D593AE830FBC02DC517894CCDBFB7F1BA579E624198DE46A7A819FAABAA309
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 15D593AE830FBC02DC517894CCDBFB7F1BA579E624198DE46A7A819FAABAA309
+          label_len: 256
+        last_epoch: 2
+        min_descendant_epoch: 2
+        parent:
+          label_val: "1000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 0275C64BD8F46BDEB28B9EFD921831DC35876A4B84C81F4955F2DAED26EA34F5
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 1EDF80D70B304EE674025E88C07E188DBDDB131AB70F94C42519674C2C8E37D8
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 1EDF80D70B304EE674025E88C07E188DBDDB131AB70F94C42519674C2C8E37D8
           label_len: 256
         last_epoch: 6
         min_descendant_epoch: 6
         parent:
-          label_val: "6000000000000000000000000000000000000000000000000000000000000000"
+          label_val: "1000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: ED557078CD9BD4B9B7C84BE6DD80083C73B2B27FD5D6014C56246DF6B832E1B2
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 2FE1876847F44393AE2DA7BE4E090E6F1FA26E0B6F7BAC746DBDF81FFAC66989
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 2FE1876847F44393AE2DA7BE4E090E6F1FA26E0B6F7BAC746DBDF81FFAC66989
+          label_len: 256
+        last_epoch: 1
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: D7B658ED6F9DB4183A1A37B8C79DE96409B3EC4E5C32C62B2E8514ED22DB40B2
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 43CCBE8BA4A4A59C932BC7C34DCE84A1AE68A7F4C67CB4B9554E8F3B14E9BB86
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 43CCBE8BA4A4A59C932BC7C34DCE84A1AE68A7F4C67CB4B9554E8F3B14E9BB86
+          label_len: 256
+        last_epoch: 7
+        min_descendant_epoch: 7
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
           label_len: 3
         node_type: Leaf
         left_child: ~
         right_child: ~
-        hash: FD5808558FD229CA27E68F61076ED0D9C37E8E50FAD97592ACCE5ED30CC51AB2
+        hash: 22D897D8C1FB4AD842C3FEBDA213DBFEBEC3CE5F155D10339F47A389071D88B6
       previous_node: ~
   - TreeNode:
       label:
-        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 6
-      latest_node:
-        label:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 6
-        last_epoch: 5
-        min_descendant_epoch: 1
-        parent:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        node_type: Interior
-        left_child:
-          label_val: 40B7654182ACF470672602DCE7186CEA1DB59738D7C9F1D607A9B24C362BE6C0
-          label_len: 256
-        right_child:
-          label_val: 426B148EEF56E37D269EFC61247411446CE289AA5D167BD32CCFEC877765FCB2
-          label_len: 256
-        hash: 6B3419C7C423D84C7B07EDE63A174BB163A67222C6A4FAF1E2C77527A7684F8A
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 2
-      latest_node:
-        label:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        last_epoch: 8
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        right_child:
-          label_val: "6000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        hash: BD71CB156FC8155DE6EB132929F0B7F6BE9D7B7228232F030A5E764D572DE138
-      previous_node:
-        label:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 2
-        last_epoch: 6
-        min_descendant_epoch: 1
-        parent:
-          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 1
-        node_type: Interior
-        left_child:
-          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        right_child:
-          label_val: "6000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        hash: A857119636BF4BDA061A5AF477DA9D05CFDA9BDCB164B42AC50E2AD68003D174
-  - TreeNode:
-      label:
-        label_val: "7000000000000000000000000000000000000000000000000000000000000000"
-        label_len: 4
-      latest_node:
-        label:
-          label_val: "7000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 4
-        last_epoch: 6
-        min_descendant_epoch: 2
-        parent:
-          label_val: "6000000000000000000000000000000000000000000000000000000000000000"
-          label_len: 3
-        node_type: Interior
-        left_child:
-          label_val: 74F6AB77F795C02E81A82D318C73EEF444C184E8A6D994E0F4B64F91553351DA
-          label_len: 256
-        right_child:
-          label_val: "7800000000000000000000000000000000000000000000000000000000000000"
-          label_len: 5
-        hash: 22C6EAF3539F43F0B6A493C3D6813FB06777C7365713E634645E8E8F166B2317
-      previous_node: ~
-  - TreeNode:
-      label:
-        label_val: 9EC4B36008568F3A571EE4BDE03E76611E51BBE7D7C6D2777CCA71B0BDF31E7F
+        label_val: 55406EA0A875AD8CEA804D34E74A26728C6DF07F76BC8F76AFECFE8A58EDD821
         label_len: 256
       latest_node:
         label:
-          label_val: 9EC4B36008568F3A571EE4BDE03E76611E51BBE7D7C6D2777CCA71B0BDF31E7F
+          label_val: 55406EA0A875AD8CEA804D34E74A26728C6DF07F76BC8F76AFECFE8A58EDD821
+          label_len: 256
+        last_epoch: 4
+        min_descendant_epoch: 4
+        parent:
+          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 061B75664BD63CD9292F2F4626D19B81C7AD32FACA45CE72D6EEEBE3B75DED05
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 5EDDBD26F1ADEF9ED0A0CAE9E4D943F492E28B98D8181C96A834614FA40396FE
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 5EDDBD26F1ADEF9ED0A0CAE9E4D943F492E28B98D8181C96A834614FA40396FE
           label_len: 256
         last_epoch: 5
         min_descendant_epoch: 5
         parent:
-          label_val: "9000000000000000000000000000000000000000000000000000000000000000"
+          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
           label_len: 4
         node_type: Leaf
         left_child: ~
         right_child: ~
-        hash: FD1EB17D43CAD8D453C2C8A38E00D9A00BAE17E0C00E4D19DA646D887E3A8DBB
+        hash: E038635766FB6548BE7D8263881EA861A0DB792C6539DB9CA7A4610157DB7AA5
       previous_node: ~
   - TreeNode:
       label:
-        label_val: C000000000000000000000000000000000000000000000000000000000000000
-        label_len: 4
+        label_val: 7174C888D9A49B2527981950D34769A58F2C082903FDB232515107B0EC0F1D0F
+        label_len: 256
       latest_node:
         label:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
+          label_val: 7174C888D9A49B2527981950D34769A58F2C082903FDB232515107B0EC0F1D0F
+          label_len: 256
+        last_epoch: 7
+        min_descendant_epoch: 7
+        parent:
+          label_val: "7000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 750092D6213331373A82432DC642695C7613A9BB38C1E1B1E1D7381BD636FF82
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 76B4E057390179DC53787FE517C20150AE40EF0F49C312307E9612141C10963B
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 76B4E057390179DC53787FE517C20150AE40EF0F49C312307E9612141C10963B
+          label_len: 256
+        last_epoch: 3
+        min_descendant_epoch: 3
+        parent:
+          label_val: "7600000000000000000000000000000000000000000000000000000000000000"
+          label_len: 7
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: E5FAC6590A8A448AEA77B2862695645385EFD3AD18DC91542E09F7487637D959
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 77AF0D50803929DCCD4156C815A714DCEC3D77265156798E6BE20F194F14189D
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 77AF0D50803929DCCD4156C815A714DCEC3D77265156798E6BE20F194F14189D
+          label_len: 256
+        last_epoch: 5
+        min_descendant_epoch: 5
+        parent:
+          label_val: "7600000000000000000000000000000000000000000000000000000000000000"
+          label_len: 7
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 474467997521CB4730812DDF66E23239CB367DB246A0EB228AE179F40D69DBF4
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 8200E25CF621883F9924829AC1AE41EEBB577BC83F4A5AFF7CCD8B8512D0DCC8
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 8200E25CF621883F9924829AC1AE41EEBB577BC83F4A5AFF7CCD8B8512D0DCC8
+          label_len: 256
         last_epoch: 2
         min_descendant_epoch: 2
         parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 09D434A1872363A8BD2895D2776A7CD993DBBB4497D72B7CA7533AE7ACC4FBE7
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 86B837789865B058126EBC012AA52F1D83E76AB517390431196D1F7DB2FC8648
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 86B837789865B058126EBC012AA52F1D83E76AB517390431196D1F7DB2FC8648
+          label_len: 256
+        last_epoch: 4
+        min_descendant_epoch: 4
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 28D9374ACD96E637AE21FAE38CC4912F58DC08B43577FE58D196C7652A9DC288
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 8DD2ECC135DD951442104A7FB071734D51C5585104EDC0B70FF33247DEBD7E97
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 8DD2ECC135DD951442104A7FB071734D51C5585104EDC0B70FF33247DEBD7E97
+          label_len: 256
+        last_epoch: 7
+        min_descendant_epoch: 7
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: E20BB992EA396406FC576254E7CED2B49660A887DA05B5D8BC0CF4C3E7B43C4F
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 97702376D7DD777A9DE17B56D0C82A0B3205FB075737B40027EB63B831508676
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 97702376D7DD777A9DE17B56D0C82A0B3205FB075737B40027EB63B831508676
+          label_len: 256
+        last_epoch: 4
+        min_descendant_epoch: 4
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: E7D62A70CD05D96804B002250DDE8C8F8649C4725C6A26624789B3DDA9938BA6
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: A2F95664E2D6E4FE6FE6640664F9B1CDFAA4482365D581FADA34C1D7A36BE455
+        label_len: 256
+      latest_node:
+        label:
+          label_val: A2F95664E2D6E4FE6FE6640664F9B1CDFAA4482365D581FADA34C1D7A36BE455
+          label_len: 256
+        last_epoch: 1
+        min_descendant_epoch: 1
+        parent:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 169A882566734EF17AAAB408C16BB8C8C6B4E5786148502E24F038342C4CEC64
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: A918CC35D187E0F6C349A70D154A88C4B5509895EC1030EEBB0F4BB57D9097D8
+        label_len: 256
+      latest_node:
+        label:
+          label_val: A918CC35D187E0F6C349A70D154A88C4B5509895EC1030EEBB0F4BB57D9097D8
+          label_len: 256
+        last_epoch: 2
+        min_descendant_epoch: 2
+        parent:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 5C16883D0152BEBA83F03191C240C81123EB475BBB498CC7A9E34103EC9732DB
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: C56CFAEFB7763D8BE2AEC18A25EBFC294DCC6C2230AEEAF7C1FE9B3FD52EB5D3
+        label_len: 256
+      latest_node:
+        label:
+          label_val: C56CFAEFB7763D8BE2AEC18A25EBFC294DCC6C2230AEEAF7C1FE9B3FD52EB5D3
+          label_len: 256
+        last_epoch: 1
+        min_descendant_epoch: 1
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 9578B64153F7877B74D797FBEA4EDA51F4FC1E0B1385B00B036B33ABD8A8AD8C
+      previous_node: ~
+  - ValueState:
+      value: 0007EECCE9AE4CA014774A8B9A454C1D2CB58C0026136BD946980D5A7AFECF69
+      version: 1
+      label:
+        label_val: 77AF0D50803929DCCD4156C815A714DCEC3D77265156798E6BE20F194F14189D
+        label_len: 256
+      epoch: 5
+      username: 6862FC52888AABA651B2AD1C437CC12FC61FDA7F0BCA89822747B7A503660B36
+  - ValueState:
+      value: 2B8F6957C9A8B2C36E3E30D9B7C61C8B7BBB6FE6C166B6931BFF049E5DC21A45
+      version: 1
+      label:
+        label_val: 15D593AE830FBC02DC517894CCDBFB7F1BA579E624198DE46A7A819FAABAA309
+        label_len: 256
+      epoch: 2
+      username: A0DA8888138772F004B810537AE3D97DEF44D2866785498ACA67225BC5097380
+  - ValueState:
+      value: 2D2B3F4A2370AED4583007D2953E3E7CB8190215A233F88DB9A6879AB951927D
+      version: 1
+      label:
+        label_val: A2F95664E2D6E4FE6FE6640664F9B1CDFAA4482365D581FADA34C1D7A36BE455
+        label_len: 256
+      epoch: 1
+      username: B01A289E9F6DD8BFDAE613BC8F3F799B82B3E75ACCBCE0BDE37D9D31AAD45C20
+  - ValueState:
+      value: 2DABCAA9142B4CE6D754DCF9F1A68937EF102FA70CDE13A66CE5FC1826D4B610
+      version: 1
+      label:
+        label_val: 0C3119F4E4B887BD0829B51036AE825336491BA4404775A443E691D88A3B0FD4
+        label_len: 256
+      epoch: 7
+      username: A9760CB172EB7232C9EA8B85438F87773FFDD5C9EA3BCB3A5775B3AC260F070B
+  - ValueState:
+      value: 4493CC1848B1FB8627D77CAA16EF5B3F0398D9CDEA4BF38591365C3718EF735A
+      version: 1
+      label:
+        label_val: 55406EA0A875AD8CEA804D34E74A26728C6DF07F76BC8F76AFECFE8A58EDD821
+        label_len: 256
+      epoch: 4
+      username: 6E7CC3658DFAB220299EA9C7961F72E3FEC07E701F5B8B1C7ACAB1CBAD89563A
+  - ValueState:
+      value: 4D9BDFABFE9CC886AB6C86634E3BDD1513BF243F493910724CCC4E2EB0513B66
+      version: 1
+      label:
+        label_val: 5EDDBD26F1ADEF9ED0A0CAE9E4D943F492E28B98D8181C96A834614FA40396FE
+        label_len: 256
+      epoch: 5
+      username: 760B84503176262A852ED1C63CB2A0A8D6CE692FB90DAED99D295BBBD656A497
+  - ValueState:
+      value: 51F4F995FFAA13AB9AFCF6F0005BB41717354C25AE6C608044025D50AEA77796
+      version: 1
+      label:
+        label_val: 8DD2ECC135DD951442104A7FB071734D51C5585104EDC0B70FF33247DEBD7E97
+        label_len: 256
+      epoch: 7
+      username: BE486FDC27D032EB725CA8BAB6A4564EFD6ED018C3EE9EE18A21321C72EFE6FE
+  - ValueState:
+      value: 5A21A6A6C905134EE4CAE77520285D2875CC7ECC26E5F98BC3A086BBEF9A4FFD
+      version: 1
+      label:
+        label_val: 76B4E057390179DC53787FE517C20150AE40EF0F49C312307E9612141C10963B
+        label_len: 256
+      epoch: 3
+      username: 4C5EBFEA15023A0CE04FDE03E456590D79A25FB8830380AFA0BA8CB06C6BB0A7
+  - ValueState:
+      value: 660DAD6D8B63BD9A5BB1D8A49EFC9FB7CF9921D23D08770F87DC1C9D18949A73
+      version: 1
+      label:
+        label_val: 8200E25CF621883F9924829AC1AE41EEBB577BC83F4A5AFF7CCD8B8512D0DCC8
+        label_len: 256
+      epoch: 2
+      username: 25D8EA4672365D742B2FE7C01EEC5059D5FA7BF59A3EDA0DC3265D6B0F736AE6
+  - ValueState:
+      value: 709503A12AB0CFB202F78144651911FD0B78E6D3E6E0E071BE00B79D310B5281
+      version: 1
+      label:
+        label_val: 97702376D7DD777A9DE17B56D0C82A0B3205FB075737B40027EB63B831508676
+        label_len: 256
+      epoch: 4
+      username: 8079BDD384D4CC2828CD2704DDF389B35F73B482AB5A3E584017CB9A9CB684B0
+  - ValueState:
+      value: 863F03833665237839974639017655DB68D9144209758146E3EC462330C00F91
+      version: 1
+      label:
+        label_val: 1EDF80D70B304EE674025E88C07E188DBDDB131AB70F94C42519674C2C8E37D8
+        label_len: 256
+      epoch: 6
+      username: 77A8C8234E1D5962343863D9796FE297FBB12675FA0C90E3A68AF3E372350491
+  - ValueState:
+      value: 8FA75DF0044E2067922BF69E7F5EA6C420B52FB8C4777157B105A71243A22523
+      version: 1
+      label:
+        label_val: 135C0227DC8DA44BEC49816ADB703777386065DDE54D1676FA4C3617FBFF38C9
+        label_len: 256
+      epoch: 1
+      username: C9EE1C106F66E172C869BD5F8F0DB4C43200551BE49478F9879A60B832F24FF7
+  - ValueState:
+      value: A75DC429AA86F5FB84756558C5210A2DE4A8D4D3B4207BEB0D419072A22CC779
+      version: 1
+      label:
+        label_val: 2FE1876847F44393AE2DA7BE4E090E6F1FA26E0B6F7BAC746DBDF81FFAC66989
+        label_len: 256
+      epoch: 1
+      username: 11BC9883996317A3F9C90269D56771005D540A19184939C9E8D0DB2A55F292A9
+  - ValueState:
+      value: C5828C45313F0A48729A95F4C4525087F43405B0BAF850DF89FBB00866F41834
+      version: 1
+      label:
+        label_val: A918CC35D187E0F6C349A70D154A88C4B5509895EC1030EEBB0F4BB57D9097D8
+        label_len: 256
+      epoch: 2
+      username: E966833FE093AF91F176D0143E1A253E2132F52E5AEE21C949168BEDB8134D6A
+  - ValueState:
+      value: D652F2178A44DA0328015B7A09223A4DEC18DCAEC013FB5F1B86B1BF2621EB24
+      version: 1
+      label:
+        label_val: C56CFAEFB7763D8BE2AEC18A25EBFC294DCC6C2230AEEAF7C1FE9B3FD52EB5D3
+        label_len: 256
+      epoch: 1
+      username: 99A12E45E4375D8AF35927A3128AB6DA37483430633AAC7FDF7E0D65E76E60E8
+  - ValueState:
+      value: DE4AF47A2377DE3CB418D8D7982D96400C40760FA43C739D9E5B17E543C85223
+      version: 1
+      label:
+        label_val: 43CCBE8BA4A4A59C932BC7C34DCE84A1AE68A7F4C67CB4B9554E8F3B14E9BB86
+        label_len: 256
+      epoch: 7
+      username: 4DC5A52F437DE076B5DF65A72A2BC6F93D1BCD4AE178851F295FEBC5089AA8CD
+  - ValueState:
+      value: E83C0DF8AD096EB0B1E2996E9060D042290D9DB2DF94EB10C4465337AAD4CB02
+      version: 1
+      label:
+        label_val: 86B837789865B058126EBC012AA52F1D83E76AB517390431196D1F7DB2FC8648
+        label_len: 256
+      epoch: 4
+      username: 228BACB51D8FD632C58DEAF7C797F287B619613371E3A34703DBDF5C9112E2C9
+  - ValueState:
+      value: F41BA2596A8B1A2C0798F9ACB6617A6AAEF6E8826E1D1DB04E218C6D9502D375
+      version: 1
+      label:
+        label_val: 7174C888D9A49B2527981950D34769A58F2C082903FDB232515107B0EC0F1D0F
+        label_len: 256
+      epoch: 7
+      username: 60462AE2E5686291A58E2499DC405625FDD739C5C195CFA2607A3DAA7987C953
+
+# Delta - Epoch 10
+---
+epoch: 10
+updates: []
+
+# State - Epoch 10
+---
+epoch: 10
+records:
+  - Azks:
+      latest_epoch: 7
+      num_nodes: 35
+  - TreeNode:
+      label:
+        label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 0
+      latest_node:
+        label:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 0
+        last_epoch: 7
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 0
+        node_type: Root
+        left_child:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        right_child:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        hash: 4F6A7FA6555ABB366EEB50AB610F5AD6AF26E4155C317D7A678C7AEFCA509083
+      previous_node:
+        label:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 0
+        last_epoch: 6
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 0
+        node_type: Root
+        left_child:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        right_child:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        hash: 6C84E02C12EAC329B08D25BB2B1E31BD5445C42A3FFEDDC6B35126F5AF8E55F4
+  - TreeNode:
+      label:
+        label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 1
+      latest_node:
+        label:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        last_epoch: 7
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 0
         node_type: Interior
         left_child:
-          label_val: C7BAF6ABCDCC44429E4FD296B3E506F3BBC9BAE0CCCAF3D51C052FD3EA12A643
-          label_len: 256
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
         right_child:
-          label_val: CA3A8FB4749A2F7C6FC2C0BEEBD5D4270758E7A06D9D92D2928D1AFCB5E7F648
-          label_len: 256
-        hash: AB87A500A9DA1FE84837DFEFC72529CAABE2A0EF2A2C693778D9DF54B172DF31
-      previous_node: ~
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        hash: F344EA4084A239866253B518B2E7B4344AE177D4C325A1348624BD4BB339B070
+      previous_node:
+        label:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        last_epoch: 6
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 0
+        node_type: Interior
+        left_child:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        right_child:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        hash: 03A536754CDCE7DC649B95CB41651280FB7962428F1BF4C97DC8B77DBD7BFF67
   - TreeNode:
       label:
         label_val: "8000000000000000000000000000000000000000000000000000000000000000"
@@ -2240,8 +1082,8 @@ records:
         label:
           label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 1
-        last_epoch: 8
-        min_descendant_epoch: 2
+        last_epoch: 7
+        min_descendant_epoch: 1
         parent:
           label_val: "0000000000000000000000000000000000000000000000000000000000000000"
           label_len: 0
@@ -2250,15 +1092,15 @@ records:
           label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 2
         right_child:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        hash: 347E816B94F160C728BB4A02A20DA2F59115DA9C60DDF1E2D610A0C933C92352
+          label_val: C56CFAEFB7763D8BE2AEC18A25EBFC294DCC6C2230AEEAF7C1FE9B3FD52EB5D3
+          label_len: 256
+        hash: 9B4A979F8E949ECB0FB3A71CF86C174AB657C042A359EA3553FFA55954516C1C
       previous_node:
         label:
           label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 1
-        last_epoch: 6
-        min_descendant_epoch: 2
+        last_epoch: 4
+        min_descendant_epoch: 1
         parent:
           label_val: "0000000000000000000000000000000000000000000000000000000000000000"
           label_len: 0
@@ -2267,254 +1109,846 @@ records:
           label_val: "8000000000000000000000000000000000000000000000000000000000000000"
           label_len: 2
         right_child:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        hash: EA0B4997CD2435F434F46AC1D7B0AD4DC5860BB83EC6A10F8EB0463A950B5510
+          label_val: C56CFAEFB7763D8BE2AEC18A25EBFC294DCC6C2230AEEAF7C1FE9B3FD52EB5D3
+          label_len: 256
+        hash: 3240D8D04E3240A263847DEFBE8B120D96A88A605889D4AC3A6373E8088AC008
   - TreeNode:
       label:
-        label_val: E000000000000000000000000000000000000000000000000000000000000000
+        label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 2
+      latest_node:
+        label:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        last_epoch: 7
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        right_child:
+          label_val: 2FE1876847F44393AE2DA7BE4E090E6F1FA26E0B6F7BAC746DBDF81FFAC66989
+          label_len: 256
+        hash: 21FB739CF36BF1E5E6D7E3389BE03B89598CADD2187FCA3285CEEE8218F67995
+      previous_node:
+        label:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        last_epoch: 6
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: "1000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        right_child:
+          label_val: 2FE1876847F44393AE2DA7BE4E090E6F1FA26E0B6F7BAC746DBDF81FFAC66989
+          label_len: 256
+        hash: C678A14A14E89CFEDA6FC4365FC4E1747C61D98923028FFC2ED18F60007D38C1
+  - TreeNode:
+      label:
+        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 2
+      latest_node:
+        label:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        last_epoch: 7
+        min_descendant_epoch: 3
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        right_child:
+          label_val: "7000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        hash: 23F9E2C9A006D874E65F1D18CBE432F79E61FA5CA1C5EC79BB04C9CD0250DABF
+      previous_node:
+        label:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        last_epoch: 5
+        min_descendant_epoch: 3
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        right_child:
+          label_val: "7600000000000000000000000000000000000000000000000000000000000000"
+          label_len: 7
+        hash: E3E8D12CE7551B75963D1A804C061B9DBB01D62CC2717070848A989AC32A0461
+  - TreeNode:
+      label:
+        label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 2
+      latest_node:
+        label:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        last_epoch: 7
+        min_descendant_epoch: 1
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        right_child:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        hash: 7E7FB832223530BBD4A2969D8A479F6B195172C735AD175C0FBD9AD9589153A6
+      previous_node:
+        label:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        last_epoch: 4
+        min_descendant_epoch: 1
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Interior
+        left_child:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        right_child:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        hash: F67DFF587B70193FBDC116527047A0ADA9D0B012811D13F5D0CC1652FA8A3BA1
+  - TreeNode:
+      label:
+        label_val: "0000000000000000000000000000000000000000000000000000000000000000"
         label_len: 3
       latest_node:
         label:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
           label_len: 3
-        last_epoch: 6
-        min_descendant_epoch: 2
+        last_epoch: 7
+        min_descendant_epoch: 1
         parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
           label_len: 2
         node_type: Interior
         left_child:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
-        right_child:
-          label_val: F30D287863718B9C41B6318D293C68D6B2D7F10A106EECA37A4411A41759AAD3
+          label_val: 0C3119F4E4B887BD0829B51036AE825336491BA4404775A443E691D88A3B0FD4
           label_len: 256
-        hash: FE55F5CC713923396B9C4B88CF1075D2CCB04270E7D0F8680EF2189850ABAC8F
-      previous_node:
-        label:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 3
-        last_epoch: 5
-        min_descendant_epoch: 2
-        parent:
-          label_val: C000000000000000000000000000000000000000000000000000000000000000
-          label_len: 2
-        node_type: Interior
-        left_child:
-          label_val: E000000000000000000000000000000000000000000000000000000000000000
-          label_len: 4
         right_child:
-          label_val: F30D287863718B9C41B6318D293C68D6B2D7F10A106EECA37A4411A41759AAD3
-          label_len: 256
-        hash: 4BB78E7180A19BF15294290CE178B589532412A6C9528A44B6E21D53CBB142FC
+          label_val: "1000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        hash: 8E7B67A809275F3603AE294EFC84220A196384F36C5BADE3F28DE90326CB3E58
+      previous_node: ~
   - TreeNode:
       label:
-        label_val: 1B3197016C32205D6B4768770B19A563B0E204CA0F291071A4B5690FDE5D5E9F
+        label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 3
+      latest_node:
+        label:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        last_epoch: 7
+        min_descendant_epoch: 4
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: 43CCBE8BA4A4A59C932BC7C34DCE84A1AE68A7F4C67CB4B9554E8F3B14E9BB86
+          label_len: 256
+        right_child:
+          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        hash: 27A8F45251A4F77C43C37F7DC2DCAAAE89AD97B52DF36B3E0B0EBCF4EA2DC39C
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 3
+      latest_node:
+        label:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        last_epoch: 7
+        min_descendant_epoch: 2
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        right_child:
+          label_val: 97702376D7DD777A9DE17B56D0C82A0B3205FB075737B40027EB63B831508676
+          label_len: 256
+        hash: AF63DA27C9C73234B67A8139DDC7D47C64F0B182C214A98BB1B1424FFCE7BDFA
+      previous_node:
+        label:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        last_epoch: 4
+        min_descendant_epoch: 2
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        right_child:
+          label_val: 97702376D7DD777A9DE17B56D0C82A0B3205FB075737B40027EB63B831508676
+          label_len: 256
+        hash: 2CCF33B386814AEDB52A6E74DA7DC66C6C37815C273AF31DAC5F3714B494B586
+  - TreeNode:
+      label:
+        label_val: "1000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 4
+      latest_node:
+        label:
+          label_val: "1000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        last_epoch: 6
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        node_type: Interior
+        left_child:
+          label_val: "1000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        right_child:
+          label_val: 1EDF80D70B304EE674025E88C07E188DBDDB131AB70F94C42519674C2C8E37D8
+          label_len: 256
+        hash: A4F41FF1EF9D814AC4F54A542502A3D6DA488630841A3B11D1282E253AFE04E2
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "5000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 4
+      latest_node:
+        label:
+          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        last_epoch: 5
+        min_descendant_epoch: 4
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        node_type: Interior
+        left_child:
+          label_val: 55406EA0A875AD8CEA804D34E74A26728C6DF07F76BC8F76AFECFE8A58EDD821
+          label_len: 256
+        right_child:
+          label_val: 5EDDBD26F1ADEF9ED0A0CAE9E4D943F492E28B98D8181C96A834614FA40396FE
+          label_len: 256
+        hash: 475A3FCE53462DE70FD443C3B9B295FB0A57BA89160E1A4299AB624A2EAC868D
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 4
+      latest_node:
+        label:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        last_epoch: 7
+        min_descendant_epoch: 2
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        node_type: Interior
+        left_child:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        right_child:
+          label_val: 8DD2ECC135DD951442104A7FB071734D51C5585104EDC0B70FF33247DEBD7E97
+          label_len: 256
+        hash: A7F8B4473492886191B685BC6E1B0B1ABF5FEFBEC9BE413736B7BF40482C580B
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: A000000000000000000000000000000000000000000000000000000000000000
+        label_len: 4
+      latest_node:
+        label:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        last_epoch: 2
+        min_descendant_epoch: 1
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: A2F95664E2D6E4FE6FE6640664F9B1CDFAA4482365D581FADA34C1D7A36BE455
+          label_len: 256
+        right_child:
+          label_val: A918CC35D187E0F6C349A70D154A88C4B5509895EC1030EEBB0F4BB57D9097D8
+          label_len: 256
+        hash: 2449203C480837D98F0A03AA18078E789BD3DB67E09BC406E4B192D9A0925A9A
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "1000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 5
+      latest_node:
+        label:
+          label_val: "1000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        last_epoch: 2
+        min_descendant_epoch: 1
+        parent:
+          label_val: "1000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        node_type: Interior
+        left_child:
+          label_val: 135C0227DC8DA44BEC49816ADB703777386065DDE54D1676FA4C3617FBFF38C9
+          label_len: 256
+        right_child:
+          label_val: 15D593AE830FBC02DC517894CCDBFB7F1BA579E624198DE46A7A819FAABAA309
+          label_len: 256
+        hash: 6EEE7DC3BAF3258E652779CDEC51CD2572B932564B25EE909E17438782F78414
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "7000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 5
+      latest_node:
+        label:
+          label_val: "7000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        last_epoch: 7
+        min_descendant_epoch: 3
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        node_type: Interior
+        left_child:
+          label_val: 7174C888D9A49B2527981950D34769A58F2C082903FDB232515107B0EC0F1D0F
+          label_len: 256
+        right_child:
+          label_val: "7600000000000000000000000000000000000000000000000000000000000000"
+          label_len: 7
+        hash: 5E6ED36E528DB7C1A99C74150945A1F81D4A11EAED9545C9F9E0D2CC606F3081
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+        label_len: 5
+      latest_node:
+        label:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        last_epoch: 4
+        min_descendant_epoch: 2
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        node_type: Interior
+        left_child:
+          label_val: 8200E25CF621883F9924829AC1AE41EEBB577BC83F4A5AFF7CCD8B8512D0DCC8
+          label_len: 256
+        right_child:
+          label_val: 86B837789865B058126EBC012AA52F1D83E76AB517390431196D1F7DB2FC8648
+          label_len: 256
+        hash: C44B701497AD38194F0069EB6532DD3480BC6E302398C13F85647770AE019C25
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: "7600000000000000000000000000000000000000000000000000000000000000"
+        label_len: 7
+      latest_node:
+        label:
+          label_val: "7600000000000000000000000000000000000000000000000000000000000000"
+          label_len: 7
+        last_epoch: 5
+        min_descendant_epoch: 3
+        parent:
+          label_val: "7000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        node_type: Interior
+        left_child:
+          label_val: 76B4E057390179DC53787FE517C20150AE40EF0F49C312307E9612141C10963B
+          label_len: 256
+        right_child:
+          label_val: 77AF0D50803929DCCD4156C815A714DCEC3D77265156798E6BE20F194F14189D
+          label_len: 256
+        hash: 553E2E8843FB17C36F1A4168B93F628E21B397BB3471B35EDE41F7C6D970B979
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 0C3119F4E4B887BD0829B51036AE825336491BA4404775A443E691D88A3B0FD4
         label_len: 256
       latest_node:
         label:
-          label_val: 1B3197016C32205D6B4768770B19A563B0E204CA0F291071A4B5690FDE5D5E9F
+          label_val: 0C3119F4E4B887BD0829B51036AE825336491BA4404775A443E691D88A3B0FD4
           label_len: 256
         last_epoch: 7
         min_descendant_epoch: 7
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: C6E14E32FDF8B8EF40EE5D168A4EF303132454550D15C30A30B751E842CEBD31
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 135C0227DC8DA44BEC49816ADB703777386065DDE54D1676FA4C3617FBFF38C9
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 135C0227DC8DA44BEC49816ADB703777386065DDE54D1676FA4C3617FBFF38C9
+          label_len: 256
+        last_epoch: 1
+        min_descendant_epoch: 1
+        parent:
+          label_val: "1000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 0F8341865FFB77A40BFAC873A97595CF511E5B3E9E205B5F6EC086964979F90F
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 15D593AE830FBC02DC517894CCDBFB7F1BA579E624198DE46A7A819FAABAA309
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 15D593AE830FBC02DC517894CCDBFB7F1BA579E624198DE46A7A819FAABAA309
+          label_len: 256
+        last_epoch: 2
+        min_descendant_epoch: 2
+        parent:
+          label_val: "1000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 0275C64BD8F46BDEB28B9EFD921831DC35876A4B84C81F4955F2DAED26EA34F5
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 1EDF80D70B304EE674025E88C07E188DBDDB131AB70F94C42519674C2C8E37D8
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 1EDF80D70B304EE674025E88C07E188DBDDB131AB70F94C42519674C2C8E37D8
+          label_len: 256
+        last_epoch: 6
+        min_descendant_epoch: 6
         parent:
           label_val: "1000000000000000000000000000000000000000000000000000000000000000"
           label_len: 4
         node_type: Leaf
         left_child: ~
         right_child: ~
-        hash: 6A8C04B3FB065A530FD6A1D8B4EDAE0A27864A92EF5F33FD8DB728DDA04D4082
+        hash: ED557078CD9BD4B9B7C84BE6DD80083C73B2B27FD5D6014C56246DF6B832E1B2
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 2FE1876847F44393AE2DA7BE4E090E6F1FA26E0B6F7BAC746DBDF81FFAC66989
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 2FE1876847F44393AE2DA7BE4E090E6F1FA26E0B6F7BAC746DBDF81FFAC66989
+          label_len: 256
+        last_epoch: 1
+        min_descendant_epoch: 1
+        parent:
+          label_val: "0000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 2
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: D7B658ED6F9DB4183A1A37B8C79DE96409B3EC4E5C32C62B2E8514ED22DB40B2
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 43CCBE8BA4A4A59C932BC7C34DCE84A1AE68A7F4C67CB4B9554E8F3B14E9BB86
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 43CCBE8BA4A4A59C932BC7C34DCE84A1AE68A7F4C67CB4B9554E8F3B14E9BB86
+          label_len: 256
+        last_epoch: 7
+        min_descendant_epoch: 7
+        parent:
+          label_val: "4000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 22D897D8C1FB4AD842C3FEBDA213DBFEBEC3CE5F155D10339F47A389071D88B6
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 55406EA0A875AD8CEA804D34E74A26728C6DF07F76BC8F76AFECFE8A58EDD821
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 55406EA0A875AD8CEA804D34E74A26728C6DF07F76BC8F76AFECFE8A58EDD821
+          label_len: 256
+        last_epoch: 4
+        min_descendant_epoch: 4
+        parent:
+          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 061B75664BD63CD9292F2F4626D19B81C7AD32FACA45CE72D6EEEBE3B75DED05
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 5EDDBD26F1ADEF9ED0A0CAE9E4D943F492E28B98D8181C96A834614FA40396FE
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 5EDDBD26F1ADEF9ED0A0CAE9E4D943F492E28B98D8181C96A834614FA40396FE
+          label_len: 256
+        last_epoch: 5
+        min_descendant_epoch: 5
+        parent:
+          label_val: "5000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: E038635766FB6548BE7D8263881EA861A0DB792C6539DB9CA7A4610157DB7AA5
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 7174C888D9A49B2527981950D34769A58F2C082903FDB232515107B0EC0F1D0F
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 7174C888D9A49B2527981950D34769A58F2C082903FDB232515107B0EC0F1D0F
+          label_len: 256
+        last_epoch: 7
+        min_descendant_epoch: 7
+        parent:
+          label_val: "7000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 750092D6213331373A82432DC642695C7613A9BB38C1E1B1E1D7381BD636FF82
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 76B4E057390179DC53787FE517C20150AE40EF0F49C312307E9612141C10963B
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 76B4E057390179DC53787FE517C20150AE40EF0F49C312307E9612141C10963B
+          label_len: 256
+        last_epoch: 3
+        min_descendant_epoch: 3
+        parent:
+          label_val: "7600000000000000000000000000000000000000000000000000000000000000"
+          label_len: 7
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: E5FAC6590A8A448AEA77B2862695645385EFD3AD18DC91542E09F7487637D959
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 77AF0D50803929DCCD4156C815A714DCEC3D77265156798E6BE20F194F14189D
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 77AF0D50803929DCCD4156C815A714DCEC3D77265156798E6BE20F194F14189D
+          label_len: 256
+        last_epoch: 5
+        min_descendant_epoch: 5
+        parent:
+          label_val: "7600000000000000000000000000000000000000000000000000000000000000"
+          label_len: 7
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 474467997521CB4730812DDF66E23239CB367DB246A0EB228AE179F40D69DBF4
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 8200E25CF621883F9924829AC1AE41EEBB577BC83F4A5AFF7CCD8B8512D0DCC8
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 8200E25CF621883F9924829AC1AE41EEBB577BC83F4A5AFF7CCD8B8512D0DCC8
+          label_len: 256
+        last_epoch: 2
+        min_descendant_epoch: 2
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 09D434A1872363A8BD2895D2776A7CD993DBBB4497D72B7CA7533AE7ACC4FBE7
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 86B837789865B058126EBC012AA52F1D83E76AB517390431196D1F7DB2FC8648
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 86B837789865B058126EBC012AA52F1D83E76AB517390431196D1F7DB2FC8648
+          label_len: 256
+        last_epoch: 4
+        min_descendant_epoch: 4
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 5
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 28D9374ACD96E637AE21FAE38CC4912F58DC08B43577FE58D196C7652A9DC288
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 8DD2ECC135DD951442104A7FB071734D51C5585104EDC0B70FF33247DEBD7E97
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 8DD2ECC135DD951442104A7FB071734D51C5585104EDC0B70FF33247DEBD7E97
+          label_len: 256
+        last_epoch: 7
+        min_descendant_epoch: 7
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: E20BB992EA396406FC576254E7CED2B49660A887DA05B5D8BC0CF4C3E7B43C4F
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: 97702376D7DD777A9DE17B56D0C82A0B3205FB075737B40027EB63B831508676
+        label_len: 256
+      latest_node:
+        label:
+          label_val: 97702376D7DD777A9DE17B56D0C82A0B3205FB075737B40027EB63B831508676
+          label_len: 256
+        last_epoch: 4
+        min_descendant_epoch: 4
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 3
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: E7D62A70CD05D96804B002250DDE8C8F8649C4725C6A26624789B3DDA9938BA6
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: A2F95664E2D6E4FE6FE6640664F9B1CDFAA4482365D581FADA34C1D7A36BE455
+        label_len: 256
+      latest_node:
+        label:
+          label_val: A2F95664E2D6E4FE6FE6640664F9B1CDFAA4482365D581FADA34C1D7A36BE455
+          label_len: 256
+        last_epoch: 1
+        min_descendant_epoch: 1
+        parent:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 169A882566734EF17AAAB408C16BB8C8C6B4E5786148502E24F038342C4CEC64
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: A918CC35D187E0F6C349A70D154A88C4B5509895EC1030EEBB0F4BB57D9097D8
+        label_len: 256
+      latest_node:
+        label:
+          label_val: A918CC35D187E0F6C349A70D154A88C4B5509895EC1030EEBB0F4BB57D9097D8
+          label_len: 256
+        last_epoch: 2
+        min_descendant_epoch: 2
+        parent:
+          label_val: A000000000000000000000000000000000000000000000000000000000000000
+          label_len: 4
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 5C16883D0152BEBA83F03191C240C81123EB475BBB498CC7A9E34103EC9732DB
+      previous_node: ~
+  - TreeNode:
+      label:
+        label_val: C56CFAEFB7763D8BE2AEC18A25EBFC294DCC6C2230AEEAF7C1FE9B3FD52EB5D3
+        label_len: 256
+      latest_node:
+        label:
+          label_val: C56CFAEFB7763D8BE2AEC18A25EBFC294DCC6C2230AEEAF7C1FE9B3FD52EB5D3
+          label_len: 256
+        last_epoch: 1
+        min_descendant_epoch: 1
+        parent:
+          label_val: "8000000000000000000000000000000000000000000000000000000000000000"
+          label_len: 1
+        node_type: Leaf
+        left_child: ~
+        right_child: ~
+        hash: 9578B64153F7877B74D797FBEA4EDA51F4FC1E0B1385B00B036B33ABD8A8AD8C
       previous_node: ~
   - ValueState:
-      value: 334146627651746464545A4E4338326A353968706A744C4D4665356974717366
+      value: 0007EECCE9AE4CA014774A8B9A454C1D2CB58C0026136BD946980D5A7AFECF69
       version: 1
       label:
-        label_val: E1E2366C30A2E8246783077E6AD13599563448038C78C0B9E492AC365614DEB7
+        label_val: 77AF0D50803929DCCD4156C815A714DCEC3D77265156798E6BE20F194F14189D
         label_len: 256
-      epoch: 4
-      username: 736C7959594437396856435531627164426668746167537163624259736E3130
+      epoch: 5
+      username: 6862FC52888AABA651B2AD1C437CC12FC61FDA7F0BCA89822747B7A503660B36
   - ValueState:
-      value: 745A517042743972666B50436F36734F6A54495A6872635A6A574D6247715633
+      value: 2B8F6957C9A8B2C36E3E30D9B7C61C8B7BBB6FE6C166B6931BFF049E5DC21A45
       version: 1
       label:
-        label_val: 8E2DF8905DE002AD29677FEF43C369E0D0504F9A7E3CB3F221E65E1AA9554A8B
-        label_len: 256
-      epoch: 3
-      username: 4765526F3841636563306E7769367A39346B766F5541443951355470794D3862
-  - ValueState:
-      value: 7851725473327746684A56703548514136706A7A714A426E5251316D326D7853
-      version: 1
-      label:
-        label_val: CA3A8FB4749A2F7C6FC2C0BEEBD5D4270758E7A06D9D92D2928D1AFCB5E7F648
+        label_val: 15D593AE830FBC02DC517894CCDBFB7F1BA579E624198DE46A7A819FAABAA309
         label_len: 256
       epoch: 2
-      username: 6B6F50796B564C414D726C7277395367426C72376A4D4B56304F5035504F4F35
+      username: A0DA8888138772F004B810537AE3D97DEF44D2866785498ACA67225BC5097380
   - ValueState:
-      value: 6E65787774725065716547767A77504853704E73686C4644675A77715857746E
+      value: 2D2B3F4A2370AED4583007D2953E3E7CB8190215A233F88DB9A6879AB951927D
       version: 1
       label:
-        label_val: 426B148EEF56E37D269EFC61247411446CE289AA5D167BD32CCFEC877765FCB2
-        label_len: 256
-      epoch: 5
-      username: 6C36684E777569306D6F454D71714865555A6132335769516E6470633066564C
-  - ValueState:
-      value: 4D626971477730574A4F6639615379424E7A357438764353576B487753596548
-      version: 1
-      label:
-        label_val: 9EC4B36008568F3A571EE4BDE03E76611E51BBE7D7C6D2777CCA71B0BDF31E7F
-        label_len: 256
-      epoch: 5
-      username: 35637332787368554B4950575A57536D3435526F657A514A324246705542674B
-  - ValueState:
-      value: 44395942376C7361446A356A776F74746D5864375176425341484D65694F4167
-      version: 1
-      label:
-        label_val: 97B2F1F86164C236771A8CC90D192CD7D99A3016C5A5C1D912EAD392BC94AE20
-        label_len: 256
-      epoch: 5
-      username: 526372714F4D574A4A7278676C47644841566865374E654479567561744F7975
-  - ValueState:
-      value: 795871456A5371334935704D57775A5451744743695848566F50517575465A51
-      version: 1
-      label:
-        label_val: C7BAF6ABCDCC44429E4FD296B3E506F3BBC9BAE0CCCAF3D51C052FD3EA12A643
-        label_len: 256
-      epoch: 2
-      username: 673448775A58634162733235734D496D3851787271776F4B7730746A53384249
-  - ValueState:
-      value: 3550397A6F364B6A666D565A624B36784E504A6661556C4E5974696353717277
-      version: 1
-      label:
-        label_val: 40B7654182ACF470672602DCE7186CEA1DB59738D7C9F1D607A9B24C362BE6C0
+        label_val: A2F95664E2D6E4FE6FE6640664F9B1CDFAA4482365D581FADA34C1D7A36BE455
         label_len: 256
       epoch: 1
-      username: 64534A635475736B6D59617155384C693779776F4141494832426D6E49554259
+      username: B01A289E9F6DD8BFDAE613BC8F3F799B82B3E75ACCBCE0BDE37D9D31AAD45C20
   - ValueState:
-      value: 5A6F456D6E48624A62626F3636715A554971703631644A6C656E556C64377953
+      value: 2DABCAA9142B4CE6D754DCF9F1A68937EF102FA70CDE13A66CE5FC1826D4B610
       version: 1
       label:
-        label_val: AEBC771586C4265DAB54EBC4629AB9BFD382BE30FDC67FDBA7FB067E3B51D8B7
-        label_len: 256
-      epoch: 3
-      username: 6E30374D356341694C664665746A317137447861665850644C4E59724D627A66
-  - ValueState:
-      value: 6C5779574964696D3176315359424B524E4F3343723533456B736F737143746D
-      version: 1
-      label:
-        label_val: E963B4F8460FFD1F7D93D4DE499B11AAC91030B2AD59EC45AE63C4479A45A133
-        label_len: 256
-      epoch: 5
-      username: 533545636F7530467532586A704B634A4258774B79764570734D33416F377462
-  - ValueState:
-      value: 6E4473387A65663370756B4D676F6254534F663455426D334A7A734C4D627342
-      version: 1
-      label:
-        label_val: 57BDA197268698B8CBB74D80A5510AC869EEB21D80810BAD3FEABD26F258B52B
-        label_len: 256
-      epoch: 6
-      username: 5A306B4F56696230477739355131666B4C53586E3057397A33544B67746B5768
-  - ValueState:
-      value: 6E4C4E636A7371787665307345513455436E7075634D33304A6B515A4567504A
-      version: 1
-      label:
-        label_val: 1B3197016C32205D6B4768770B19A563B0E204CA0F291071A4B5690FDE5D5E9F
+        label_val: 0C3119F4E4B887BD0829B51036AE825336491BA4404775A443E691D88A3B0FD4
         label_len: 256
       epoch: 7
-      username: 79593474675A6B346E6261416D3550333363467431307639574F376C64436B4D
+      username: A9760CB172EB7232C9EA8B85438F87773FFDD5C9EA3BCB3A5775B3AC260F070B
   - ValueState:
-      value: 496E5870394F544351646B57794B32345A786B3555746E62594A4D31784C5330
+      value: 4493CC1848B1FB8627D77CAA16EF5B3F0398D9CDEA4BF38591365C3718EF735A
       version: 1
       label:
-        label_val: 398E7F16B6562B76B5A9E5B1F9B584263DA97CA6F4D06220A0EF2C2F1A95AB12
+        label_val: 55406EA0A875AD8CEA804D34E74A26728C6DF07F76BC8F76AFECFE8A58EDD821
         label_len: 256
-      epoch: 1
-      username: 674F733959655638316E5976736D743367714978424372755052493551357A30
+      epoch: 4
+      username: 6E7CC3658DFAB220299EA9C7961F72E3FEC07E701F5B8B1C7ACAB1CBAD89563A
   - ValueState:
-      value: 4B336F51544563567A3431564A354B6E33385A7335534B6A486667316662754A
+      value: 4D9BDFABFE9CC886AB6C86634E3BDD1513BF243F493910724CCC4E2EB0513B66
       version: 1
       label:
-        label_val: 7948F1797F2C5BDE543241EDD4F6D826AAA9F65331493ED8D6D96BFE6BC9507C
+        label_val: 5EDDBD26F1ADEF9ED0A0CAE9E4D943F492E28B98D8181C96A834614FA40396FE
         label_len: 256
-      epoch: 2
-      username: 6C786E4664624D384D394E386166704B744B75536631696359367036426D7333
+      epoch: 5
+      username: 760B84503176262A852ED1C63CB2A0A8D6CE692FB90DAED99D295BBBD656A497
   - ValueState:
-      value: 48516F694A6F75564271476D624C5166626E5A6D3462326E484863444D377254
+      value: 51F4F995FFAA13AB9AFCF6F0005BB41717354C25AE6C608044025D50AEA77796
       version: 1
       label:
-        label_val: E6B42CD9ABDFBE613158800BF70011C56F9D17F001BBD0C7CA0EA900FD4845DF
+        label_val: 8DD2ECC135DD951442104A7FB071734D51C5585104EDC0B70FF33247DEBD7E97
         label_len: 256
-      epoch: 6
-      username: 467A6E72444E484178547A6D4A6F466C655A70694B74326365597269464F6579
+      epoch: 7
+      username: BE486FDC27D032EB725CA8BAB6A4564EFD6ED018C3EE9EE18A21321C72EFE6FE
   - ValueState:
-      value: 537A4334624577464C33595848437977746D5A3933495672725867475950526A
+      value: 5A21A6A6C905134EE4CAE77520285D2875CC7ECC26E5F98BC3A086BBEF9A4FFD
       version: 1
       label:
-        label_val: 06DEEEE0508C6152127EEBA6B13C7EF8E78DD54126A36B27E6AA1D7C8AF297DE
-        label_len: 256
-      epoch: 1
-      username: 62736A34657A44596C4938534E7A304A3737316755506D394D75434861457A42
-  - ValueState:
-      value: 4575636F65396269526B364E64675663316C464F6F6D77414368713662697377
-      version: 1
-      label:
-        label_val: 1542AECD490E66E32D92BA6068843407531D99DE5C195A94EE7D229294431944
-        label_len: 256
-      epoch: 8
-      username: 324F4F5241506F5273514B38565250765839777A6E6972704C5470626765655A
-  - ValueState:
-      value: 347474734845695A517947357165716E616D5957674445634258663757554E35
-      version: 1
-      label:
-        label_val: 7EC32D61A61F3D8C53F1B3F312F3AE60E153AB552FC46E94091F89C35A0E1341
+        label_val: 76B4E057390179DC53787FE517C20150AE40EF0F49C312307E9612141C10963B
         label_len: 256
       epoch: 3
-      username: 79426866585A39794B5541434C5737464C484B656E64326B3831747454723578
+      username: 4C5EBFEA15023A0CE04FDE03E456590D79A25FB8830380AFA0BA8CB06C6BB0A7
   - ValueState:
-      value: 68444139424F674447374A50736964334F6B4F4655424C385547594F62733466
+      value: 660DAD6D8B63BD9A5BB1D8A49EFC9FB7CF9921D23D08770F87DC1C9D18949A73
       version: 1
       label:
-        label_val: 4DF787D51E8E649F935F4DBBDEF0AE7E79C12A4ADBB250DEEAD4FE9E8D983756
-        label_len: 256
-      epoch: 1
-      username: 33464C395674314C58416661634E507574416A75636F7242587A724765316147
-  - ValueState:
-      value: 436D6331766332374376305273534E524D44707A337430454E68786976434650
-      version: 1
-      label:
-        label_val: A4D9DDD2ED43F51B4123A55FC47610B129B7DB8B521248F4DAC92258AB960EF9
-        label_len: 256
-      epoch: 8
-      username: 736C4E386A4833483468456330624D395A6C6772356537716D68744B33627037
-  - ValueState:
-      value: 675A5A74764D564D336D6D494F577678423962777A3231565131515A72374173
-      version: 1
-      label:
-        label_val: 74F6AB77F795C02E81A82D318C73EEF444C184E8A6D994E0F4B64F91553351DA
-        label_len: 256
-      epoch: 6
-      username: 753264484171355A71763463557150444779346C6E6B48737043685645646F43
-  - ValueState:
-      value: 6F67553448504F3145585754324B706945396172594C514E383267775378526D
-      version: 1
-      label:
-        label_val: 5D6D3BC6F72784D580BE798EF5816FB519485E184405F3BB517D7E1E11BE84B3
-        label_len: 256
-      epoch: 8
-      username: 3956733254734748744F664F55386C687144366F6C614D36784A31494B384851
-  - ValueState:
-      value: 51307267667034654B646E6273795A384835356A42374D61377645726A78716C
-      version: 1
-      label:
-        label_val: F30D287863718B9C41B6318D293C68D6B2D7F10A106EECA37A4411A41759AAD3
+        label_val: 8200E25CF621883F9924829AC1AE41EEBB577BC83F4A5AFF7CCD8B8512D0DCC8
         label_len: 256
       epoch: 2
-      username: 533453507445775379383938534549706D3939756234586C5967304961706265
+      username: 25D8EA4672365D742B2FE7C01EEC5059D5FA7BF59A3EDA0DC3265D6B0F736AE6
   - ValueState:
-      value: 55505061453078335168596F78536B566D596E4C72324352426A626B6C633249
+      value: 709503A12AB0CFB202F78144651911FD0B78E6D3E6E0E071BE00B79D310B5281
       version: 1
       label:
-        label_val: 6AB612EBC1965816ECCDD704B2D9AF25269ABC0E0D02990FED0B2BCE6C06C389
+        label_val: 97702376D7DD777A9DE17B56D0C82A0B3205FB075737B40027EB63B831508676
+        label_len: 256
+      epoch: 4
+      username: 8079BDD384D4CC2828CD2704DDF389B35F73B482AB5A3E584017CB9A9CB684B0
+  - ValueState:
+      value: 863F03833665237839974639017655DB68D9144209758146E3EC462330C00F91
+      version: 1
+      label:
+        label_val: 1EDF80D70B304EE674025E88C07E188DBDDB131AB70F94C42519674C2C8E37D8
         label_len: 256
       epoch: 6
-      username: 7A5139346E6C4C5A465A6147386D5057546A4B67756F445632326B3232494741
+      username: 77A8C8234E1D5962343863D9796FE297FBB12675FA0C90E3A68AF3E372350491
+  - ValueState:
+      value: 8FA75DF0044E2067922BF69E7F5EA6C420B52FB8C4777157B105A71243A22523
+      version: 1
+      label:
+        label_val: 135C0227DC8DA44BEC49816ADB703777386065DDE54D1676FA4C3617FBFF38C9
+        label_len: 256
+      epoch: 1
+      username: C9EE1C106F66E172C869BD5F8F0DB4C43200551BE49478F9879A60B832F24FF7
+  - ValueState:
+      value: A75DC429AA86F5FB84756558C5210A2DE4A8D4D3B4207BEB0D419072A22CC779
+      version: 1
+      label:
+        label_val: 2FE1876847F44393AE2DA7BE4E090E6F1FA26E0B6F7BAC746DBDF81FFAC66989
+        label_len: 256
+      epoch: 1
+      username: 11BC9883996317A3F9C90269D56771005D540A19184939C9E8D0DB2A55F292A9
+  - ValueState:
+      value: C5828C45313F0A48729A95F4C4525087F43405B0BAF850DF89FBB00866F41834
+      version: 1
+      label:
+        label_val: A918CC35D187E0F6C349A70D154A88C4B5509895EC1030EEBB0F4BB57D9097D8
+        label_len: 256
+      epoch: 2
+      username: E966833FE093AF91F176D0143E1A253E2132F52E5AEE21C949168BEDB8134D6A
+  - ValueState:
+      value: D652F2178A44DA0328015B7A09223A4DEC18DCAEC013FB5F1B86B1BF2621EB24
+      version: 1
+      label:
+        label_val: C56CFAEFB7763D8BE2AEC18A25EBFC294DCC6C2230AEEAF7C1FE9B3FD52EB5D3
+        label_len: 256
+      epoch: 1
+      username: 99A12E45E4375D8AF35927A3128AB6DA37483430633AAC7FDF7E0D65E76E60E8
+  - ValueState:
+      value: DE4AF47A2377DE3CB418D8D7982D96400C40760FA43C739D9E5B17E543C85223
+      version: 1
+      label:
+        label_val: 43CCBE8BA4A4A59C932BC7C34DCE84A1AE68A7F4C67CB4B9554E8F3B14E9BB86
+        label_len: 256
+      epoch: 7
+      username: 4DC5A52F437DE076B5DF65A72A2BC6F93D1BCD4AE178851F295FEBC5089AA8CD
+  - ValueState:
+      value: E83C0DF8AD096EB0B1E2996E9060D042290D9DB2DF94EB10C4465337AAD4CB02
+      version: 1
+      label:
+        label_val: 86B837789865B058126EBC012AA52F1D83E76AB517390431196D1F7DB2FC8648
+        label_len: 256
+      epoch: 4
+      username: 228BACB51D8FD632C58DEAF7C797F287B619613371E3A34703DBDF5C9112E2C9
+  - ValueState:
+      value: F41BA2596A8B1A2C0798F9ACB6617A6AAEF6E8826E1D1DB04E218C6D9502D375
+      version: 1
+      label:
+        label_val: 7174C888D9A49B2527981950D34769A58F2C082903FDB232515107B0EC0F1D0F
+        label_len: 256
+      epoch: 7
+      username: 60462AE2E5686291A58E2499DC405625FDD739C5C195CFA2607A3DAA7987C953


### PR DESCRIPTION
Making fixture generation be deterministic so that we can more easily test for deltas when re-running fixture generation.

This involves adding Ord to the objects that can be stored in a DbRecord, as well as using StdRng with a seed instead of OsRng.

Also moved to using StdRng for a bunch of other tests, and added a more complex publish test.