### PR TITLE
Using AzksValue as node value instead of Digest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,9 +142,6 @@ jobs:
           - name: Build the akd benches
             package: akd
             flags: -F bench
-
-            
-
     steps:
       - uses: actions/checkout@main
       - name: Install rust
@@ -163,6 +160,14 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUSTDOCFLAGS: -Dwarnings
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: akd
+          - package: akd_core
+          - package: akd_client
+          - package: akd_mysql
     steps:
       - uses: actions/checkout@main
       - name: Install rust
@@ -171,10 +176,11 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: Run rustdoc
+      - name: Run rustdoc for ${{matrix.package}}
         uses: actions-rs/cargo@v1
         with:
           command: doc
+          args: --package ${{matrix.package}}
 
   wasm-tests:
     name: ${{matrix.name}}

--- a/akd/benches/azks.rs
+++ b/akd/benches/azks.rs
@@ -12,7 +12,7 @@ use akd::append_only_zks::InsertMode;
 use akd::auditor;
 use akd::storage::manager::StorageManager;
 use akd::storage::memory::AsyncInMemoryDatabase;
-use akd::{Azks, AzksElement, NodeLabel};
+use akd::{Azks, AzksElement, AzksValue, NodeLabel};
 use criterion::{BatchSize, Criterion};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -130,7 +130,7 @@ fn gen_nodes(rng: &mut impl Rng, num_nodes: usize) -> Vec<AzksElement> {
             };
             let mut input = [0u8; 32];
             rng.fill_bytes(&mut input);
-            let value = akd_core::hash::hash(&input);
+            let value = AzksValue(input);
             AzksElement { label, value }
         })
         .collect()

--- a/akd/src/auditor.rs
+++ b/akd/src/auditor.rs
@@ -7,14 +7,13 @@
 
 //! Code for an auditor of a authenticated key directory
 
-use crate::crypto::hash_leaf_with_commitment;
-
 use crate::{
     append_only_zks::InsertMode,
     errors::{AkdError, AuditorError, AzksError},
     storage::{manager::StorageManager, memory::AsyncInMemoryDatabase},
     AppendOnlyProof, Azks, Digest, SingleAppendOnlyProof,
 };
+use crate::{crypto::hash_leaf_with_commitment, AzksValue};
 
 /// Verifies an audit proof, given start and end hashes for a merkle patricia tree.
 pub async fn audit_verify(hashes: Vec<Digest>, proof: AppendOnlyProof) -> Result<(), AkdError> {
@@ -67,7 +66,7 @@ pub async fn verify_consecutive_append_only(
         .iter()
         .map(|x| {
             let mut y = *x;
-            y.value = hash_leaf_with_commitment(x.value, end_epoch);
+            y.value = AzksValue(hash_leaf_with_commitment(x.value, end_epoch).0);
             y
         })
         .collect();

--- a/akd/src/storage/tests.rs
+++ b/akd/src/storage/tests.rs
@@ -16,6 +16,8 @@ use crate::utils::byte_arr_from_u64;
 use crate::NodeLabel;
 use crate::{AkdLabel, AkdValue};
 
+use akd_core::hash::EMPTY_DIGEST;
+use akd_core::AzksValue;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use std::time::{Duration, Instant};
@@ -86,7 +88,7 @@ async fn test_get_and_set_item<Ns: Database>(storage: &Ns) {
         node_type: TreeNodeType::Leaf,
         left_child: None,
         right_child: None,
-        hash: [0; crate::DIGEST_BYTES],
+        hash: AzksValue(EMPTY_DIGEST),
     };
     let mut node2 = node.clone();
     node2.label = NodeLabel::new(byte_arr_from_u64(16), 4);

--- a/akd/src/storage/transaction.rs
+++ b/akd/src/storage/transaction.rs
@@ -289,7 +289,7 @@ mod tests {
     use crate::storage::types::*;
     use crate::tree_node::*;
     use crate::utils::byte_arr_from_u64;
-    use crate::{AkdLabel, AkdValue};
+    use crate::{AkdLabel, AkdValue, AzksValue};
     use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
 
     #[test]
@@ -306,7 +306,7 @@ mod tests {
             node_type: TreeNodeType::Root,
             left_child: None,
             right_child: None,
-            hash: crate::hash::EMPTY_DIGEST,
+            hash: AzksValue(crate::hash::EMPTY_DIGEST),
         }));
         let node2 = DbRecord::TreeNode(TreeNodeWithPreviousValue::from_tree_node(TreeNode {
             label: NodeLabel::new(byte_arr_from_u64(1), 1),
@@ -316,7 +316,7 @@ mod tests {
             node_type: TreeNodeType::Leaf,
             left_child: None,
             right_child: None,
-            hash: crate::hash::EMPTY_DIGEST,
+            hash: AzksValue(crate::hash::EMPTY_DIGEST),
         }));
         let value1 = DbRecord::ValueState(ValueState {
             username: AkdLabel::from("test"),

--- a/akd/src/storage/types.rs
+++ b/akd/src/storage/types.rs
@@ -7,6 +7,8 @@
 
 //! Various storage and representation related types
 
+use akd_core::AzksValue;
+
 use crate::storage::Storable;
 use crate::tree_node::{TreeNode, TreeNodeType, TreeNodeWithPreviousValue};
 use crate::{AkdLabel, AkdValue};
@@ -227,7 +229,7 @@ impl DbRecord {
         node_type: u8,
         left_child: Option<NodeLabel>,
         right_child: Option<NodeLabel>,
-        hash: crate::Digest,
+        value: crate::Digest,
         p_last_epoch: Option<u64>,
         p_least_descendant_ep: Option<u64>,
         p_parent_label_val: Option<[u8; 32]>,
@@ -235,7 +237,7 @@ impl DbRecord {
         p_node_type: Option<u8>,
         p_left_child: Option<NodeLabel>,
         p_right_child: Option<NodeLabel>,
-        p_hash: Option<crate::Digest>,
+        p_value: Option<crate::Digest>,
     ) -> TreeNodeWithPreviousValue {
         let label = NodeLabel::new(label_val, label_len);
         let p_node = match (
@@ -244,7 +246,7 @@ impl DbRecord {
             p_parent_label_val,
             p_parent_label_len,
             p_node_type,
-            p_hash,
+            p_value,
         ) {
             (Some(a), Some(b), Some(c), Some(d), Some(e), Some(f)) => Some(TreeNode {
                 label,
@@ -254,7 +256,7 @@ impl DbRecord {
                 node_type: TreeNodeType::from_u8(e),
                 left_child: p_left_child,
                 right_child: p_right_child,
-                hash: f,
+                hash: AzksValue(f),
             }),
             _ => None,
         };
@@ -268,7 +270,7 @@ impl DbRecord {
                 node_type: TreeNodeType::from_u8(node_type),
                 left_child,
                 right_child,
-                hash,
+                hash: AzksValue(value),
             },
             previous_node: p_node,
         }

--- a/akd_core/Cargo.toml
+++ b/akd_core/Cargo.toml
@@ -33,8 +33,8 @@ parallel_vrf = ["tokio"]
 
 bench = ["parallel_vrf", "blake3", "vrf", "tokio/rt-multi-thread"]
 
-# Default features mix (no hash function is selected at this point)
-default = ["vrf"]
+# Default features mix (with blake3 as the default hash function)
+default = ["vrf", "blake3"]
 
 [dependencies]
 ## Required dependencies ##

--- a/akd_core/src/crypto.rs
+++ b/akd_core/src/crypto.rs
@@ -9,23 +9,28 @@
 
 use crate::hash::{hash, Digest, DIGEST_BYTES};
 use crate::utils::i2osp_array;
-use crate::{AkdLabel, AkdValue, NodeLabel, VersionFreshness, EMPTY_LABEL, EMPTY_VALUE};
+use crate::{
+    AkdLabel, AkdValue, AzksValue, AzksValueWithEpoch, NodeLabel, VersionFreshness, EMPTY_LABEL,
+    EMPTY_VALUE,
+};
 
 #[cfg(feature = "nostd")]
 use alloc::vec::Vec;
 
 /// The value stored in the root node upon initialization, with no children
-pub fn empty_root_value() -> Digest {
+pub fn empty_root_value() -> AzksValue {
     // FIXME(#344) Change this to:
     // [0u8; 32]
-    hash(&crate::EMPTY_VALUE)
+    AzksValue(hash(&crate::EMPTY_VALUE))
 }
 
 /// AZKS value corresponding to an empty node
-pub fn empty_node_hash() -> Digest {
+pub fn empty_node_hash() -> AzksValue {
     // FIXME(#344) Change this to:
     // [0u8; 32]
-    hash(&[hash(&EMPTY_VALUE).to_vec(), EMPTY_LABEL.hash()].concat())
+    AzksValue(hash(
+        &[hash(&EMPTY_VALUE).to_vec(), EMPTY_LABEL.hash()].concat(),
+    ))
 }
 
 /// Used by the client to supply a commitment nonce and value to reconstruct the commitment, via:
@@ -33,22 +38,26 @@ pub fn empty_node_hash() -> Digest {
 pub(crate) fn generate_commitment_from_nonce_client(
     value: &crate::AkdValue,
     nonce: &[u8],
-) -> crate::hash::Digest {
-    hash(&[i2osp_array(value), i2osp_array(nonce)].concat())
+) -> AzksValue {
+    AzksValue(hash(&[i2osp_array(value), i2osp_array(nonce)].concat()))
 }
 
 /// Hash a leaf epoch and nonce with a given [AkdValue]
-pub(crate) fn hash_leaf_with_value(value: &crate::AkdValue, epoch: u64, nonce: &[u8]) -> Digest {
+pub(crate) fn hash_leaf_with_value(
+    value: &crate::AkdValue,
+    epoch: u64,
+    nonce: &[u8],
+) -> AzksValueWithEpoch {
     let commitment = generate_commitment_from_nonce_client(value, nonce);
     hash_leaf_with_commitment(commitment, epoch)
 }
 
 /// Hash a commit and epoch together to get the leaf's hash value
-pub fn hash_leaf_with_commitment(commitment: Digest, epoch: u64) -> Digest {
+pub fn hash_leaf_with_commitment(commitment: AzksValue, epoch: u64) -> AzksValueWithEpoch {
     let mut data = [0; DIGEST_BYTES + 8];
-    data[..DIGEST_BYTES].copy_from_slice(&commitment);
+    data[..DIGEST_BYTES].copy_from_slice(&commitment.0);
     data[DIGEST_BYTES..].copy_from_slice(&epoch.to_be_bytes());
-    hash(&data)
+    AzksValueWithEpoch(hash(&data))
 }
 
 /// Used by the server to produce a commitment nonce for an AkdLabel, version, and AkdValue.
@@ -106,11 +115,11 @@ pub(crate) fn get_hash_from_label_input(
 
 /// Computes the parent hash from the children hashes and labels
 pub fn compute_parent_hash_from_children(
-    left_val: &[u8],
+    left_val: &AzksValue,
     left_label: &[u8],
-    right_val: &[u8],
+    right_val: &AzksValue,
     right_label: &[u8],
-) -> Digest {
+) -> AzksValue {
     // FIXME(#344) Change this to:
     // hash(
     //    &[
@@ -120,21 +129,21 @@ pub fn compute_parent_hash_from_children(
     //        right_label,
     //    ].concat()
     // )
-    hash(
+    AzksValue(hash(
         &[
-            hash(&[left_val.to_vec(), left_label.to_vec()].concat()),
-            hash(&[right_val.to_vec(), right_label.to_vec()].concat()),
+            hash(&[left_val.0.to_vec(), left_label.to_vec()].concat()),
+            hash(&[right_val.0.to_vec(), right_label.to_vec()].concat()),
         ]
         .concat(),
-    )
+    ))
 }
 
 /// Given the top-level hash, compute the "actual" root hash that is published
 /// by the directory maintainer
-pub fn compute_root_hash_from_val(root_val: &[u8]) -> Digest {
+pub fn compute_root_hash_from_val(root_val: &AzksValue) -> Digest {
     // FIXME(#344) Change this to:
     // root_val
-    hash(&[root_val, &NodeLabel::root().hash()].concat())
+    hash(&[&root_val.0[..], &NodeLabel::root().hash()].concat())
 }
 
 /// Used by the server to produce a commitment for an AkdLabel, version, and AkdValue
@@ -147,19 +156,19 @@ pub fn compute_root_hash_from_val(root_val: &[u8]) -> Digest {
 /// value (even though the binding to value is somewhat optional).
 ///
 /// Note that this commitment needs to be a hash function (random oracle) output
-pub fn commit_fresh_value(
+pub fn compute_fresh_azks_value(
     commitment_key: &[u8],
     label: &NodeLabel,
     version: u64,
     value: &AkdValue,
-) -> Digest {
+) -> AzksValue {
     let nonce = get_commitment_nonce(commitment_key, label, version, value);
-    hash(&[i2osp_array(value), i2osp_array(&nonce)].concat())
+    AzksValue(hash(&[i2osp_array(value), i2osp_array(&nonce)].concat()))
 }
 
 /// Similar to commit_fresh_value, but used for stale values.
-pub fn commit_stale_value() -> Digest {
+pub fn stale_azks_value() -> AzksValue {
     // FIXME(#344) Change this to:
     // crate::hash::EMPTY_DIGEST
-    hash(&EMPTY_VALUE)
+    AzksValue(hash(&EMPTY_VALUE))
 }

--- a/akd_core/src/proto/mod.rs
+++ b/akd_core/src/proto/mod.rs
@@ -15,7 +15,7 @@ pub mod specs;
 #[cfg(test)]
 mod tests;
 
-use crate::hash::Digest;
+use crate::{hash::Digest, AzksValue};
 
 use core::convert::{TryFrom, TryInto};
 use protobuf::MessageField;
@@ -146,7 +146,7 @@ impl From<&crate::AzksElement> for specs::types::AzksElement {
     fn from(input: &crate::AzksElement) -> Self {
         Self {
             label: MessageField::some((&input.label).into()),
-            value: Some(input.value.to_vec()),
+            value: Some(input.value.0.to_vec()),
             ..Default::default()
         }
     }
@@ -163,7 +163,10 @@ impl TryFrom<&specs::types::AzksElement> for crate::AzksElement {
         // get the raw data & it's length, but at most crate::hash::DIGEST_BYTES bytes
         let value = hash_from_bytes!(input.value());
 
-        Ok(Self { label, value })
+        Ok(Self {
+            label,
+            value: AzksValue(value),
+        })
     }
 }
 
@@ -218,7 +221,7 @@ impl From<&crate::MembershipProof> for specs::types::MembershipProof {
     fn from(input: &crate::MembershipProof) -> Self {
         Self {
             label: MessageField::some((&input.label).into()),
-            hash_val: Some(input.hash_val.to_vec()),
+            hash_val: Some(input.hash_val.0.to_vec()),
             sibling_proofs: input
                 .sibling_proofs
                 .iter()
@@ -246,7 +249,7 @@ impl TryFrom<&specs::types::MembershipProof> for crate::MembershipProof {
 
         Ok(Self {
             label,
-            hash_val,
+            hash_val: AzksValue(hash_val),
             sibling_proofs,
         })
     }

--- a/akd_core/src/proto/tests.rs
+++ b/akd_core/src/proto/tests.rs
@@ -9,7 +9,7 @@
 
 use super::specs::types::*;
 use super::*;
-use crate::Direction;
+use crate::{AzksValue, Direction};
 use rand::{thread_rng, Rng};
 
 // ================= Test helpers ================= //
@@ -21,7 +21,7 @@ fn random_hash() -> [u8; 32] {
 fn random_azks_element() -> crate::AzksElement {
     crate::AzksElement {
         label: random_label(),
-        value: random_hash(),
+        value: AzksValue(random_hash()),
     }
 }
 
@@ -66,7 +66,7 @@ fn test_convert_layer_proof() {
 fn test_convert_membership_proof() {
     let original = crate::MembershipProof {
         label: random_label(),
-        hash_val: random_hash(),
+        hash_val: AzksValue(random_hash()),
         sibling_proofs: vec![crate::SiblingProof {
             label: random_label(),
             siblings: [random_azks_element()],
@@ -86,7 +86,7 @@ fn test_convert_non_membership_proof() {
         longest_prefix_children: [random_azks_element(), random_azks_element()],
         longest_prefix_membership_proof: crate::MembershipProof {
             label: random_label(),
-            hash_val: random_hash(),
+            hash_val: AzksValue(random_hash()),
             sibling_proofs: vec![crate::SiblingProof {
                 label: random_label(),
                 siblings: [random_azks_element()],
@@ -109,7 +109,7 @@ fn test_convert_lookup_proof() {
         existence_vrf_proof: random_hash().to_vec(),
         existence_proof: crate::MembershipProof {
             label: random_label(),
-            hash_val: random_hash(),
+            hash_val: AzksValue(random_hash()),
             sibling_proofs: vec![crate::SiblingProof {
                 label: random_label(),
                 siblings: [random_azks_element()],
@@ -119,7 +119,7 @@ fn test_convert_lookup_proof() {
         marker_vrf_proof: random_hash().to_vec(),
         marker_proof: crate::MembershipProof {
             label: random_label(),
-            hash_val: random_hash(),
+            hash_val: AzksValue(random_hash()),
             sibling_proofs: vec![crate::SiblingProof {
                 label: random_label(),
                 siblings: [random_azks_element()],
@@ -133,7 +133,7 @@ fn test_convert_lookup_proof() {
             longest_prefix_children: [random_azks_element(), random_azks_element()],
             longest_prefix_membership_proof: crate::MembershipProof {
                 label: random_label(),
-                hash_val: random_hash(),
+                hash_val: AzksValue(random_hash()),
                 sibling_proofs: vec![crate::SiblingProof {
                     label: random_label(),
                     siblings: [random_azks_element()],
@@ -158,7 +158,7 @@ fn test_convert_update_proof() {
         existence_vrf_proof: random_hash().to_vec(),
         existence_proof: crate::MembershipProof {
             label: random_label(),
-            hash_val: random_hash(),
+            hash_val: AzksValue(random_hash()),
             sibling_proofs: vec![crate::SiblingProof {
                 label: random_label(),
                 siblings: [random_azks_element()],
@@ -168,7 +168,7 @@ fn test_convert_update_proof() {
         previous_version_vrf_proof: Some(random_hash().to_vec()),
         previous_version_proof: Some(crate::MembershipProof {
             label: random_label(),
-            hash_val: random_hash(),
+            hash_val: AzksValue(random_hash()),
             sibling_proofs: vec![crate::SiblingProof {
                 label: random_label(),
                 siblings: [random_azks_element()],
@@ -191,7 +191,7 @@ fn test_convert_history_proof() {
             longest_prefix_children: [random_azks_element(), random_azks_element()],
             longest_prefix_membership_proof: crate::MembershipProof {
                 label: random_label(),
-                hash_val: random_hash(),
+                hash_val: AzksValue(random_hash()),
                 sibling_proofs: vec![crate::SiblingProof {
                     label: random_label(),
                     siblings: [random_azks_element()],
@@ -210,7 +210,7 @@ fn test_convert_history_proof() {
             existence_vrf_proof: random_hash().to_vec(),
             existence_proof: crate::MembershipProof {
                 label: random_label(),
-                hash_val: random_hash(),
+                hash_val: AzksValue(random_hash()),
                 sibling_proofs: vec![crate::SiblingProof {
                     label: random_label(),
                     siblings: [random_azks_element()],
@@ -220,7 +220,7 @@ fn test_convert_history_proof() {
             previous_version_vrf_proof: Some(random_hash().to_vec()),
             previous_version_proof: Some(crate::MembershipProof {
                 label: random_label(),
-                hash_val: random_hash(),
+                hash_val: AzksValue(random_hash()),
                 sibling_proofs: vec![crate::SiblingProof {
                     label: random_label(),
                     siblings: [random_azks_element()],

--- a/akd_core/src/verify/base.rs
+++ b/akd_core/src/verify/base.rs
@@ -16,7 +16,7 @@ use crate::crypto::{
 use crate::ecvrf::{Proof, VrfError};
 use crate::hash::Digest;
 use crate::{
-    AkdLabel, AkdValue, Direction, MembershipProof, NodeLabel, NonMembershipProof,
+    AkdLabel, AkdValue, AzksValue, Direction, MembershipProof, NodeLabel, NonMembershipProof,
     VersionFreshness, EMPTY_LABEL,
 };
 
@@ -187,7 +187,7 @@ pub(crate) fn verify_existence_with_val(
     vrf_proof: &[u8],
     membership_proof: &MembershipProof,
 ) -> Result<(), VerificationError> {
-    if hash_leaf_with_value(akd_value, epoch, commitment_nonce) != membership_proof.hash_val {
+    if hash_leaf_with_value(akd_value, epoch, commitment_nonce).0 != membership_proof.hash_val.0 {
         return Err(VerificationError::MembershipProof(
             "Hash of plaintext value did not match existence proof hash".to_string(),
         ));
@@ -210,14 +210,14 @@ pub(crate) fn verify_existence_with_commitment(
     vrf_public_key: &[u8],
     root_hash: Digest,
     akd_label: &AkdLabel,
-    commitment: Digest,
+    commitment: AzksValue,
     epoch: u64,
     freshness: VersionFreshness,
     version: u64,
     vrf_proof: &[u8],
     membership_proof: &MembershipProof,
 ) -> Result<(), VerificationError> {
-    if hash_leaf_with_commitment(commitment, epoch) != membership_proof.hash_val {
+    if hash_leaf_with_commitment(commitment, epoch).0 != membership_proof.hash_val.0 {
         return Err(VerificationError::MembershipProof(
             "Hash of plaintext value did not match existence proof hash".to_string(),
         ));

--- a/akd_core/src/verify/history.rs
+++ b/akd_core/src/verify/history.rs
@@ -13,7 +13,7 @@ use super::base::{
 };
 use super::VerificationError;
 
-use crate::crypto::commit_stale_value;
+use crate::crypto::stale_azks_value;
 use crate::hash::Digest;
 use crate::{AkdLabel, HistoryProof, UpdateProof, VerifyResult, VersionFreshness};
 #[cfg(feature = "nostd")]
@@ -210,7 +210,7 @@ fn verify_single_update_proof(
         vrf_public_key,
         root_hash,
         akd_label,
-        commit_stale_value(),
+        stale_azks_value(),
         proof.epoch,
         VersionFreshness::Stale,
         proof.version - 1,

--- a/akd_mysql/src/mysql_storables.rs
+++ b/akd_mysql/src/mysql_storables.rs
@@ -135,7 +135,7 @@ impl MySqlStorable for DbRecord {
                 "left_child_label_val" => node.latest_node.left_child.map(|lc| lc.label_val),
                 "right_child_len" => node.latest_node.right_child.map(|rc| rc.label_len),
                 "right_child_label_val" => node.latest_node.right_child.map(|rc| rc.label_val),
-                "hash" => node.latest_node.hash,
+                "hash" => node.latest_node.hash.0,
                 // "Previous" node values
                 "p_last_epoch" => node.previous_node.clone().map(|a| a.last_epoch),
                 "p_least_descendant_ep" => node.previous_node.clone().map(|a| a.min_descendant_epoch),
@@ -146,7 +146,7 @@ impl MySqlStorable for DbRecord {
                 "p_left_child_label_val" => node.previous_node.clone().and_then(|a| a.left_child.map(|lc| lc.label_val)),
                 "p_right_child_len" => node.previous_node.clone().and_then(|a| a.right_child.map(|rc| rc.label_len)),
                 "p_right_child_label_val" => node.previous_node.clone().and_then(|a| a.right_child.map(|rc| rc.label_val)),
-                "p_hash" => node.previous_node.clone().map(|a| a.hash),
+                "p_hash" => node.previous_node.clone().map(|a| a.hash.0),
             }),
             DbRecord::ValueState(state) => Some(
                 params! { "username" => state.get_id().0, "epoch" => state.epoch, "version" => state.version, "node_label_len" => state.label.label_len, "node_label_val" => state.label.label_val, "data" => state.value.0.clone() },
@@ -306,7 +306,7 @@ impl MySqlStorable for DbRecord {
                             format!("right_child_label_val{}", idx),
                             Value::from(node.latest_node.right_child.map(|rc| rc.label_val)),
                         ),
-                        (format!("hash{}", idx), Value::from(node.latest_node.hash)),
+                        (format!("hash{}", idx), Value::from(node.latest_node.hash.0)),
                         (
                             format!("p_last_epoch{}", idx),
                             Value::from(pnode.clone().map(|a| a.last_epoch)),
@@ -361,7 +361,7 @@ impl MySqlStorable for DbRecord {
                         ),
                         (
                             format!("p_hash{}", idx),
-                            Value::from(pnode.clone().map(|a| a.hash)),
+                            Value::from(pnode.clone().map(|a| a.hash.0)),
                         ),
                     ])
                 }


### PR DESCRIPTION
- Defines a wrapper struct `AzksValue` which is used to hold the node's value. Previously it was just a raw `Digest`
- `AzksElement` now has two fields, a label `NodeLabel` and a value `AzksValue`
- Also defines `AzksValueWithEpoch` to make the distinction of when the value is hashed together with the epoch for leaf nodes
- Also adds cargo doc build tests for each package individually (since akd_core was not building, see https://docs.rs/crate/akd_core/latest)
- Doesn't change any protobuf generation or the fixture

Btw, given this change, I am thinking of renaming the `NodeLabel` struct to `AzksLabel`. Thoughts? This would potentially affect the protobuf files.