### PR TITLE
Using PrefixOrdering to replace invalid Directions

### DIFF
--- a/akd_core/src/lib.rs
+++ b/akd_core/src/lib.rs
@@ -191,6 +191,5 @@ pub mod verify;
 pub mod types;
 pub use types::*;
 
-/// The arity of the tree. Should EXACTLY match the ARITY within
-/// the AKD crate (i.e. akd::ARITY)
+/// The number of children each non-leaf node has in the tree
 pub const ARITY: usize = 2;

--- a/akd_core/src/proto/mod.rs
+++ b/akd_core/src/proto/mod.rs
@@ -15,7 +15,7 @@ pub mod specs;
 #[cfg(test)]
 mod tests;
 
-use crate::{hash::Digest, AzksValue};
+use crate::{hash::Digest, AzksValue, Bit};
 
 use core::convert::{TryFrom, TryInto};
 use protobuf::MessageField;
@@ -203,12 +203,21 @@ impl TryFrom<&specs::types::SiblingProof> for crate::SiblingProof {
 
         // blind out the highest bits to all 0's, since we're pulling it down to a u8
         let direction = (input.direction() & DIRECTION_BLINDING_FACTOR) as u8;
+        let bit = match direction {
+            0 => Bit::Zero,
+            1 => Bit::One,
+            _ => {
+                return Err(ConversionError::Deserialization(format!(
+                    "Invalid direction: {}",
+                    direction
+                )))
+            }
+        };
 
         Ok(Self {
             label,
             siblings: [siblings.unwrap().try_into()?],
-            direction: crate::types::Direction::try_from(direction)
-                .map_err(ConversionError::Deserialization)?,
+            direction: crate::types::Direction::from(bit),
         })
     }
 }

--- a/akd_core/src/verify/base.rs
+++ b/akd_core/src/verify/base.rs
@@ -37,12 +37,6 @@ pub fn verify_membership(
     for sibling_proof in proof.sibling_proofs.iter().rev() {
         let sibling = sibling_proof.siblings[0];
         let (left_val, left_label, right_val, right_label) = match sibling_proof.direction {
-            Direction::None => {
-                return Err(VerificationError::MembershipProof(format!(
-                    "Empty direction for {:?}",
-                    sibling_proof.label.label_val
-                )))
-            }
             Direction::Left => (
                 curr_val,
                 curr_label.hash(),


### PR DESCRIPTION
Closes #314.

We introduce a `PrefixOrdering` which is like a `Direction` that can be `None`, and then remove the `None` option from a `Direction`. That way, we isolate the places where we check for invalid prefix ordering, and deal with only valid directions in tree-manipulating code.