### PR TITLE
Optimizations to preload nodes in history proofs

### DIFF
--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -28,6 +28,10 @@ runtime_metrics = []
 parallel_vrf = ["akd_core/parallel_vrf"]
 # Parallelize node insertion during publish
 parallel_insert = []
+# Enable pre-loading of the nodes when generating history proofs
+preload_history = []
+# TESTING ONLY: Artifically slow the in-memory database (for benchmarking)
+slow_internal_db = []
 
 # Default features mix (blake3 + audit-proof protobuf mgmt support)
 default = ["blake3", "public_auditing", "parallel_vrf", "parallel_insert"]
@@ -71,5 +75,10 @@ akd = { path = ".", features = ["public-tests"], default-features = false }
 
 [[bench]]
 name = "azks"
+harness = false
+required-features = ["bench"]
+
+[[bench]]
+name = "directory"
 harness = false
 required-features = ["bench"]

--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd"
-version = "0.8.6"
+version = "0.8.7"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "An implementation of an auditable key directory"
 license = "MIT OR Apache-2.0"
@@ -38,7 +38,7 @@ default = ["blake3", "public_auditing", "parallel_vrf", "parallel_insert"]
 
 [dependencies]
 ## Required dependencies ##
-akd_core = { path = "../akd_core", version = "0.8.5", default-features = false, features = ["vrf"] }
+akd_core = { path = "../akd_core", version = "0.8.7", default-features = false, features = ["vrf"] }
 async-recursion = "0.3"
 async-trait = "0.1"
 curve25519-dalek = "3"

--- a/akd/benches/directory.rs
+++ b/akd/benches/directory.rs
@@ -1,0 +1,86 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree and the Apache
+// License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+// of this source tree.
+
+#[macro_use]
+extern crate criterion;
+
+use akd::ecvrf::HardCodedAkdVRF;
+use akd::storage::manager::StorageManager;
+use akd::storage::memory::AsyncInMemoryDatabase;
+use akd::{AkdLabel, AkdValue, Directory};
+use criterion::{BatchSize, Criterion};
+use rand::distributions::Alphanumeric;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+fn history_generation(c: &mut Criterion) {
+    let num_users = 1000;
+    let num_updates = 10;
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_time()
+        .build()
+        .unwrap();
+
+    let idata = (1..num_users)
+        .into_iter()
+        .map(|i| {
+            let user = format!("User {}", i);
+            AkdLabel::from(&user)
+        })
+        .collect::<Vec<_>>();
+
+    let id = "Benchmark key history proof generation on a small tree".to_string();
+
+    c.bench_function(&id, move |b| {
+        b.iter_batched(
+            || {
+                let mut rng = StdRng::seed_from_u64(42);
+                let database = AsyncInMemoryDatabase::new();
+                let vrf = HardCodedAkdVRF {};
+                let db = StorageManager::new(
+                    database,
+                    Some(std::time::Duration::from_secs(60)),
+                    None,
+                    Some(std::time::Duration::from_secs(60)),
+                );
+                let db_clone = db.clone();
+                let directory = runtime
+                    .block_on(async move { Directory::new(db, vrf, false).await })
+                    .unwrap();
+
+                for _epoch in 1..num_updates {
+                    let value: String = (0..rng.gen_range(10, 20))
+                        .map(|_| rng.sample(&Alphanumeric))
+                        .map(char::from)
+                        .collect();
+                    let data = idata
+                        .iter()
+                        .map(|k| (k.clone(), AkdValue::from(&value)))
+                        .collect::<Vec<_>>();
+                    runtime.block_on(directory.publish(data)).unwrap();
+                }
+
+                (directory, db_clone)
+            },
+            |(directory, db)| {
+                // flush the cache prior to each generation to get fresh results
+                runtime.block_on(db.flush_cache());
+
+                // generate for the most recent 10 updates
+                let label = AkdLabel::from("User 1");
+                let params = akd::HistoryParams::MostRecent(5);
+                runtime
+                    .block_on(directory.key_history(&label, params))
+                    .unwrap();
+            },
+            BatchSize::PerIteration,
+        );
+    });
+}
+
+criterion_group!(directory_benches, history_generation);
+criterion_main!(directory_benches);

--- a/akd_client/Cargo.toml
+++ b/akd_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_client"
-version = "0.8.6"
+version = "0.8.7"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Client verification companion for the auditable key directory with limited dependencies."
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 ## Required dependencies ##
-akd_core = { path = "../akd_core", version = "0.8.0", default-features = false, features = ["vrf"] }
+akd_core = { path = "../akd_core", version = "0.8", default-features = false, features = ["vrf"] }
 hex = "0.4"
 
 ## Optional dependencies ##

--- a/akd_core/Cargo.toml
+++ b/akd_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_core"
-version = "0.8.6"
+version = "0.8.7"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Core utilities for the auditable-key-directory suite of crates (akd and akd_client)"
 license = "MIT OR Apache-2.0"

--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_mysql"
-version = "0.8.6"
+version = "0.8.7"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "A MySQL storage layer implementation for an auditable key directory (AKD)"
 license = "MIT OR Apache-2.0"
@@ -25,9 +25,9 @@ async-recursion = "0.3"
 mysql_async = "0.31"
 mysql_common = "0.29.1"
 log = { version = "0.4.8", features = ["kv_unstable"] }
-akd = { path = "../akd", version = "0.8.6", features = ["serde_serialization"], default-features = false }
+akd = { path = "../akd", version = "0.8.7", features = ["serde_serialization"], default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"
 serial_test = "0.5"
-akd = { path = "../akd", version = "0.8.6", features = ["blake3", "public-tests"], default-features = false }
+akd = { path = "../akd", version = "0.8.7", features = ["blake3", "public-tests"], default-features = false }

--- a/akd_test_tools/Cargo.toml
+++ b/akd_test_tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_test_tools"
-version = "0.8.6"
+version = "0.8.7"
 authors = ["Evan Au <evanau@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Test utilities and tooling"
 license = "MIT OR Apache-2.0"
@@ -22,9 +22,9 @@ serde = "1.0"
 async-trait = "0.1"
 thread-id = "3"
 
-akd = { path = "../akd", features = ["serde_serialization"], version = "0.8.6" }
+akd = { path = "../akd", features = ["serde_serialization"], version = "0.8.7" }
 
 [dev-dependencies]
 assert_fs="1"
 
-akd = { path = "../akd", features = ["public-tests", "rand", "serde_serialization"], version = "0.8.6" }
+akd = { path = "../akd", features = ["public-tests", "rand", "serde_serialization"], version = "0.8.7" }


### PR DESCRIPTION
We were doing a LOT of direct get requests to the data layer to retrieve the various nodes needed to do proof generation. This can be demonstrated with the benchmark added in this PR, and additionally artifically slowing the database's `get` call to simulate some network latency.

```bash
$ cargo bench -p akd --bench directory -F bench,slow_internal_db
...
Benchmark key history proof generation on a small tree
                        time:   [4.2915 s 4.3005 s 4.3096 s]
```

Then if we enable the support for preloading nodes in `akd/src/directory.rs` that this PR adds, we see that we are just calling batch_get which greatly improves our overall performance, even if batch-get has similar latency

```bash
$ cargo bench -p akd --bench directory -F bench,slow_internal_db,preload_history
...
Benchmark key history proof generation on a small tree
                        time:   [1.7625 s 1.7663 s 1.7700 s]
                        change: [-59.051% -58.929% -58.804%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Without any artifical db slowing we have the following:

No preload:
```bash
Benchmark key history proof generation on a small tree
                        time:   [23.138 ms 23.557 ms 23.977 ms]
```

With preload:
```bash
Benchmark key history proof generation on a small tree
                        time:   [23.798 ms 24.204 ms 24.608 ms]
```