### PR TITLE
Adding parallelism to audit proof generation

### DIFF
--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd"
-version = "0.8.7"
+version = "0.8.8"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "An implementation of an auditable key directory"
 license = "MIT OR Apache-2.0"

--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -34,7 +34,7 @@ preload_history = []
 slow_internal_db = []
 
 # Default features mix (blake3 + audit-proof protobuf mgmt support)
-default = ["blake3", "public_auditing", "parallel_vrf", "parallel_insert"]
+default = ["blake3", "public_auditing", "parallel_vrf", "parallel_insert", "preload_history"]
 
 [dependencies]
 ## Required dependencies ##

--- a/akd/benches/azks.rs
+++ b/akd/benches/azks.rs
@@ -124,7 +124,7 @@ fn audit_verify(c: &mut Criterion) {
 fn audit_generate(c: &mut Criterion) {
     let num_leaves = 10000;
     let num_epochs = 100;
-    
+
     let mut rng = StdRng::seed_from_u64(42);
     let runtime = tokio::runtime::Builder::new_multi_thread().build().unwrap();
 
@@ -136,19 +136,13 @@ fn audit_generate(c: &mut Criterion) {
     for _epoch in 0..num_epochs {
         let node_set = gen_nodes(&mut rng, num_leaves);
         runtime
-        .block_on(azks.batch_insert_nodes(
-            &db,
-            node_set,
-            InsertMode::Directory,
-        ))
-        .unwrap();
+            .block_on(azks.batch_insert_nodes(&db, node_set, InsertMode::Directory))
+            .unwrap();
     }
     let epoch = azks.get_latest_epoch();
 
     // benchmark audit verify
-    let id = format!(
-        "Audit proof generation. {num_leaves} leaves over {num_epochs} epochs"
-    );
+    let id = format!("Audit proof generation. {num_leaves} leaves over {num_epochs} epochs");
     c.bench_function(&id, move |b| {
         b.iter_batched(
             || {},

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -783,8 +783,9 @@ impl Azks {
                     if parallel_levels.map(|p| p as u64 > level).unwrap_or(false) {
                         // we can parallelise further!
                         let storage_clone = storage.clone();
+                        #[allow(clippy::type_complexity)]
                         let tsk: tokio::task::JoinHandle<
-                            Result<(Vec<AzksElement>, Vec<AzksElement>), AkdError>,
+                            Result<_, AkdError>,
                         > = tokio::spawn(async move {
                             let my_storage = storage_clone;
                             let child_node = TreeNode::get_from_storage(
@@ -831,13 +832,11 @@ impl Azks {
                 #[cfg(not(feature = "parallel_insert"))]
                 {
                     // NO Parallelism, BAD! parallelism. Get your nose out of the garbage!
-                    let child_node = TreeNode::get_from_storage(
-                        storage,
-                        &NodeKey(left_child),
-                        latest_epoch,
-                    )
-                    .await?;
-                    let (mut inner_unchanged, mut inner_leaf) = Self::get_append_only_proof_helper::<_>(
+                    let child_node =
+                        TreeNode::get_from_storage(storage, &NodeKey(left_child), latest_epoch)
+                            .await?;
+                    let (mut inner_unchanged, mut inner_leaf) =
+                        Self::get_append_only_proof_helper::<_>(
                             latest_epoch,
                             storage,
                             child_node,

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -628,9 +628,12 @@ impl<S: Database + 'static, V: VRFKeyStorage> Directory<S, V> {
                 "End epoch {audit_end_ep} is greater than the current epoch {current_epoch}"
             ))))
         } else {
-            current_azks
+            self.storage.disable_cache_cleaning();
+            let result = current_azks
                 .get_append_only_proof::<_>(&self.storage, audit_start_ep, audit_end_ep)
-                .await
+                .await;
+            self.storage.enable_cache_cleaning();
+            result
         }
     }
 

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -410,12 +410,10 @@ impl<S: Database + 'static, V: VRFKeyStorage> Directory<S, V> {
                 // Need to throw an error
                 match std::str::from_utf8(&akd_label) {
                     Ok(name) => Err(AkdError::Storage(StorageError::NotFound(format!(
-                        "User {} at epoch {}",
-                        name, epoch
+                        "User {name} at epoch {epoch}"
                     )))),
                     _ => Err(AkdError::Storage(StorageError::NotFound(format!(
-                        "User {:?} at epoch {}",
-                        akd_label, epoch
+                        "User {akd_label:?} at epoch {epoch}"
                     )))),
                 }
             }
@@ -460,9 +458,9 @@ impl<S: Database + 'static, V: VRFKeyStorage> Directory<S, V> {
 
         if user_data.is_empty() {
             let msg = if let Ok(username_str) = std::str::from_utf8(akd_label) {
-                format!("User {}", username_str)
+                format!("User {username_str}")
             } else {
-                format!("User {:?}", akd_label)
+                format!("User {akd_label:?}")
             };
             return Err(AkdError::Storage(StorageError::NotFound(msg)));
         }
@@ -595,8 +593,7 @@ impl<S: Database + 'static, V: VRFKeyStorage> Directory<S, V> {
                     if let Some(channel) = &change_detected {
                         channel.send(()).await.map_err(|send_err| {
                             AkdError::Storage(StorageError::Connection(format!(
-                                "Tokio MPSC sender failed to publish notification with error {:?}",
-                                send_err
+                                "Tokio MPSC sender failed to publish notification with error {send_err:?}"
                             )))
                         })?;
                     }
@@ -624,13 +621,11 @@ impl<S: Database + 'static, V: VRFKeyStorage> Directory<S, V> {
 
         if audit_start_ep >= audit_end_ep {
             Err(AkdError::Directory(DirectoryError::InvalidEpoch(format!(
-                "Start epoch {} is greater than or equal the end epoch {}",
-                audit_start_ep, audit_end_ep
+                "Start epoch {audit_start_ep} is greater than or equal the end epoch {audit_end_ep}"
             ))))
         } else if current_epoch < audit_end_ep {
             Err(AkdError::Directory(DirectoryError::InvalidEpoch(format!(
-                "End epoch {} is greater than the current epoch {}",
-                audit_end_ep, current_epoch
+                "End epoch {audit_end_ep} is greater than the current epoch {current_epoch}"
             ))))
         } else {
             current_azks

--- a/akd/src/errors.rs
+++ b/akd/src/errors.rs
@@ -87,28 +87,28 @@ impl std::fmt::Display for AkdError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
             AkdError::TreeNode(err) => {
-                writeln!(f, "AKD Tree Node Error: {}", err)
+                writeln!(f, "AKD Tree Node Error: {err}")
             }
             AkdError::Directory(err) => {
-                writeln!(f, "AKD Directory Error: {}", err)
+                writeln!(f, "AKD Directory Error: {err}")
             }
             AkdError::AzksErr(err) => {
-                writeln!(f, "AKD AZKS Error: {}", err)
+                writeln!(f, "AKD AZKS Error: {err}")
             }
             AkdError::Vrf(err) => {
-                writeln!(f, "AKD VRF Error: {}", err)
+                writeln!(f, "AKD VRF Error: {err}")
             }
             AkdError::Storage(err) => {
-                writeln!(f, "AKD Storage Error: {}", err)
+                writeln!(f, "AKD Storage Error: {err}")
             }
             AkdError::AuditErr(err) => {
-                writeln!(f, "AKD Auditor Error {}", err)
+                writeln!(f, "AKD Auditor Error {err}")
             }
             AkdError::Parallelism(err) => {
-                writeln!(f, "AKD Parallelism Error: {}", err)
+                writeln!(f, "AKD Parallelism Error: {err}")
             }
             AkdError::TestErr(err) => {
-                writeln!(f, "{}", err)
+                writeln!(f, "{err}")
             }
         }
     }
@@ -145,24 +145,23 @@ impl fmt::Display for TreeNodeError {
             Self::InvalidDirection(dir) => {
                 write!(
                     f,
-                    "AKD is based on a binary tree. No child with a given direction: {:?}",
-                    dir
+                    "AKD is based on a binary tree. No child with a given direction: {dir:?}"
                 )
             }
             Self::NoDirection(node_label, child_label) => {
-                let mut to_print = format!("no direction provided for the node {:?}", node_label);
+                let mut to_print = format!("no direction provided for the node {node_label:?}");
                 // Add child info if given.
                 if let Some(child_label) = child_label {
-                    let child_str = format!(" and child {:?}", child_label);
+                    let child_str = format!(" and child {child_label:?}");
                     to_print.push_str(&child_str);
                 }
-                write!(f, "{}", to_print)
+                write!(f, "{to_print}")
             }
             Self::NoChildAtEpoch(epoch, direction) => {
-                write!(f, "no node in direction {:?} at epoch {}", direction, epoch)
+                write!(f, "no node in direction {direction:?} at epoch {epoch}")
             }
             Self::ParentNextEpochInvalid(epoch) => {
-                write!(f, "Next epoch of parent is invalid, epoch = {}", epoch)
+                write!(f, "Next epoch of parent is invalid, epoch = {epoch}")
             }
             Self::HashUpdateOrderInconsistent => {
                 write!(
@@ -173,19 +172,17 @@ impl fmt::Display for TreeNodeError {
             Self::NonexistentAtEpoch(label, epoch) => {
                 write!(
                     f,
-                    "This node, labelled {:?}, did not exist at epoch {:?}.",
-                    label, epoch
+                    "This node, labelled {label:?}, did not exist at epoch {epoch:?}."
                 )
             }
             Self::NoStateAtEpoch(label, epoch) => {
                 write!(
                     f,
-                    "This node, labelled {:?}, did not exist at epoch {:?}.",
-                    label, epoch
+                    "This node, labelled {label:?}, did not exist at epoch {epoch:?}."
                 )
             }
             Self::DigestDeserializationFailed(inner_error) => {
-                write!(f, "Encountered a serialization error {}", inner_error)
+                write!(f, "Encountered a serialization error {inner_error}")
             }
         }
     }
@@ -209,7 +206,7 @@ impl fmt::Display for AzksError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::VerifyMembershipProof(error_string) => {
-                write!(f, "{}", error_string)
+                write!(f, "{error_string}")
             }
             Self::VerifyAppendOnlyProof => {
                 write!(f, "Append only proof did not verify!")
@@ -239,13 +236,13 @@ impl fmt::Display for DirectoryError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Verification(err) => {
-                write!(f, "Verification failure {}", err)
+                write!(f, "Verification failure {err}")
             }
             Self::InvalidEpoch(err_string) => {
-                write!(f, "Invalid epoch {}", err_string)
+                write!(f, "Invalid epoch {err_string}")
             }
             Self::ReadOnlyDirectory(inner_message) => {
-                write!(f, "Directory in read-only mode: {}", inner_message)
+                write!(f, "Directory in read-only mode: {inner_message}")
             }
         }
     }
@@ -277,16 +274,16 @@ impl fmt::Display for StorageError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             StorageError::Connection(inner) => {
-                write!(f, "Storage connection: {}", inner)
+                write!(f, "Storage connection: {inner}")
             }
             StorageError::Transaction(inner) => {
-                write!(f, "Transaction: {}", inner)
+                write!(f, "Transaction: {inner}")
             }
             StorageError::NotFound(inner) => {
-                write!(f, "Data not found: {}", inner)
+                write!(f, "Data not found: {inner}")
             }
             StorageError::Other(inner) => {
-                write!(f, "Other storage error: {}", inner)
+                write!(f, "Other storage error: {inner}")
             }
         }
     }
@@ -306,7 +303,7 @@ impl fmt::Display for AuditorError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::VerifyAuditProof(err_string) => {
-                write!(f, "Failed to verify audit {}", err_string)
+                write!(f, "Failed to verify audit {err_string}")
             }
         }
     }
@@ -326,7 +323,7 @@ impl fmt::Display for ParallelismError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::JoinErr(err_string) => {
-                write!(f, "Failed to join tokio task {}", err_string)
+                write!(f, "Failed to join tokio task {err_string}")
             }
         }
     }

--- a/akd/src/local_auditing.rs
+++ b/akd/src/local_auditing.rs
@@ -91,8 +91,7 @@ impl TryFrom<&str> for AuditBlobName {
         // PART[1] = PREVIOUS_HASH
         let previous_hash_bytes = hex::decode(parts[1]).map_err(|hex_err| {
             LocalAuditorError::NameParseError(format!(
-                "Failed to decode previous hash from hex string: {}",
-                hex_err
+                "Failed to decode previous hash from hex string: {hex_err}"
             ))
         })?;
         let previous_hash = hash_from_ref!(&previous_hash_bytes)?;
@@ -100,8 +99,7 @@ impl TryFrom<&str> for AuditBlobName {
         // PART[2] = CURRENT_HASH
         let current_hash_bytes = hex::decode(parts[2]).map_err(|hex_err| {
             LocalAuditorError::NameParseError(format!(
-                "Failed to decode current hash from hex string: {}",
-                hex_err
+                "Failed to decode current hash from hex string: {hex_err}"
             ))
         })?;
         let current_hash = hash_from_ref!(&current_hash_bytes)?;

--- a/akd/src/storage/cache/high_parallelism.rs
+++ b/akd/src/storage/cache/high_parallelism.rs
@@ -50,12 +50,9 @@ impl TimedCache {
             let hit_count = self.hit_count.swap(0, Ordering::Relaxed);
             let cache_size = self.map.len();
 
-            let msg = format!(
-                "Cache hit since last: {}, cached size: {} items",
-                hit_count, cache_size
-            );
+            let msg = format!("Cache hit since last: {hit_count}, cached size: {cache_size} items");
             match _level {
-                log::Level::Trace => println!("{}", msg),
+                log::Level::Trace => println!("{msg}"),
                 log::Level::Debug => debug!("{}", msg),
                 log::Level::Info => info!("{}", msg),
                 log::Level::Warn => warn!("{}", msg),

--- a/akd/src/storage/manager/mod.rs
+++ b/akd/src/storage/manager/mod.rs
@@ -132,7 +132,7 @@ impl<Db: Database> StorageManager<Db> {
             let snapshot = self
                 .metrics
                 .iter()
-                .map(|metric| metric.load(Ordering::Relaxed))
+                .map(|metric| metric.swap(0, Ordering::Relaxed))
                 .collect::<Vec<_>>();
 
             let msg = format!(
@@ -168,7 +168,7 @@ impl<Db: Database> StorageManager<Db> {
             match level {
                 // Currently logs cannot be captured unless they are
                 // println!. Normally Level::Trace should use the trace! macro.
-                log::Level::Trace => println!("{}", msg),
+                log::Level::Trace => println!("{msg}"),
                 log::Level::Debug => debug!("{}", msg),
                 log::Level::Info => info!("{}", msg),
                 log::Level::Warn => warn!("{}", msg),
@@ -210,8 +210,7 @@ impl<Db: Database> StorageManager<Db> {
         let _epoch = match records.last() {
             Some(DbRecord::Azks(azks)) => Ok(azks.latest_epoch),
             other => Err(StorageError::Transaction(format!(
-                "The last record in the transaction log is NOT an Azks record {:?}",
-                other
+                "The last record in the transaction log is NOT an Azks record {other:?}"
             ))),
         }?;
 
@@ -471,7 +470,7 @@ impl<Db: Database> StorageManager<Db> {
 
             Ok(state)
         } else {
-            Err(StorageError::NotFound(format!("ValueState {:?}", username)))
+            Err(StorageError::NotFound(format!("ValueState {username:?}")))
         }
     }
 
@@ -516,8 +515,7 @@ impl<Db: Database> StorageManager<Db> {
             Ok(data)
         } else {
             Err(StorageError::NotFound(format!(
-                "ValueState records for {:?}",
-                username
+                "ValueState records for {username:?}"
             )))
         }
     }

--- a/akd/src/storage/manager/mod.rs
+++ b/akd/src/storage/manager/mod.rs
@@ -245,6 +245,20 @@ impl<Db: Database> StorageManager<Db> {
         self.transaction.is_transaction_active()
     }
 
+    /// Disable cache cleaning (if present)
+    pub fn disable_cache_cleaning(&self) {
+        if let Some(cache) = &self.cache {
+            cache.disable_clean();
+        }
+    }
+
+    /// Enable cache cleaning (if present)
+    pub fn enable_cache_cleaning(&self) {
+        if let Some(cache) = &self.cache {
+            cache.enable_clean();
+        }
+    }
+
     /// Store a record in the database
     pub async fn set(&self, record: DbRecord) -> Result<(), StorageError> {
         // we're in a transaction, set the item in the transaction

--- a/akd/src/storage/memory.rs
+++ b/akd/src/storage/memory.rs
@@ -60,7 +60,7 @@ impl AsyncInMemoryDatabase {
                         return Ok(DbRecord::ValueState(found.clone()));
                     }
                 }
-                return Err(StorageError::NotFound(format!("ValueState {:?}", id)));
+                return Err(StorageError::NotFound(format!("ValueState {id:?}")));
             }
         }
         // fallback to regular get/set db
@@ -163,7 +163,7 @@ impl Database for AsyncInMemoryDatabase {
 
             Ok(KeyData { states: results })
         } else {
-            Err(StorageError::NotFound(format!("ValueState {:?}", username)))
+            Err(StorageError::NotFound(format!("ValueState {username:?}")))
         }
     }
 
@@ -230,7 +230,7 @@ impl Database for AsyncInMemoryDatabase {
                 }
             }
         }
-        Err(StorageError::NotFound(format!("ValueState {:?}", username)))
+        Err(StorageError::NotFound(format!("ValueState {username:?}")))
     }
 
     async fn get_user_state_versions(

--- a/akd/src/storage/transaction.rs
+++ b/akd/src/storage/transaction.rs
@@ -78,7 +78,7 @@ impl Transaction {
             let r = self.num_reads.swap(0, Ordering::Relaxed);
             let w = self.num_writes.swap(0, Ordering::Relaxed);
 
-            let msg = format!("Transaction writes: {}, Transaction reads: {}", w, r);
+            let msg = format!("Transaction writes: {w}, Transaction reads: {r}");
 
             match _level {
                 log::Level::Trace => trace!("{}", msg),

--- a/akd/src/test_utils.rs
+++ b/akd/src/test_utils.rs
@@ -25,9 +25,9 @@ impl TestConsoleLogger {
         let target = {
             if let Some(target_str) = record.target().split(':').last() {
                 if let Some(line) = record.line() {
-                    format!(" ({}:{})", target_str, line)
+                    format!(" ({target_str}:{line})")
                 } else {
-                    format!(" ({})", target_str)
+                    format!(" ({target_str})")
                 }
             } else {
                 "".to_string()
@@ -62,7 +62,7 @@ impl TestConsoleLogger {
             Level::Warn => msg.yellow(),
             Level::Error => msg.red(),
         };
-        println!("{}", msg);
+        println!("{msg}");
     }
 }
 

--- a/akd/src/tests.rs
+++ b/akd/src/tests.rs
@@ -447,7 +447,7 @@ async fn test_simple_key_history() -> Result<(), AkdError> {
         borked_proof,
         HistoryVerificationParams::default(),
     );
-    assert!(matches!(result, Err(_)), "{:?}", result);
+    assert!(matches!(result, Err(_)), "{}", "{result:?}");
 
     Ok(())
 }
@@ -1114,8 +1114,8 @@ async fn test_publish_op_makes_no_get_requests() {
     let mut updates = vec![];
     for i in 0..1 {
         updates.push((
-            AkdLabel(format!("hello1{}", i).as_bytes().to_vec()),
-            AkdValue(format!("hello1{}", i).as_bytes().to_vec()),
+            AkdLabel(format!("hello1{i}").as_bytes().to_vec()),
+            AkdValue(format!("hello1{i}").as_bytes().to_vec()),
         ));
     }
     // Publish the updates. Now the akd's epoch will be 1.
@@ -1142,7 +1142,7 @@ async fn test_publish_op_makes_no_get_requests() {
     let mut updates = vec![];
     for i in 0..1 {
         updates.push((
-            AkdLabel(format!("hello1{}", i).as_bytes().to_vec()),
+            AkdLabel(format!("hello1{i}").as_bytes().to_vec()),
             AkdValue(format!("hello1{}", i + 1).as_bytes().to_vec()),
         ));
     }
@@ -1175,8 +1175,8 @@ async fn test_simple_lookup_for_small_tree_blake() -> Result<(), AkdError> {
     let mut updates = vec![];
     for i in 0..1 {
         updates.push((
-            AkdLabel(format!("hello1{}", i).as_bytes().to_vec()),
-            AkdValue(format!("hello1{}", i).as_bytes().to_vec()),
+            AkdLabel(format!("hello1{i}").as_bytes().to_vec()),
+            AkdValue(format!("hello1{i}").as_bytes().to_vec()),
         ));
     }
     // Publish the updates. Now the akd's epoch will be 1.

--- a/akd/src/tree_node.rs
+++ b/akd/src/tree_node.rs
@@ -184,8 +184,7 @@ impl TreeNodeWithPreviousValue {
         match storage.get::<Self>(key).await? {
             DbRecord::TreeNode(node) => node.determine_node_to_get(target_epoch),
             _ => Err(StorageError::NotFound(format!(
-                "TreeNodeWithPreviousValue {:?}",
-                key
+                "TreeNodeWithPreviousValue {key:?}"
             ))),
         }
     }
@@ -460,8 +459,7 @@ impl TreeNode {
                 Ok(node) => Ok(Some(node)),
                 Err(StorageError::NotFound(_)) => Ok(None),
                 _ => Err(AkdError::Storage(StorageError::NotFound(format!(
-                    "TreeNode {:?}",
-                    child_key
+                    "TreeNode {child_key:?}"
                 )))),
             }
         } else {
@@ -645,8 +643,7 @@ mod tests {
         let root_expected_min_dec = 1u64;
         assert_eq!(
             root_expected_min_dec, root_smallest_descendant_ep,
-            "Minimum descendant epoch not equal to expected: root, expected: {:?}, got: {:?}",
-            root_expected_min_dec, root_smallest_descendant_ep
+            "Minimum descendant epoch not equal to expected: root, expected: {root_expected_min_dec:?}, got: {root_smallest_descendant_ep:?}"
         );
 
         let right_child_expected_min_dec = 2u64;

--- a/akd_client/Cargo.toml
+++ b/akd_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_client"
-version = "0.8.7"
+version = "0.8.8"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Client verification companion for the auditable key directory with limited dependencies."
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 ## Required dependencies ##
-akd_core = { path = "../akd_core", version = "0.8", default-features = false, features = ["vrf"] }
+akd_core = { path = "../akd_core", version = "0.8.7", default-features = false, features = ["vrf"] }
 hex = "0.4"
 
 ## Optional dependencies ##

--- a/akd_core/Cargo.toml
+++ b/akd_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_core"
-version = "0.8.7"
+version = "0.8.8"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Core utilities for the auditable-key-directory suite of crates (akd and akd_client)"
 license = "MIT OR Apache-2.0"

--- a/akd_core/src/build.rs
+++ b/akd_core/src/build.rs
@@ -21,8 +21,8 @@ fn build_protobufs() {
     let mut protobuf_files = Vec::with_capacity(PROTOBUF_FILES.len());
 
     for file in PROTOBUF_FILES.iter() {
-        let proto_file = format!("{}/{}.proto", PROTOBUF_BASE_DIRECTORY, file);
-        println!("cargo:rerun-if-changed={}", proto_file);
+        let proto_file = format!("{PROTOBUF_BASE_DIRECTORY}/{file}.proto");
+        println!("cargo:rerun-if-changed={proto_file}");
         protobuf_files.push(proto_file);
     }
 

--- a/akd_core/src/ecvrf/ecvrf_impl.rs
+++ b/akd_core/src/ecvrf/ecvrf_impl.rs
@@ -140,7 +140,7 @@ impl TryFrom<&[u8]> for VRFPrivateKey {
     fn try_from(bytes: &[u8]) -> Result<VRFPrivateKey, VrfError> {
         match ed25519_PrivateKey::from_bytes(bytes) {
             Ok(result) => Ok(VRFPrivateKey(result)),
-            Err(sig_err) => Err(VrfError::SigningKey(format!("Signature error {}", sig_err))),
+            Err(sig_err) => Err(VrfError::SigningKey(format!("Signature error {sig_err}"))),
         }
     }
 }
@@ -169,7 +169,7 @@ impl TryFrom<&[u8]> for VRFPublicKey {
 
         match ed25519_PublicKey::from_bytes(bytes) {
             Ok(result) => Ok(VRFPublicKey(result)),
-            Err(sig_err) => Err(VrfError::PublicKey(format!("Signature error {}", sig_err))),
+            Err(sig_err) => Err(VrfError::PublicKey(format!("Signature error {sig_err}"))),
         }
     }
 }

--- a/akd_core/src/ecvrf/mod.rs
+++ b/akd_core/src/ecvrf/mod.rs
@@ -57,11 +57,11 @@ pub enum VrfError {
 impl core::fmt::Display for VrfError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let code = match &self {
-            VrfError::PublicKey(msg) => format!("(Public Key) - {}", msg),
-            VrfError::SigningKey(msg) => format!("(Signing Key) - {}", msg),
-            VrfError::Verification(msg) => format!("(Verification) - {}", msg),
+            VrfError::PublicKey(msg) => format!("(Public Key) - {msg}"),
+            VrfError::SigningKey(msg) => format!("(Signing Key) - {msg}"),
+            VrfError::Verification(msg) => format!("(Verification) - {msg}"),
         };
-        write!(f, "Verifiable random function error {}", code)
+        write!(f, "Verifiable random function error {code}")
     }
 }
 

--- a/akd_core/src/ecvrf/traits.rs
+++ b/akd_core/src/ecvrf/traits.rs
@@ -177,8 +177,7 @@ pub trait VRFKeyStorage: Clone + Sync + Send {
                 match res {
                     Err(join_err) => {
                         return Err(VrfError::SigningKey(format!(
-                            "Parallel VRF join error {}",
-                            join_err
+                            "Parallel VRF join error {join_err}"
                         )))
                     }
                     Ok((node_label, (label, freshness, version, value))) => {

--- a/akd_core/src/proto/mod.rs
+++ b/akd_core/src/proto/mod.rs
@@ -34,8 +34,7 @@ pub enum ConversionError {
 impl From<protobuf::Error> for ConversionError {
     fn from(err: protobuf::Error) -> Self {
         Self::Protobuf(format!(
-            "An error occurred in protobuf serialization/deserialization {}",
-            err
+            "An error occurred in protobuf serialization/deserialization {err}"
         ))
     }
 }
@@ -43,10 +42,10 @@ impl From<protobuf::Error> for ConversionError {
 impl core::fmt::Display for ConversionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> core::fmt::Result {
         let code = match &self {
-            ConversionError::Deserialization(msg) => format!("(Deserialization) - {}", msg),
-            ConversionError::Protobuf(msg) => format!("(Protobuf) - {}", msg),
+            ConversionError::Deserialization(msg) => format!("(Deserialization) - {msg}"),
+            ConversionError::Protobuf(msg) => format!("(Protobuf) - {msg}"),
         };
-        write!(f, "Type conversion error {}", code)
+        write!(f, "Type conversion error {code}")
     }
 }
 
@@ -208,8 +207,7 @@ impl TryFrom<&specs::types::SiblingProof> for crate::SiblingProof {
             1 => Bit::One,
             _ => {
                 return Err(ConversionError::Deserialization(format!(
-                    "Invalid direction: {}",
-                    direction
+                    "Invalid direction: {direction}"
                 )))
             }
         };

--- a/akd_core/src/types/node_label/tests.rs
+++ b/akd_core/src/types/node_label/tests.rs
@@ -63,8 +63,7 @@ pub fn test_get_bit_at_small() {
         assert_eq!(
             label.get_bit_at(index),
             Bit::Zero,
-            "Index {} should be 0 in a label of length 4 but it doesn't!",
-            index
+            "Index {index} should be 0 in a label of length 4 but it doesn't!"
         );
     }
 }
@@ -79,9 +78,8 @@ pub fn test_get_bit_at_medium_1() {
     let computed = label.get_bit_at(0);
     assert!(
         expected == computed,
-        "get_bit_at(2) wrong for the 4 digit label 10! Expected {:?} and got {:?}",
-        expected,
-        computed
+        "{}",
+        "get_bit_at(2) wrong for the 4 digit label 10! Expected {expected:?} and got {computed:?}"
     )
 }
 
@@ -97,9 +95,8 @@ pub fn test_get_bit_at_medium_2() {
     let computed = label.get_bit_at(190);
     assert!(
         expected == computed,
-        "get_bit_at(2) wrong for the 4 digit label 10! Expected {:?} and got {:?}",
-        expected,
-        computed
+        "{}",
+        "get_bit_at(2) wrong for the 4 digit label 10! Expected {expected:?} and got {computed:?}"
     )
 }
 
@@ -163,9 +160,8 @@ pub fn test_byte_arr_from_u64_small() {
     let computed = byte_arr_from_u64(val);
     assert!(
         expected == computed,
-        "Byte from u64 conversion wrong for small u64! Expected {:?} and got {:?}",
-        expected,
-        computed
+        "{}",
+        "Byte from u64 conversion wrong for small u64! Expected {expected:?} and got {computed:?}"
     )
 }
 
@@ -184,9 +180,7 @@ pub fn test_byte_arr_from_u64_medium() {
     let computed = byte_arr_from_u64(val);
     assert!(
         expected == computed,
-        "Byte from u64 conversion wrong for medium, ~2 byte u64! Expected {:?} and got {:?}",
-        expected,
-        computed
+        "{}", "Byte from u64 conversion wrong for medium, ~2 byte u64! Expected {expected:?} and got {computed:?}"
     )
 }
 
@@ -206,9 +200,7 @@ pub fn test_byte_arr_from_u64_larger() {
     let computed = byte_arr_from_u64(val);
     assert!(
         expected == computed,
-        "Byte from u64 conversion wrong for larger, ~3 byte u64! Expected {:?} and got {:?}",
-        expected,
-        computed
+        "{}", "Byte from u64 conversion wrong for larger, ~3 byte u64! Expected {expected:?} and got {computed:?}"
     )
 }
 
@@ -318,8 +310,7 @@ pub fn test_node_label_lcp_self_prefix_leading_one() {
     let computed = label_1.get_longest_common_prefix(label_2);
     assert!(
         computed == expected,
-        "Longest common substring with self with leading one, not equal to itself! Expected: {:?}, Got: {:?}",
-        expected, computed
+        "{}", "Longest common substring with self with leading one, not equal to itself! Expected: {expected:?}, Got: {computed:?}"
     )
 }
 
@@ -344,8 +335,7 @@ pub fn test_node_label_lcp_other_one() {
     let computed = label_1.get_longest_common_prefix(label_2);
     assert!(
         computed == expected,
-        "Longest common substring with other with leading one, not equal to expected! Expected: {:?}, Computed: {:?}",
-        expected, computed
+        "{}", "Longest common substring with other with leading one, not equal to expected! Expected: {expected:?}, Computed: {computed:?}"
     )
 }
 
@@ -415,9 +405,8 @@ pub fn test_get_dir_large() {
         let computed = label_2.get_prefix_ordering(label_1);
         assert!(
             computed == expected,
-            "Direction not equal to expected. Node = {:?}, prefix = {:?}",
-            label_1,
-            label_2
+            "{}",
+            "Direction not equal to expected. Node = {label_1:?}, prefix = {label_2:?}"
         )
     }
 }
@@ -434,10 +423,7 @@ pub fn test_get_dir_example() {
     let computed = label_2.get_prefix_ordering(label_1);
     assert!(
         computed == expected,
-        "Direction not equal to expected. Node = {:?}, prefix = {:?}, computed = {:?}",
-        label_1,
-        label_2,
-        computed
+        "{}", "Direction not equal to expected. Node = {label_1:?}, prefix = {label_2:?}, computed = {computed:?}"
     )
 }
 
@@ -453,10 +439,7 @@ pub fn test_get_prefix_small() {
     let computed = label_1.get_prefix(prefix_len);
     assert!(
         computed == label_2,
-        "Direction not equal to expected. Node = {:?}, prefix = {:?}, computed = {:?}",
-        label_1,
-        label_2,
-        computed
+        "{}", "Direction not equal to expected. Node = {label_1:?}, prefix = {label_2:?}, computed = {computed:?}"
     )
 }
 

--- a/akd_core/src/verify/history.rs
+++ b/akd_core/src/verify/history.rs
@@ -60,8 +60,7 @@ pub fn key_history_verify(
     // Make sure the update proofs are non-empty
     if num_proofs == 0 {
         return Err(VerificationError::HistoryProof(format!(
-            "No update proofs included in the proof of user {:?} at epoch {:?}!",
-            akd_key, current_epoch
+            "No update proofs included in the proof of user {akd_key:?} at epoch {current_epoch:?}!"
         )));
     }
 
@@ -136,8 +135,7 @@ pub fn key_history_verify(
             &proof.future_marker_vrf_proofs[i],
             &proof.non_existence_of_future_marker_proofs[i],
         ).map_err(|_|
-            VerificationError::HistoryProof(format!("Non-existence of future marker proof of user {:?}'s version {:?} at epoch {:?} does not verify",
-            akd_key, version, current_epoch)))?;
+            VerificationError::HistoryProof(format!("Non-existence of future marker proof of user {akd_key:?}'s version {version:?} at epoch {current_epoch:?} does not verify")))?;
     }
 
     Ok(results)

--- a/akd_core/src/verify/mod.rs
+++ b/akd_core/src/verify/mod.rs
@@ -40,18 +40,18 @@ pub enum VerificationError {
 impl core::fmt::Display for VerificationError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let code = match &self {
-            VerificationError::MembershipProof(err) => format!("(Membership proof) - {}", err),
+            VerificationError::MembershipProof(err) => format!("(Membership proof) - {err}"),
             VerificationError::NonMembershipProof(err) => {
-                format!("(Non-membership proof) - {}", err)
+                format!("(Non-membership proof) - {err}")
             }
-            VerificationError::LookupProof(err) => format!("(Lookup proof) - {}", err),
-            VerificationError::HistoryProof(err) => format!("(History proof) - {}", err),
+            VerificationError::LookupProof(err) => format!("(Lookup proof) - {err}"),
+            VerificationError::HistoryProof(err) => format!("(History proof) - {err}"),
             #[cfg(feature = "vrf")]
             VerificationError::Vrf(vrf) => vrf.to_string(),
             #[cfg(feature = "protobuf")]
             VerificationError::Serialization(proto) => proto.to_string(),
         };
-        write!(f, "Verification error {}", code)
+        write!(f, "Verification error {code}")
     }
 }
 

--- a/akd_local_auditor/src/common_test.rs
+++ b/akd_local_auditor/src/common_test.rs
@@ -74,15 +74,15 @@ pub async fn generate_audit_proofs(
             // generate (n) epochs of updates on many users
             let data = (1..100000)
                 .map(|item| {
-                    let user = format!("user{}", item);
-                    let value = format!("value{}_{}", _epoch, item);
+                    let user = format!("user{item}");
+                    let value = format!("value{_epoch}_{item}");
                     (AkdLabel::from(&user), AkdValue::from(&value))
                 })
                 .collect::<Vec<(AkdLabel, AkdValue)>>();
             akd.publish(data).await?;
         } else {
             // generate (n) epochs of updates on the same user
-            let t_value = format!("certificate{}", _epoch);
+            let t_value = format!("certificate{_epoch}");
             akd.publish(vec![(AkdLabel::from("user"), AkdValue::from(&t_value))])
                 .await?;
         }

--- a/akd_local_auditor/src/console_log.rs
+++ b/akd_local_auditor/src/console_log.rs
@@ -34,9 +34,9 @@ impl ConsoleLogger {
         let target = {
             if let Some(target_str) = record.target().split(':').last() {
                 if let Some(line) = record.line() {
-                    format!(" ({}:{})", target_str, line)
+                    format!(" ({target_str}:{line})")
                 } else {
-                    format!(" ({})", target_str)
+                    format!(" ({target_str})")
                 }
             } else {
                 "".to_string()
@@ -72,9 +72,9 @@ impl ConsoleLogger {
                 Level::Warn => msg.yellow().bold(),
                 Level::Error => msg.red().bold(),
             };
-            let _ = writeln!(io, "{}", msg);
+            let _ = writeln!(io, "{msg}");
         } else {
-            let _ = writeln!(io, "{}", msg);
+            let _ = writeln!(io, "{msg}");
         }
     }
 }

--- a/akd_local_auditor/src/storage/dynamodb/mod.rs
+++ b/akd_local_auditor/src/storage/dynamodb/mod.rs
@@ -49,7 +49,7 @@ fn validate_table_name(s: &str) -> Result<String, String> {
 
     for c in str.chars() {
         if !ALLOWED_TABLE_CHARS.iter().any(|v| c == *v) {
-            return Err(format!("Character '{}' is not allowed in table name. Table names must contain lower-case letters, numbers, '-', '_', and '.' only.", c));
+            return Err(format!("Character '{c}' is not allowed in table name. Table names must contain lower-case letters, numbers, '-', '_', and '.' only."));
         }
     }
     Ok(str)

--- a/akd_local_auditor/src/storage/s3/mod.rs
+++ b/akd_local_auditor/src/storage/s3/mod.rs
@@ -48,7 +48,7 @@ pub(crate) fn validate_bucket_name(s: &str) -> Result<String, String> {
 
     for c in str.chars() {
         if !ALLOWED_BUCKET_CHARS.iter().any(|v| c == *v) {
-            return Err(format!("Character '{}' is not allowed in bucket name. Bucket names must contain lower-case letters, numbers, '-', and '.' only.", c));
+            return Err(format!("Character '{c}' is not allowed in bucket name. Bucket names must contain lower-case letters, numbers, '-', and '.' only."));
         }
     }
     Ok(str)

--- a/akd_local_auditor/src/ui/auditor/mod.rs
+++ b/akd_local_auditor/src/ui/auditor/mod.rs
@@ -118,11 +118,11 @@ impl Auditor {
             let blob = storage
                 .get_proof(&epoch_summary)
                 .await
-                .map_err(|err| format!("Error downloading proof {}", err))?;
+                .map_err(|err| format!("Error downloading proof {err}"))?;
             // decode the proof
             let (epoch, p_hash, c_hash, proof) = blob
                 .decode()
-                .map_err(|err| format!("Error decodeing proof {:?}", err))?;
+                .map_err(|err| format!("Error decodeing proof {err:?}"))?;
             // audit the proof
             akd::auditor::audit_verify(
                 vec![p_hash, c_hash],
@@ -132,7 +132,7 @@ impl Auditor {
                 },
             )
             .await
-            .map_err(|err| format!("Error auditing proof {}", err))?;
+            .map_err(|err| format!("Error auditing proof {err}"))?;
 
             let qr_data = crate::auditor::format_qr_record(p_hash, c_hash, epoch);
             Ok(qr_data)
@@ -170,8 +170,7 @@ impl Auditor {
                     }
                     Err(err) => {
                         let c = super::logstream::error(format!(
-                            "Error downloading epoch information {}",
-                            err
+                            "Error downloading epoch information {err}"
                         ));
                         log::error!("Error downloading epoch infomation {}", err);
                         c
@@ -221,7 +220,7 @@ impl Auditor {
                         );
 
                         self.qr_codes
-                            .insert(epoch_summary, Err(format!("Audit failed! {}", err)));
+                            .insert(epoch_summary, Err(format!("Audit failed! {err}")));
                         command
                     }
                 }
@@ -259,8 +258,7 @@ impl Auditor {
                         row_batch
                             .iter()
                             .map(|(start, end)| {
-                                let txt =
-                                    text(format!("{}..{}", start, end)).size(DEFAULT_FONT_SIZE);
+                                let txt = text(format!("{start}..{end}")).size(DEFAULT_FONT_SIZE);
                                 button(txt)
                                     .padding(DEFAULT_SPACING)
                                     .width(Length::FillPortion(1))

--- a/akd_local_auditor/src/ui/settings/mod.rs
+++ b/akd_local_auditor/src/ui/settings/mod.rs
@@ -278,7 +278,7 @@ impl StorageSettings {
                     }
                     Err(err) => {
                         log::error!("Failed to save settings: {:?}", err);
-                        crate::ui::logstream::warn(format!("Failed to save settings: {:?}", err))
+                        crate::ui::logstream::warn(format!("Failed to save settings: {err:?}"))
                     }
                 }
             }
@@ -293,7 +293,7 @@ impl StorageSettings {
                 }
                 Err(err) => {
                     log::error!("Failed to load settings: {:?}", err);
-                    crate::ui::logstream::warn(format!("Failed to load settings: {:?}", err))
+                    crate::ui::logstream::warn(format!("Failed to load settings: {err:?}"))
                 }
             },
         }
@@ -445,7 +445,7 @@ impl super::AuditorTab for StorageSettings {
                 row![text("Storage Type: ")].spacing(DEFAULT_SPACING),
                 |row, ty| {
                     row.push(radio(
-                        format!("{}", ty),
+                        format!("{ty}"),
                         *ty,
                         Some(match self.settings {
                             SpecificStorageSettings::S3(_) => StorageType::S3,

--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_mysql"
-version = "0.8.7"
+version = "0.8.8"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "A MySQL storage layer implementation for an auditable key directory (AKD)"
 license = "MIT OR Apache-2.0"

--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/novifinancial/akd"
 
 [features]
 # Collect runtime metrics on db access calls + timing
-runtime_metrics = []
+runtime_metrics = ["akd/runtime_metrics"]
 
 [dependencies]
 bincode = "1"

--- a/akd_mysql/src/mysql.rs
+++ b/akd_mysql/src/mysql.rs
@@ -70,11 +70,11 @@ pub struct AsyncMySqlDatabase {
 impl std::fmt::Display for AsyncMySqlDatabase {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let db_str = match self.opts.db_name() {
-            Some(db) => format!("Database {}", db),
+            Some(db) => format!("Database {db}"),
             None => String::from(""),
         };
         let user_str = match self.opts.user() {
-            Some(user) => format!(", User {}", user),
+            Some(user) => format!(", User {user}"),
             None => String::from(""),
         };
 
@@ -623,7 +623,7 @@ impl<'a> AsyncMySqlDatabase {
             ))),
             Err(error) => {
                 error!("MySQL error {}", error);
-                Err(StorageError::Other(format!("MySQL Error {}", error)))
+                Err(StorageError::Other(format!("MySQL Error {error}")))
             }
         }
     }
@@ -637,7 +637,7 @@ impl Database for AsyncMySqlDatabase {
             Ok(_) => Ok(()),
             Err(error) => {
                 error!("MySQL error {}", error);
-                Err(StorageError::Other(format!("MySQL Error {}", error)))
+                Err(StorageError::Other(format!("MySQL Error {error}")))
             }
         }
     }
@@ -719,7 +719,7 @@ impl Database for AsyncMySqlDatabase {
             Ok(_) => Ok(()),
             Err(error) => {
                 error!("MySQL error {}", error);
-                Err(StorageError::Other(format!("MySQL Error {}", error)))
+                Err(StorageError::Other(format!("MySQL Error {error}")))
             }
         }
     }
@@ -823,7 +823,7 @@ impl Database for AsyncMySqlDatabase {
 
                 // drop the temp table of ids
                 let t_out = conn
-                    .query_drop(format!("DROP TEMPORARY TABLE `{}`", TEMP_IDS_TABLE))
+                    .query_drop(format!("DROP TEMPORARY TABLE `{TEMP_IDS_TABLE}`"))
                     .await;
                 self.check_for_infra_error(t_out)?;
 
@@ -851,7 +851,7 @@ impl Database for AsyncMySqlDatabase {
             }
             Err(error) => {
                 error!("MySQL error {}", error);
-                return Err(StorageError::Other(format!("MySQL Error {}", error)));
+                return Err(StorageError::Other(format!("MySQL Error {error}")));
             }
         }
 
@@ -925,7 +925,7 @@ impl Database for AsyncMySqlDatabase {
             Ok(output) => Ok(output),
             Err(error) => {
                 error!("MySQL error {}", error);
-                Err(StorageError::Other(format!("MySQL Error {}", error)))
+                Err(StorageError::Other(format!("MySQL Error {error}")))
             }
         }
     }
@@ -1011,10 +1011,10 @@ impl Database for AsyncMySqlDatabase {
         };
         match result.await {
             Ok(Some(result)) => Ok(result),
-            Ok(None) => Err(StorageError::NotFound(format!("ValueState {:?}", username))),
+            Ok(None) => Err(StorageError::NotFound(format!("ValueState {username:?}"))),
             Err(error) => {
                 error!("MySQL error {}", error);
-                Err(StorageError::Other(format!("MySQL Error {}", error)))
+                Err(StorageError::Other(format!("MySQL Error {error}")))
             }
         }
     }
@@ -1053,9 +1053,9 @@ impl Database for AsyncMySqlDatabase {
             let mut statement = "INSERT INTO `search_users` (`username`) VALUES ".to_string();
             for i in 0..self.tunable_insert_depth {
                 if i < self.tunable_insert_depth - 1 {
-                    statement += format!("(:username{}), ", i).as_ref();
+                    statement += format!("(:username{i}), ").as_ref();
                 } else {
-                    statement += format!("(:username{})", i).as_ref();
+                    statement += format!("(:username{i})").as_ref();
                 }
             }
 
@@ -1070,7 +1070,7 @@ impl Database for AsyncMySqlDatabase {
                         .iter()
                         .enumerate()
                         .map(|(idx, username)| {
-                            (format!("username{}", idx), Value::from(username.0.clone()))
+                            (format!("username{idx}"), Value::from(username.0.clone()))
                         })
                         .collect();
                     params.push(mysql_async::Params::from(pvec));
@@ -1091,9 +1091,9 @@ impl Database for AsyncMySqlDatabase {
                     "INSERT INTO `search_users` (`username`) VALUES ".to_string();
                 for i in 0..rlen {
                     if i < rlen - 1 {
-                        remainder_stmt += format!("(:username{}), ", i).as_ref();
+                        remainder_stmt += format!("(:username{i}), ").as_ref();
                     } else {
-                        remainder_stmt += format!("(:username{})", i).as_ref();
+                        remainder_stmt += format!("(:username{i})").as_ref();
                     }
                 }
 
@@ -1102,7 +1102,7 @@ impl Database for AsyncMySqlDatabase {
                     .iter()
                     .enumerate()
                     .map(|(idx, username)| {
-                        (format!("username{}", idx), Value::from(username.0.clone()))
+                        (format!("username{idx}"), Value::from(username.0.clone()))
                     })
                     .collect();
                 let params_batch = mysql_async::Params::from(users_vec);
@@ -1142,19 +1142,18 @@ impl Database for AsyncMySqlDatabase {
             };
             let select_statement = format!(
                 r"SELECT full.`username`, full.`version`, full.`data`
-                FROM {} full
+                FROM {TABLE_USER} full
                 INNER JOIN (
-                    SELECT tmp.`username`, {} AS `epoch`
-                    FROM {} tmp
+                    SELECT tmp.`username`, {epoch_grouping} AS `epoch`
+                    FROM {TABLE_USER} tmp
                     INNER JOIN `search_users` su
                         ON su.`username` = tmp.`username`
-                    {}
+                    {filter}
                     GROUP BY tmp.`username`
                 ) epochs
                     ON epochs.`username` = full.`username`
                     AND epochs.`epoch` = full.`epoch`
-                ",
-                TABLE_USER, epoch_grouping, TABLE_USER, filter
+                "
             );
 
             let out = if params_map.is_empty() {
@@ -1204,7 +1203,7 @@ impl Database for AsyncMySqlDatabase {
             Ok(()) => Ok(results),
             Err(error) => {
                 error!("MySQL error {}", error);
-                Err(StorageError::Other(format!("MySQL Error {}", error)))
+                Err(StorageError::Other(format!("MySQL Error {error}")))
             }
         }
     }

--- a/akd_mysql/src/mysql_db_tests.rs
+++ b/akd_mysql/src/mysql_db_tests.rs
@@ -42,7 +42,7 @@ async fn test_mysql_db() {
         .expect("Failed to create async mysql db");
 
         if let Err(error) = mysql_db.delete_data().await {
-            println!("Error cleaning mysql prior to test suite: {}", error);
+            println!("Error cleaning mysql prior to test suite: {error}");
         }
 
         // The test cases
@@ -50,10 +50,7 @@ async fn test_mysql_db() {
 
         // clean the test infra
         if let Err(mysql_async::Error::Server(error)) = manager.get_db().drop_tables().await {
-            println!(
-                "ERROR: Failed to clean MySQL test database with error {}",
-                error
-            );
+            println!("ERROR: Failed to clean MySQL test database with error {error}");
         }
     } else {
         println!("WARN: Skipping MySQL test due to test guard noting that the docker container appears to not be running.");

--- a/akd_test_tools/Cargo.toml
+++ b/akd_test_tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_test_tools"
-version = "0.8.7"
+version = "0.8.8"
 authors = ["Evan Au <evanau@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Test utilities and tooling"
 license = "MIT OR Apache-2.0"
@@ -22,9 +22,9 @@ serde = "1.0"
 async-trait = "0.1"
 thread-id = "3"
 
-akd = { path = "../akd", features = ["serde_serialization"], version = "0.8.7" }
+akd = { path = "../akd", features = ["serde_serialization"], version = "0.8.8" }
 
 [dev-dependencies]
 assert_fs="1"
 
-akd = { path = "../akd", features = ["public-tests", "rand", "serde_serialization"], version = "0.8.7" }
+akd = { path = "../akd", features = ["public-tests", "rand", "serde_serialization"], version = "0.8.8" }

--- a/akd_test_tools/src/fixture_generator/generator.rs
+++ b/akd_test_tools/src/fixture_generator/generator.rs
@@ -107,7 +107,7 @@ pub(crate) async fn generate(args: Args) {
     raw_args
         .split(" -")
         .skip(1)
-        .map(|arg| format!("  -{} \\", arg))
+        .map(|arg| format!("  -{arg} \\"))
         .for_each(|comment| writer.write_comment(&comment));
 
     // write fixture metadata
@@ -151,7 +151,7 @@ pub(crate) async fn generate(args: Args) {
         // write delta if required
         if let Some(ref deltas) = args.capture_deltas {
             if deltas.contains(&epoch) {
-                let comment = format!("{} {}", DELTA_COMMENT, epoch);
+                let comment = format!("{DELTA_COMMENT} {epoch}");
                 let delta = Delta {
                     epoch,
                     updates: updates.clone(),
@@ -168,7 +168,7 @@ pub(crate) async fn generate(args: Args) {
         // write state if required
         if let Some(ref states) = args.capture_states {
             if states.contains(&epoch) {
-                let comment = format!("{} {}", STATE_COMMENT, epoch);
+                let comment = format!("{STATE_COMMENT} {epoch}");
 
                 // Sort the records by label to make the output deterministic.
                 let mut records = storage_manager

--- a/akd_test_tools/src/fixture_generator/reader/mod.rs
+++ b/akd_test_tools/src/fixture_generator/reader/mod.rs
@@ -37,8 +37,8 @@ impl std::fmt::Display for ReaderError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             ReaderError::NotFound => write!(f, "Object not found"),
-            ReaderError::Format(message) => write!(f, "Unexpected format: {}", message),
-            ReaderError::Input(message) => write!(f, "Input stream error: {}", message),
+            ReaderError::Format(message) => write!(f, "Unexpected format: {message}"),
+            ReaderError::Input(message) => write!(f, "Input stream error: {message}"),
         }
     }
 }

--- a/akd_test_tools/src/fixture_generator/reader/yaml.rs
+++ b/akd_test_tools/src/fixture_generator/reader/yaml.rs
@@ -9,7 +9,7 @@
 
 use std::fmt::Write as _;
 use std::fs::File;
-use std::io::{BufRead, BufReader, Lines, Seek, SeekFrom};
+use std::io::{BufRead, BufReader, Lines, Seek};
 use std::iter::Peekable;
 use std::result::Result; // import without risk of name clashing
 
@@ -48,7 +48,7 @@ impl YamlFileReader {
     // Instantiates a new buffer for a given file.
     fn buffer(file: &File) -> Result<Peekable<Lines<BufReader<File>>>, ReaderError> {
         let mut file_ref_copy = file.try_clone()?;
-        file_ref_copy.seek(SeekFrom::Start(0))?;
+        file_ref_copy.rewind()?;
 
         Ok(BufReader::new(file_ref_copy).lines().peekable())
     }
@@ -85,7 +85,7 @@ impl YamlFileReader {
                 }
                 Some(Ok(line)) => {
                     // avoid the extra allocation call with a format!
-                    let _ = writeln!(doc, "{}", line);
+                    let _ = writeln!(doc, "{line}");
                     self.buffer.next();
                 }
                 None => {

--- a/akd_test_tools/src/fixture_generator/writer/yaml.rs
+++ b/akd_test_tools/src/fixture_generator/writer/yaml.rs
@@ -31,7 +31,7 @@ impl<T: Write> Writer for YamlWriter<T> {
 
     fn write_comment(&mut self, comment: &str) {
         let lines = comment.split('\n');
-        lines.for_each(|line| writeln!(self.out, "# {}", line).unwrap());
+        lines.for_each(|line| writeln!(self.out, "# {line}").unwrap());
     }
 
     fn write_line(&mut self) {

--- a/akd_test_tools/src/test_suites.rs
+++ b/akd_test_tools/src/test_suites.rs
@@ -49,7 +49,7 @@ pub async fn directory_test_suite<S: Database + 'static, V: VRFKeyStorage>(
                 for value in users.iter() {
                     data.push((
                         AkdLabel::from(value),
-                        AkdValue(format!("{}", i).as_bytes().to_vec()),
+                        AkdValue(format!("{i}").as_bytes().to_vec()),
                     ));
                 }
 

--- a/integration_tests/src/test_util.rs
+++ b/integration_tests/src/test_util.rs
@@ -51,9 +51,9 @@ pub(crate) fn format_log_record(io: &mut (dyn Write + Send), record: &Record) {
     let target = {
         if let Some(target_str) = record.target().split(':').last() {
             if let Some(line) = record.line() {
-                format!(" ({}:{})", target_str, line)
+                format!(" ({target_str}:{line})")
             } else {
-                format!(" ({})", target_str)
+                format!(" ({target_str})")
             }
         } else {
             "".to_string()
@@ -83,7 +83,7 @@ pub(crate) fn format_log_record(io: &mut (dyn Write + Send), record: &Record) {
         record.args(),
         target
     );
-    let _ = writeln!(io, "{}", msg);
+    let _ = writeln!(io, "{msg}");
 }
 
 pub(crate) struct FileLogger {
@@ -154,7 +154,7 @@ pub(crate) async fn test_lookups<S: Database + 'static, V: VRFKeyStorage>(
                 for value in users.iter() {
                     data.push((
                         AkdLabel::from(value),
-                        AkdValue(format!("{}", i).as_bytes().to_vec()),
+                        AkdValue(format!("{i}").as_bytes().to_vec()),
                     ));
                 }
 

--- a/poc/src/directory_host.rs
+++ b/poc/src/directory_host.rs
@@ -76,7 +76,7 @@ where
                         response.send(Ok(msg)).unwrap()
                     }
                     Err(error) => {
-                        let msg = format!("Failed to publish with error: {:?}", error);
+                        let msg = format!("Failed to publish with error: {error:?}");
                         response.send(Err(msg)).unwrap();
                     }
                 }
@@ -99,7 +99,7 @@ where
                         response.send(Ok(msg)).unwrap()
                     }
                     Err(error) => {
-                        let msg = format!("Failed to publish with error: {:?}", error);
+                        let msg = format!("Failed to publish with error: {error:?}");
                         response.send(Err(msg)).unwrap();
                     }
                 }
@@ -115,15 +115,15 @@ where
                             proof,
                         );
                         if verification.is_err() {
-                            let msg = format!("WARN: Lookup proof failed verification for '{}'", a);
+                            let msg = format!("WARN: Lookup proof failed verification for '{a}'");
                             response.send(Err(msg)).unwrap();
                         } else {
-                            let msg = format!("Lookup proof verified for user '{}'", a);
+                            let msg = format!("Lookup proof verified for user '{a}'");
                             response.send(Ok(msg)).unwrap();
                         }
                     }
                     Err(error) => {
-                        let msg = format!("Failed to lookup with error {:?}", error);
+                        let msg = format!("Failed to lookup with error {error:?}");
                         response.send(Err(msg)).unwrap();
                     }
                 }
@@ -134,11 +134,11 @@ where
                     .await
                 {
                     Ok(_proof) => {
-                        let msg = format!("GOT KEY HISTORY FOR '{}'", a);
+                        let msg = format!("GOT KEY HISTORY FOR '{a}'");
                         response.send(Ok(msg)).unwrap();
                     }
                     Err(error) => {
-                        let msg = format!("Failed to lookup with error {:?}", error);
+                        let msg = format!("Failed to lookup with error {error:?}");
                         response.send(Err(msg)).unwrap();
                     }
                 }
@@ -146,11 +146,11 @@ where
             (DirectoryCommand::Audit(start, end), Some(response)) => {
                 match directory.audit(start, end).await {
                     Ok(_proof) => {
-                        let msg = format!("GOT AUDIT PROOF BETWEEN ({}, {})", start, end);
+                        let msg = format!("GOT AUDIT PROOF BETWEEN ({start}, {end})");
                         response.send(Ok(msg)).unwrap();
                     }
                     Err(error) => {
-                        let msg = format!("Failed to get audit proof with error {:?}", error);
+                        let msg = format!("Failed to get audit proof with error {error:?}");
                         response.send(Err(msg)).unwrap();
                     }
                 }
@@ -163,7 +163,7 @@ where
                         response.send(Ok(msg)).unwrap();
                     }
                     Some(Err(error)) => {
-                        let msg = format!("Failed to retrieve root hash with error {:?}", error);
+                        let msg = format!("Failed to retrieve root hash with error {error:?}");
                         response.send(Err(msg)).unwrap();
                     }
                     None => {

--- a/poc/src/logs.rs
+++ b/poc/src/logs.rs
@@ -33,9 +33,9 @@ impl ConsoleLogger {
         let target = {
             if let Some(target_str) = record.target().split(':').last() {
                 if let Some(line) = record.line() {
-                    format!(" ({}:{})", target_str, line)
+                    format!(" ({target_str}:{line})")
                 } else {
-                    format!(" ({})", target_str)
+                    format!(" ({target_str})")
                 }
             } else {
                 "".to_string()
@@ -66,7 +66,7 @@ impl ConsoleLogger {
             target
         );
         if no_color {
-            let _ = writeln!(io, "{}", msg);
+            let _ = writeln!(io, "{msg}");
         } else {
             let msg = match record.level() {
                 Level::Trace | Level::Debug => msg.white(),
@@ -74,7 +74,7 @@ impl ConsoleLogger {
                 Level::Warn => msg.yellow(),
                 Level::Error => msg.red(),
             };
-            let _ = writeln!(io, "{}", msg);
+            let _ = writeln!(io, "{msg}");
         }
     }
 }

--- a/poc/src/main.rs
+++ b/poc/src/main.rs
@@ -121,7 +121,7 @@ async fn main() {
     let level = if cli.debug {
         // File-logging enabled in debug mode
         match logs::FileLogger::new("akd_app.log") {
-            Err(err) => println!("Error initializing file logger {}", err),
+            Err(err) => println!("Error initializing file logger {err}"),
             Ok(flogger) => loggers.push(Box::new(flogger)),
         }
         // drop the log level to debug (console has a max-level of "Info")
@@ -131,7 +131,7 @@ async fn main() {
     };
 
     if let Err(err) = multi_log::MultiLogger::init(loggers, level) {
-        println!("Error initializing multi-logger {}", err);
+        println!("Error initializing multi-logger {err}");
     }
 
     let (tx, mut rx) = channel(2);
@@ -212,7 +212,7 @@ async fn process_input(
         match other_mode {
             OtherMode::BenchDbInsert { num_users } => {
                 println!("======= Benchmark operation requested ======= ");
-                println!("Beginning DB INSERT benchmark of {} users", num_users);
+                println!("Beginning DB INSERT benchmark of {num_users} users");
 
                 let mut values: Vec<String> = vec![];
                 for i in 0..*num_users {
@@ -257,8 +257,7 @@ async fn process_input(
             } => {
                 println!("======= Benchmark operation requested ======= ");
                 println!(
-                    "Beginning PUBLISH benchmark of {} users with {} updates/user",
-                    num_users, num_updates_per_user
+                    "Beginning PUBLISH benchmark of {num_users} users with {num_updates_per_user} updates/user"
                 );
 
                 let users: Vec<String> = (1..=*num_users)
@@ -299,7 +298,7 @@ async fn process_input(
                         continue;
                     }
                     match rpc_rx.await {
-                        Err(err) => code = Some(format!("{}", err)),
+                        Err(err) => code = Some(format!("{err}")),
                         Ok(Err(dir_err)) => code = Some(dir_err),
                         Ok(Ok(msg)) => info!("{}", msg),
                     }
@@ -330,8 +329,7 @@ async fn process_input(
             } => {
                 println!("======= Benchmark operation requested ======= ");
                 println!(
-                    "Beginning LOOKUP benchmark of {} users with {} lookups/user",
-                    num_users, num_lookups_per_user
+                    "Beginning LOOKUP benchmark of {num_users} users with {num_lookups_per_user} lookups/user"
                 );
 
                 let user_data: Vec<(String, String)> = (1..=*num_users)
@@ -375,7 +373,7 @@ async fn process_input(
                             continue;
                         }
                         match rpc_rx.await {
-                            Err(err) => code = Some(format!("{}", err)),
+                            Err(err) => code = Some(format!("{err}")),
                             Ok(Err(dir_err)) => code = Some(dir_err),
                             Ok(Ok(msg)) => {}
                         }
@@ -434,11 +432,10 @@ async fn process_input(
             stdin().read_line(&mut line).unwrap();
 
             match Command::parse(&mut line) {
-                Command::Unknown(other) => println!(
-                    "Input '{}' is not supported, enter 'help' for the help menu",
-                    other
-                ),
-                Command::InvalidArgs(message) => println!("Invalid arguments: {}", message),
+                Command::Unknown(other) => {
+                    println!("Input '{other}' is not supported, enter 'help' for the help menu")
+                }
+                Command::InvalidArgs(message) => println!("Invalid arguments: {message}"),
                 Command::Exit => {
                     info!("Exiting...");
                     break;
@@ -450,7 +447,7 @@ async fn process_input(
                     println!("Flushing the database...");
                     if let Some(mysql_db) = &db {
                         if let Err(error) = mysql_db.get_db().delete_data().await {
-                            println!("Error flushing database: {}", error);
+                            println!("Error flushing database: {error}");
                         } else {
                             println!(
                                 "Database flushed, exiting application. Please restart to create a new VKD"
@@ -482,7 +479,7 @@ async fn process_input(
                     if cli.debug {
                         match rpc_rx.await {
                             Ok(Ok(success)) => {
-                                println!("Response: {}", success);
+                                println!("Response: {success}");
                             }
                             Ok(Err(dir_err)) => {
                                 error!("Error in directory processing command: {}", dir_err);
@@ -494,7 +491,7 @@ async fn process_input(
                     } else {
                         match timeout(Duration::from_millis(1000), rpc_rx).await {
                             Ok(Ok(Ok(success))) => {
-                                println!("Response: {}", success);
+                                println!("Response: {success}");
                             }
                             Ok(Ok(Err(dir_err))) => {
                                 error!("Error in directory processing command: {}", dir_err);


### PR DESCRIPTION
Audit proofs don't currently support parallelization, and they're essentially a recursive tree-walk down the Merkle tree so are ideal candidates for parallel operations.

This change introduces parallel spawning of the audit proof walk by spawning a task for each `left_child` of the current node then recursing.

Additionally a (long) benchmark was added to assess this benefit, which will get progressively more important as the tree gets deep.

We've added a benchmark to demonstrate the functionality (with and without the `parallel_insert` feature enabled)

Without parallelism
```
Audit proof generation. 10000 leaves over 100 epochs
                        time:   [267.28 ms 271.38 ms 275.88 ms]
```

With:
```
Audit proof generation. 10000 leaves over 100 epochs
                        time:   [190.02 ms 192.30 ms 195.04 ms]
                        change: [-30.581% -29.141% -27.623%] (p = 0.00 < 0.05)
                        Performance has improved.
```

But again, these are tiny-scale tests compared to realistic data, which should continually get deeper and more complex as time goes on