### PR TITLE
Lookup proof optional optimization

### DIFF
--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd"
-version = "0.8.8"
+version = "0.8.9"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "An implementation of an auditable key directory"
 license = "MIT OR Apache-2.0"
@@ -32,13 +32,15 @@ parallel_insert = []
 preload_history = []
 # TESTING ONLY: Artifically slow the in-memory database (for benchmarking)
 slow_internal_db = []
+# Greedy loading of lookup proof nodes
+greedy_lookup_preload = []
 
 # Default features mix (blake3 + audit-proof protobuf mgmt support)
-default = ["blake3", "public_auditing", "parallel_vrf", "parallel_insert", "preload_history"]
+default = ["blake3", "public_auditing", "parallel_vrf", "parallel_insert", "preload_history", "greedy_lookup_preload"]
 
 [dependencies]
 ## Required dependencies ##
-akd_core = { path = "../akd_core", version = "0.8.7", default-features = false, features = ["vrf"] }
+akd_core = { path = "../akd_core", version = "0.8.9", default-features = false, features = ["vrf"] }
 async-recursion = "0.3"
 async-trait = "0.1"
 curve25519-dalek = "3"

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -1208,7 +1208,6 @@ mod tests {
 
         // since the label is there 3 times, it should all resolve to the same data
         assert_eq!(256, max_set.len());
-        println!("{max_set:?}");
     }
 
     #[tokio::test]

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -27,6 +27,7 @@ use crate::{
 use async_recursion::async_recursion;
 use log::info;
 use std::cmp::Ordering;
+#[cfg(feature = "greedy_lookup_preload")]
 use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::marker::Sync;
@@ -482,6 +483,7 @@ impl Azks {
         Ok((current_node, is_new, num_inserted))
     }
 
+    #[cfg(feature = "greedy_lookup_preload")]
     async fn get_next_node_in_child_path_from_cache<S: Database + Send + Sync>(
         &self,
         storage: &StorageManager<S>,
@@ -527,6 +529,7 @@ impl Azks {
     /// leaf node. This will be grossly over-estimating the true size of the
     /// tree and the number of nodes required to be fetched, however
     /// it allows a single batch-get call in necessary scenarios
+    #[cfg(feature = "greedy_lookup_preload")]
     pub(crate) async fn build_lookup_maximal_node_set<S: Database + Send + Sync>(
         &self,
         storage: &StorageManager<S>,
@@ -562,6 +565,7 @@ impl Azks {
     /// the direct path, and the children of resolved nodes on the path. This
     /// minimizes the number of batch_get operations to the storage layer which are
     /// called
+    #[cfg(feature = "greedy_lookup_preload")]
     pub(crate) async fn greedy_preload_lookup_nodes<S: Database + Send + Sync>(
         &self,
         storage: &StorageManager<S>,
@@ -1169,6 +1173,7 @@ mod tests {
     use std::time::Duration;
 
     #[tokio::test]
+    #[cfg(feature = "greedy_lookup_preload")]
     async fn test_maximal_node_set_resolution() {
         let mut rng = StdRng::seed_from_u64(42);
         let database = AsyncInMemoryDatabase::new();

--- a/akd/src/helper_structs.rs
+++ b/akd/src/helper_structs.rs
@@ -26,7 +26,7 @@ impl EpochHash {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 /// Info needed for a lookup of a user for an epoch
 pub struct LookupInfo {
     pub(crate) value_state: ValueState,

--- a/akd/src/storage/manager/tests.rs
+++ b/akd/src/storage/manager/tests.rs
@@ -26,7 +26,6 @@ async fn test_storage_manager_transaction() {
     );
 
     let mut records = (0..10)
-        .into_iter()
         .map(|i| {
             let label = NodeLabel {
                 label_len: i,
@@ -121,7 +120,6 @@ async fn test_storage_manager_cache_populated_by_batch_set() {
     let storage_manager = StorageManager::new(db, None, None, None);
 
     let mut records = (0..10)
-        .into_iter()
         .map(|i| {
             let label = NodeLabel {
                 label_len: i,
@@ -203,7 +201,6 @@ async fn test_storage_manager_cache_populated_by_batch_get() {
 
     let mut keys = vec![];
     let mut records = (0..10)
-        .into_iter()
         .map(|i| {
             let label = NodeLabel {
                 label_len: i,

--- a/akd/src/tree_node.rs
+++ b/akd/src/tree_node.rs
@@ -198,8 +198,11 @@ impl TreeNodeWithPreviousValue {
         let mut nodes = Vec::<TreeNode>::new();
         for node in node_records.into_iter() {
             if let DbRecord::TreeNode(node) = node {
-                let correct_node = node.determine_node_to_get(target_epoch)?;
-                nodes.push(correct_node);
+                // Since this is a batch-get, we should ignore node's not-found and just not add them
+                // to the result-set
+                if let Ok(correct_node) = node.determine_node_to_get(target_epoch) {
+                    nodes.push(correct_node);
+                }
             } else {
                 return Err(StorageError::NotFound(
                     "Batch retrieve returned types <> TreeNodeWithPreviousValue".to_string(),

--- a/akd/src/tree_node.rs
+++ b/akd/src/tree_node.rs
@@ -136,7 +136,10 @@ impl TreeNodeWithPreviousValue {
     /// Determine which of the previous + latest nodes to retrieve based on the
     /// target epoch. If it should be older than the latest node, and there is no
     /// previous node, it returns Not Found
-    fn determine_node_to_get(&self, target_epoch: u64) -> Result<TreeNode, StorageError> {
+    pub(crate) fn determine_node_to_get(
+        &self,
+        target_epoch: u64,
+    ) -> Result<TreeNode, StorageError> {
         // If a publish is currently underway, and "some" nodes have been updated to future values
         // our "target_epoch" may point to some older data. Therefore we may need to load a previous
         // version of this node.

--- a/akd_client/Cargo.toml
+++ b/akd_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_client"
-version = "0.8.8"
+version = "0.8.9"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Client verification companion for the auditable key directory with limited dependencies."
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 ## Required dependencies ##
-akd_core = { path = "../akd_core", version = "0.8.7", default-features = false, features = ["vrf"] }
+akd_core = { path = "../akd_core", version = "0.8.9", default-features = false, features = ["vrf"] }
 hex = "0.4"
 
 ## Optional dependencies ##

--- a/akd_core/Cargo.toml
+++ b/akd_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_core"
-version = "0.8.8"
+version = "0.8.9"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Core utilities for the auditable-key-directory suite of crates (akd and akd_client)"
 license = "MIT OR Apache-2.0"

--- a/akd_core/src/types/node_label/mod.rs
+++ b/akd_core/src/types/node_label/mod.rs
@@ -99,9 +99,7 @@ impl NodeLabel {
         if self.label_len > other.label_len {
             return false;
         }
-        (0..self.label_len)
-            .into_iter()
-            .all(|i| self.get_bit_at(i) == other.get_bit_at(i))
+        (0..self.label_len).all(|i| self.get_bit_at(i) == other.get_bit_at(i))
     }
 
     /// Takes as input a pointer to the caller and another [NodeLabel],

--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_mysql"
-version = "0.8.8"
+version = "0.8.9"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "A MySQL storage layer implementation for an auditable key directory (AKD)"
 license = "MIT OR Apache-2.0"
@@ -25,9 +25,9 @@ async-recursion = "0.3"
 mysql_async = "0.31"
 mysql_common = "0.29.1"
 log = { version = "0.4.8", features = ["kv_unstable"] }
-akd = { path = "../akd", version = "0.8.7", features = ["serde_serialization"], default-features = false }
+akd = { path = "../akd", version = "0.8.9", features = ["serde_serialization"], default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"
 serial_test = "0.5"
-akd = { path = "../akd", version = "0.8.7", features = ["blake3", "public-tests"], default-features = false }
+akd = { path = "../akd", version = "0.8.9", features = ["blake3", "public-tests"], default-features = false }

--- a/akd_mysql/src/mysql_storables.rs
+++ b/akd_mysql/src/mysql_storables.rs
@@ -369,7 +369,6 @@ impl MySqlStorable for DbRecord {
                     (format!("data{idx}"), Value::from(state.value.0.clone())),
                 ]),
             })
-            .into_iter()
             .collect::<Result<Vec<_>>>()?
             .into_iter()
             .flatten()
@@ -549,7 +548,7 @@ impl MySqlStorable for DbRecord {
                 let pvec = keys
                     .iter()
                     .enumerate()
-                    .map(|(idx, key)| {
+                    .flat_map(|(idx, key)| {
                         let bin = St::get_full_binary_key_id(key);
                         // Since these are constructed from a safe key, they should never fail
                         // so we'll leave the unwrap to simplify
@@ -560,8 +559,6 @@ impl MySqlStorable for DbRecord {
                             (format!("label_val{idx}"), Value::from(back.0.label_val)),
                         ]
                     })
-                    .into_iter()
-                    .flatten()
                     .collect::<Vec<_>>();
                 Some(mysql_async::Params::from(pvec))
             }
@@ -569,7 +566,7 @@ impl MySqlStorable for DbRecord {
                 let pvec = keys
                     .iter()
                     .enumerate()
-                    .map(|(idx, key)| {
+                    .flat_map(|(idx, key)| {
                         let bin = St::get_full_binary_key_id(key);
                         // Since these are constructed from a safe key, they should never fail
                         // so we'll leave the unwrap to simplify
@@ -580,8 +577,6 @@ impl MySqlStorable for DbRecord {
                             (format!("epoch{idx}"), Value::from(back.1)),
                         ]
                     })
-                    .into_iter()
-                    .flatten()
                     .collect::<Vec<_>>();
                 Some(mysql_async::Params::from(pvec))
             }

--- a/akd_test_tools/Cargo.toml
+++ b/akd_test_tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_test_tools"
-version = "0.8.8"
+version = "0.8.9"
 authors = ["Evan Au <evanau@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Test utilities and tooling"
 license = "MIT OR Apache-2.0"
@@ -22,9 +22,9 @@ serde = "1.0"
 async-trait = "0.1"
 thread-id = "3"
 
-akd = { path = "../akd", features = ["serde_serialization"], version = "0.8.8" }
+akd = { path = "../akd", features = ["serde_serialization"], version = "0.8.9" }
 
 [dev-dependencies]
 assert_fs="1"
 
-akd = { path = "../akd", features = ["public-tests", "rand", "serde_serialization"], version = "0.8.8" }
+akd = { path = "../akd", features = ["public-tests", "rand", "serde_serialization"], version = "0.8.9" }

--- a/integration_tests/src/mysql_tests.rs
+++ b/integration_tests/src/mysql_tests.rs
@@ -175,6 +175,7 @@ async fn test_lookups() {
 
         let vrf = HardCodedAkdVRF {};
         let storage_manager = StorageManager::new(mysql_db, None, None, None);
+
         crate::test_util::test_lookups::<_, HardCodedAkdVRF>(&storage_manager, &vrf, 50, 5, 100)
             .await;
 

--- a/integration_tests/src/test_util.rs
+++ b/integration_tests/src/test_util.rs
@@ -174,7 +174,7 @@ pub(crate) async fn test_lookups<S: Database + 'static, V: VRFKeyStorage>(
                 labels.push(label);
             }
 
-            println!("Metrics after publish(es).");
+            log::warn!("Metrics after publish(es).");
             reset_mysql_db::<S>(mysql_db).await;
 
             let start = Instant::now();
@@ -195,13 +195,13 @@ pub(crate) async fn test_lookups<S: Database + 'static, V: VRFKeyStorage>(
                     }
                 }
             }
-            println!(
+            log::warn!(
                 "Individual {} lookups took {}ms.",
                 num_lookups,
                 start.elapsed().as_millis()
             );
 
-            println!("Metrics after individual lookups:");
+            log::warn!("Metrics after individual lookups:");
             reset_mysql_db::<S>(mysql_db).await;
 
             let start = Instant::now();
@@ -226,13 +226,13 @@ pub(crate) async fn test_lookups<S: Database + 'static, V: VRFKeyStorage>(
                     }
                 }
             }
-            println!(
+            log::warn!(
                 "Bulk {} lookups took {}ms.",
                 num_lookups,
                 start.elapsed().as_millis()
             );
 
-            println!("Metrics after lookup proofs: ");
+            log::warn!("Metrics after lookup proofs: ");
             reset_mysql_db::<S>(mysql_db).await;
         }
     }
@@ -242,6 +242,6 @@ pub(crate) async fn test_lookups<S: Database + 'static, V: VRFKeyStorage>(
 // These allow us to accurately assess the additional efficiency of
 // bulk lookup proofs.
 async fn reset_mysql_db<S: Database>(mysql_db: &StorageManager<S>) {
-    mysql_db.log_metrics(Level::Trace).await;
+    mysql_db.log_metrics(Level::Warn).await;
     mysql_db.flush_cache().await;
 }


### PR DESCRIPTION
In the case of a lookup proof, generally we're normally doing up to `N = depth(Merkle Tree)` requests to preload the nodes for the proof. However this is still like 30+ queries on moderately sized trees (e.g. ~2B nodes)

In this PR, we introduce an optional optimization which will build all 256 labels which could be on the path from the root node to the intended leaf and try a single batch-get with all of them.

A lookup proof's `LookupInfo` needs 3 target labels to retrieve, so we're actually doing 3 * 256 node retrievals, but in a single query which is still often more optimal due to DB round-trip accesses than 32 targeted node requests.

After the first direct-path load for the 3 necessary targets, we then do a second batch-get of all of those node's children (which will only load the found node's children that aren't already in-cache) which gives us all of the sibling nodes to generate the necessary proof.

Additionally this PR fixed a bug in batch-loading tree nodes, where instead of just not adding not-found results to the result set, it was crashing the batch-get with a `TreeNode not found` error. Our normal batch-get operations don't error on not-found results, so this was causing some flows to fail (incl a local test, which I'm surprised slipped through).

Lastly a small optimization as well, where in bulk lookup proofs, we were preloading multiple times. Once in the batch-operation, and then again for each individual proof which is just wasted cycles since it should all be cached anyways. This removed the second loop of preloads by passing a flag to the internal operation to skip the internal preload.