### PR TITLE
Change access mode parameter from bool to custom AccessMode enum

### DIFF
--- a/akd/benches/directory.rs
+++ b/akd/benches/directory.rs
@@ -11,7 +11,7 @@ extern crate criterion;
 use akd::ecvrf::HardCodedAkdVRF;
 use akd::storage::manager::StorageManager;
 use akd::storage::memory::AsyncInMemoryDatabase;
-use akd::{AkdLabel, AkdValue, Directory};
+use akd::{AkdLabel, AkdValue, Directory, AccessMode};
 use criterion::{BatchSize, Criterion};
 use rand::distributions::Alphanumeric;
 use rand::rngs::StdRng;
@@ -49,7 +49,7 @@ fn history_generation(c: &mut Criterion) {
                 );
                 let db_clone = db.clone();
                 let directory = runtime
-                    .block_on(async move { Directory::new(db, vrf, false).await })
+                    .block_on(async move { Directory::new(db, vrf, AccessMode::Writeable).await })
                     .unwrap();
 
                 for _epoch in 1..num_updates {

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -27,6 +27,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 // An enum that represents whether an auditable key directory is read-only or writeable
+#[derive(PartialEq)]
 pub enum AccessMode{
     ReadOnly,
     Writeable

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 // An enum that represents whether an auditable key directory is read-only or writeable
-#[derive(PartialEq)]
+#[derive(PartialEq, Copy)]
 pub enum AccessMode{
     ReadOnly,
     Writeable

--- a/akd/src/lib.rs
+++ b/akd/src/lib.rs
@@ -46,19 +46,19 @@
 //! [`storage::memory::AsyncInMemoryDatabase`] as in-memory storage, and [`ecvrf::HardCodedAkdVRF`] as the VRF.
 //! The [`Directory::new`] function also takes as input a third parameter indicating whether or not it is "read-only".
 //! Note that a read-only directory cannot be updated, and so we most likely will want to keep this variable set
-//! as `false`.
+//! as `Writeable`.
 //! ```
 //! use akd::storage::StorageManager;
 //! use akd::storage::memory::AsyncInMemoryDatabase;
 //! use akd::ecvrf::HardCodedAkdVRF;
-//! use akd::directory::Directory;
+//! use akd::directory::{Directory, AccessMode};
 //!
 //! let db = AsyncInMemoryDatabase::new();
 //! let storage_manager = StorageManager::new_no_cache(db);
 //! let vrf = HardCodedAkdVRF{};
 //!
 //! # tokio_test::block_on(async {
-//! let mut akd = Directory::<_, _>::new(storage_manager, vrf, false)
+//! let mut akd = Directory::<_, _>::new(storage_manager, vrf, AccessMode::Writeable)
 //!     .await
 //!     .expect("Could not create a new directory");
 //! # });
@@ -90,7 +90,7 @@
 //!
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, false).await.unwrap();
+//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, AccessMode::Writeable).await.unwrap();
 //! let EpochHash(epoch, root_hash) = akd.publish(entries)
 //!     .await.expect("Error with publishing");
 //! println!("Published epoch {} with root hash: {}", epoch, hex::encode(root_hash));
@@ -124,7 +124,7 @@
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, false).await.unwrap();
+//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, AccessMode::Writeable).await.unwrap();
 //! #     let EpochHash(epoch, root_hash) = akd.publish(entries)
 //! #         .await.expect("Error with publishing");
 //! let (lookup_proof, _) = akd.lookup(
@@ -157,7 +157,7 @@
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, false).await.unwrap();
+//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, AccessMode::Writeable).await.unwrap();
 //! #     let _ = akd.publish(entries)
 //! #         .await.expect("Error with publishing");
 //! #     let (lookup_proof, epoch_hash) = akd.lookup(
@@ -211,7 +211,7 @@
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, false).await.unwrap();
+//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, AccessMode::Writeable).await.unwrap();
 //! #     let EpochHash(epoch, root_hash) = akd.publish(entries)
 //! #         .await.expect("Error with publishing");
 //! use akd::HistoryParams;
@@ -252,7 +252,7 @@
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, false).await.unwrap();
+//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, AccessMode::Writeable).await.unwrap();
 //! #     let _ = akd.publish(entries)
 //! #         .await.expect("Error with publishing");
 //! #     let _ = akd.publish(
@@ -315,7 +315,7 @@
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, false).await.unwrap();
+//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, AccessMode::Writeable).await.unwrap();
 //! #     let EpochHash(epoch, root_hash) = akd.publish(entries)
 //! #         .await.expect("Error with publishing");
 //! // Publish new entries into a second epoch
@@ -354,7 +354,7 @@
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, false).await.unwrap();
+//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, AccessMode::Writeable).await.unwrap();
 //! #     let EpochHash(epoch, root_hash) = akd.publish(entries)
 //! #         .await.expect("Error with publishing");
 //! #     // Publish new entries into a second epoch

--- a/akd/src/lib.rs
+++ b/akd/src/lib.rs
@@ -430,7 +430,7 @@ mod utils;
 // ========== Type re-exports which are commonly used ========== //
 pub use append_only_zks::Azks;
 pub use client::HistoryVerificationParams;
-pub use directory::{Directory, HistoryParams};
+pub use directory::{Directory, HistoryParams, AccessMode};
 pub use helper_structs::EpochHash;
 
 // ========== Constants and type aliases ========== //


### PR DESCRIPTION
a common design pattern in rust is to replace boolean config parameters with named enums so that the intent of the configuration is clear at the call site.

previous api:
```
//writeable, can't tell what the bool means from code
Directory::new(db, vrf, false);

//read-only, same problem
Directory::new(db, vrf, true);
```
new api:
```
//intent now clear from code
Directory::new(db, vrf, AccessMode::Writeable);
Directory::new(db, vrf, AccessMode::ReadOnly);
```

this type is also re-exported in lib.rs, and can be `use`d if the user doesn't feel like typing the whole scoping prefix.