### PR TITLE
Add a Newtype Representative of a Read-only Directory

### DIFF
--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd"
-version = "0.8.9"
+version = "0.9.0"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "An implementation of an auditable key directory"
 license = "MIT OR Apache-2.0"
@@ -40,7 +40,7 @@ default = ["blake3", "public_auditing", "parallel_vrf", "parallel_insert", "prel
 
 [dependencies]
 ## Required dependencies ##
-akd_core = { path = "../akd_core", version = "0.8.9", default-features = false, features = ["vrf"] }
+akd_core = { path = "../akd_core", version = "0.9.0", default-features = false, features = ["vrf"] }
 async-recursion = "0.3"
 async-trait = "0.1"
 curve25519-dalek = "3"

--- a/akd/benches/directory.rs
+++ b/akd/benches/directory.rs
@@ -49,7 +49,7 @@ fn history_generation(c: &mut Criterion) {
                 );
                 let db_clone = db.clone();
                 let directory = runtime
-                    .block_on(async move { Directory::new(db, vrf, false).await })
+                    .block_on(async move { Directory::new(db, vrf).await })
                     .unwrap();
 
                 for _epoch in 1..num_updates {

--- a/akd/src/lib.rs
+++ b/akd/src/lib.rs
@@ -44,9 +44,7 @@
 //! A [`Directory`] represents an AKD. To set up a [`Directory`], we first need to pick on
 //! a database, a hash function, and a VRF. For this example, we use Blake3 as the hash function,
 //! [`storage::memory::AsyncInMemoryDatabase`] as in-memory storage, and [`ecvrf::HardCodedAkdVRF`] as the VRF.
-//! The [`Directory::new`] function also takes as input a third parameter indicating whether or not it is "read-only".
-//! Note that a read-only directory cannot be updated, and so we most likely will want to keep this variable set
-//! as `false`.
+//! The [`directory::ReadOnlyDirectory`] creates a read-only directory which cannot be updated.
 //! ```
 //! use akd::storage::StorageManager;
 //! use akd::storage::memory::AsyncInMemoryDatabase;
@@ -58,7 +56,7 @@
 //! let vrf = HardCodedAkdVRF{};
 //!
 //! # tokio_test::block_on(async {
-//! let mut akd = Directory::<_, _>::new(storage_manager, vrf, false)
+//! let mut akd = Directory::<_, _>::new(storage_manager, vrf)
 //!     .await
 //!     .expect("Could not create a new directory");
 //! # });
@@ -90,7 +88,7 @@
 //!
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, false).await.unwrap();
+//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf).await.unwrap();
 //! let EpochHash(epoch, root_hash) = akd.publish(entries)
 //!     .await.expect("Error with publishing");
 //! println!("Published epoch {} with root hash: {}", epoch, hex::encode(root_hash));
@@ -124,7 +122,7 @@
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, false).await.unwrap();
+//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf).await.unwrap();
 //! #     let EpochHash(epoch, root_hash) = akd.publish(entries)
 //! #         .await.expect("Error with publishing");
 //! let (lookup_proof, _) = akd.lookup(
@@ -157,7 +155,7 @@
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, false).await.unwrap();
+//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf).await.unwrap();
 //! #     let _ = akd.publish(entries)
 //! #         .await.expect("Error with publishing");
 //! #     let (lookup_proof, epoch_hash) = akd.lookup(
@@ -211,7 +209,7 @@
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, false).await.unwrap();
+//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf).await.unwrap();
 //! #     let EpochHash(epoch, root_hash) = akd.publish(entries)
 //! #         .await.expect("Error with publishing");
 //! use akd::HistoryParams;
@@ -252,7 +250,7 @@
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, false).await.unwrap();
+//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf).await.unwrap();
 //! #     let _ = akd.publish(entries)
 //! #         .await.expect("Error with publishing");
 //! #     let _ = akd.publish(
@@ -315,7 +313,7 @@
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, false).await.unwrap();
+//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf).await.unwrap();
 //! #     let EpochHash(epoch, root_hash) = akd.publish(entries)
 //! #         .await.expect("Error with publishing");
 //! // Publish new entries into a second epoch
@@ -354,7 +352,7 @@
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf, false).await.unwrap();
+//! #     let mut akd = Directory::<_, _>::new(storage_manager, vrf).await.unwrap();
 //! #     let EpochHash(epoch, root_hash) = akd.publish(entries)
 //! #         .await.expect("Error with publishing");
 //! #     // Publish new entries into a second epoch

--- a/akd_client/Cargo.toml
+++ b/akd_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_client"
-version = "0.8.9"
+version = "0.9.0"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Client verification companion for the auditable key directory with limited dependencies."
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 ## Required dependencies ##
-akd_core = { path = "../akd_core", version = "0.8.9", default-features = false, features = ["vrf"] }
+akd_core = { path = "../akd_core", version = "0.9.0", default-features = false, features = ["vrf"] }
 hex = "0.4"
 
 ## Optional dependencies ##

--- a/akd_client/src/wasm.rs
+++ b/akd_client/src/wasm.rs
@@ -155,7 +155,7 @@ pub mod tests {
         let db = AsyncInMemoryDatabase::new();
         let storage = StorageManager::new_no_cache(db);
         let vrf = HardCodedAkdVRF {};
-        let akd = Directory::<_, _>::new(storage, vrf, false)
+        let akd = Directory::<_, _>::new(storage, vrf)
             .await
             .expect("Failed to construct directory");
 

--- a/akd_core/Cargo.toml
+++ b/akd_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_core"
-version = "0.8.9"
+version = "0.9.0"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Core utilities for the auditable-key-directory suite of crates (akd and akd_client)"
 license = "MIT OR Apache-2.0"

--- a/akd_local_auditor/src/auditor/mod.rs
+++ b/akd_local_auditor/src/auditor/mod.rs
@@ -87,7 +87,7 @@ pub enum AuditCommand {
     Ui,
 }
 
-/// Audit opertions supported by the client
+/// Audit operations supported by the client
 #[derive(Parser, Clone, Debug)]
 pub struct AuditArgs {
     #[clap(subcommand)]

--- a/akd_local_auditor/src/common_test.rs
+++ b/akd_local_auditor/src/common_test.rs
@@ -63,7 +63,7 @@ pub async fn generate_audit_proofs(
     let db = AsyncInMemoryDatabase::new();
     let storage_manager = StorageManager::new_no_cache(db);
     let vrf = HardCodedAkdVRF {};
-    let akd = Directory::<_, _>::new(storage_manager, vrf, false).await?;
+    let akd = Directory::<_, _>::new(storage_manager, vrf).await?;
     let mut proofs = vec![];
     // gather the hash + azks for epoch "0" (init)
     let mut azks = akd.retrieve_current_azks().await?;

--- a/akd_local_auditor/src/main.rs
+++ b/akd_local_auditor/src/main.rs
@@ -18,7 +18,7 @@
 //! 1. AWS DynamoDB index backed by S3 storage
 //! 2. AWS S3 only, without an index
 //!
-//! The applicate is started with all necessary flags to connect to the storage medium
+//! The application is started with all necessary flags to connect to the storage medium
 //! of choice, and then the REPL will start allowing the user to interact as an auditor.
 //!
 //! # Examples

--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_mysql"
-version = "0.8.9"
+version = "0.9.0"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "A MySQL storage layer implementation for an auditable key directory (AKD)"
 license = "MIT OR Apache-2.0"
@@ -25,9 +25,9 @@ async-recursion = "0.3"
 mysql_async = "0.31"
 mysql_common = "0.29.1"
 log = { version = "0.4.8", features = ["kv_unstable"] }
-akd = { path = "../akd", version = "0.8.9", features = ["serde_serialization"], default-features = false }
+akd = { path = "../akd", version = "0.9.0", features = ["serde_serialization"], default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"
 serial_test = "0.5"
-akd = { path = "../akd", version = "0.8.9", features = ["blake3", "public-tests"], default-features = false }
+akd = { path = "../akd", version = "0.9.0", features = ["blake3", "public-tests"], default-features = false }

--- a/akd_test_tools/Cargo.toml
+++ b/akd_test_tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_test_tools"
-version = "0.8.9"
+version = "0.9.0"
 authors = ["Evan Au <evanau@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Test utilities and tooling"
 license = "MIT OR Apache-2.0"
@@ -22,9 +22,9 @@ serde = "1.0"
 async-trait = "0.1"
 thread-id = "3"
 
-akd = { path = "../akd", features = ["serde_serialization"], version = "0.8.9" }
+akd = { path = "../akd", features = ["serde_serialization"], version = "0.9.0" }
 
 [dev-dependencies]
 assert_fs="1"
 
-akd = { path = "../akd", features = ["public-tests", "rand", "serde_serialization"], version = "0.8.9" }
+akd = { path = "../akd", features = ["public-tests", "rand", "serde_serialization"], version = "0.9.0" }

--- a/akd_test_tools/src/fixture_generator/examples/example_tests.rs
+++ b/akd_test_tools/src/fixture_generator/examples/example_tests.rs
@@ -36,7 +36,7 @@ async fn test_use_fixture() {
         .unwrap();
     let vrf = HardCodedAkdVRF {};
     let storage_manager = StorageManager::new_no_cache(db);
-    let akd = Directory::<_, _>::new(storage_manager.clone(), vrf, false)
+    let akd = Directory::<_, _>::new(storage_manager.clone(), vrf)
         .await
         .unwrap();
 

--- a/akd_test_tools/src/fixture_generator/generator.rs
+++ b/akd_test_tools/src/fixture_generator/generator.rs
@@ -124,7 +124,7 @@ pub(crate) async fn generate(args: Args) {
     let db = akd::storage::memory::AsyncInMemoryDatabase::new();
     let vrf = akd::ecvrf::HardCodedAkdVRF {};
     let storage_manager = StorageManager::new_no_cache(db);
-    let akd = Directory::<_, _>::new(storage_manager.clone(), vrf, false)
+    let akd = Directory::<_, _>::new(storage_manager.clone(), vrf)
         .await
         .unwrap();
 

--- a/akd_test_tools/src/test_suites.rs
+++ b/akd_test_tools/src/test_suites.rs
@@ -39,7 +39,7 @@ pub async fn directory_test_suite<S: Database + 'static, V: VRFKeyStorage>(
     }
     let mut root_hashes = vec![];
     // create & test the directory
-    let maybe_dir = Directory::<_, _>::new(mysql_db.clone(), vrf.clone(), false).await;
+    let maybe_dir = Directory::<_, _>::new(mysql_db.clone(), vrf.clone()).await;
     match maybe_dir {
         Err(akd_error) => panic!("Error initializing directory: {:?}", akd_error),
         Ok(dir) => {

--- a/integration_tests/src/test_util.rs
+++ b/integration_tests/src/test_util.rs
@@ -142,7 +142,7 @@ pub(crate) async fn test_lookups<S: Database + 'static, V: VRFKeyStorage>(
     }
 
     // create & test the directory
-    let maybe_dir = Directory::<_, _>::new(mysql_db.clone(), vrf.clone(), false).await;
+    let maybe_dir = Directory::<_, _>::new(mysql_db.clone(), vrf.clone()).await;
     match maybe_dir {
         Err(akd_error) => panic!("Error initializing directory: {:?}", akd_error),
         Ok(dir) => {

--- a/poc/src/main.rs
+++ b/poc/src/main.rs
@@ -80,7 +80,7 @@ struct Cli {
     #[clap(long = "memory", name = "Use in-memory database")]
     memory_db: bool,
 
-    /// Activate debuging mode
+    /// Activate debugging mode
     #[clap(long = "debug", short = 'd', name = "Enable debugging mode")]
     debug: bool,
 
@@ -140,9 +140,7 @@ async fn main() {
     if cli.memory_db {
         let db = akd::storage::memory::AsyncInMemoryDatabase::new();
         let storage_manager = StorageManager::new_no_cache(db);
-        let mut directory = Directory::<_, _>::new(storage_manager, vrf, false)
-            .await
-            .unwrap();
+        let mut directory = Directory::<_, _>::new(storage_manager, vrf).await.unwrap();
         if let Some(()) = pre_process_input(&cli, &tx, None).await {
             return;
         }
@@ -171,7 +169,7 @@ async fn main() {
             None,
             Some(Duration::from_secs(15)),
         );
-        let mut directory = Directory::<_, _>::new(storage_manager.clone(), vrf, false)
+        let mut directory = Directory::<_, _>::new(storage_manager.clone(), vrf)
             .await
             .unwrap();
         tokio::spawn(async move {


### PR DESCRIPTION
- Prior to this patch, we were reliant upon a boolean parameter passed to the associated `new` fn on the `Directory` type to indicate whether the instance it produced should be treated as a read-only entity. To more explicitly represent a `Directory` which should be treated as a read-only entity, this patch introduces a [newtype](https://doc.rust-lang.org/rust-by-example/generics/new_types.html) known as `ReadOnlyDirectory` which acts as a simple wrapper for a `Directory`.
- To avoid confusion around whether or not a directory has the ability to publish, the `ReadOnlyDirectory` and `Directory` types do not share any traits. Instead, the `ReadOnlyDirectory` tpye wraps a `Directory` instance and essenitally calls into the `Directory` for read-only operations. As such, we get compile time guarantees that a `publish` operation is never possible via a `ReadOnlyDirectory` since the method simply doesn't exist.