### PR TITLE
Rename public-tests Feature to public_tests

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -42,10 +42,10 @@ If you write a new storage layer for the AKD crate, you can run our standard sui
 
 ```toml
 [dev-dependencies]
-akd = { path = "../akd", version = "^0.5.0", features = ["public-tests", "serde"] }
+akd = { path = "../akd", version = "^0.5.0", features = ["public_tests", "serde"] }
 ```
 
-which will expose a common-testing pattern with the `public-tests` feature. The [`akd_mysql`](akd_mysql/src/mysql_db_tests.rs) crate does exactly this. You can simply run ths same test-suite for your new storage implementation that we run against all of them (and you'll benefit from downstream storage testing changes as well). Once you've setup your storage layer in your test case you simply invoke the suite
+which will expose a common-testing pattern with the `public_tests` feature. The [`akd_mysql`](akd_mysql/src/mysql_db_tests.rs) crate does exactly this. You can simply run ths same test-suite for your new storage implementation that we run against all of them (and you'll benefit from downstream storage testing changes as well). Once you've setup your storage layer in your test case you simply invoke the suite
 
 ```rust
 #[tokio::test]
@@ -136,7 +136,7 @@ cargo test
 is equivalent. Otherwise the full Rust suite of testing options with [Cargo Test](https://doc.rust-lang.org/cargo/commands/cargo-test.html) are available as well in this repo. Feel free to run the suite as you see fit. Another common adjustment done in this repository worth nothing is the used of specific features. For example, to test the `akd` crate with no verifiable random function (VRF) implementation, you can use the arguments
 
 ```bash
-cargo test --package akd --no-default-features --features public-tests
+cargo test --package akd --no-default-features --features public_tests
 ```
 
 which will disable the feature `vrf`, effectively running code paths tagged with

--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -18,8 +18,8 @@ sha3_256 = ["akd_core/sha3_256"]
 sha3_512 = ["akd_core/sha3_512"]
 blake3 = ["akd_core/blake3"]
 
-bench = ["blake3", "public-tests","tokio/rt-multi-thread"]
-public-tests = ["rand", "bincode", "colored", "once_cell", "serde_serialization", "akd_core/rand"]
+bench = ["blake3", "public_tests","tokio/rt-multi-thread"]
+public_tests = ["rand", "bincode", "colored", "once_cell", "serde_serialization", "akd_core/rand"]
 public_auditing = ["protobuf", "akd_core/protobuf"]
 serde_serialization = ["serde", "ed25519-dalek/serde", "akd_core/serde_serialization"]
 # Collect runtime metrics on db access calls + timing
@@ -73,7 +73,7 @@ futures = "0.3"
 itertools = "0.10"
 
 # To enable the public-test feature in tests
-akd = { path = ".", features = ["public-tests"], default-features = false }
+akd = { path = ".", features = ["public_tests"], default-features = false }
 
 [[bench]]
 name = "azks"

--- a/akd/src/errors.rs
+++ b/akd/src/errors.rs
@@ -255,7 +255,7 @@ impl From<akd_core::verify::VerificationError> for DirectoryError {
 }
 
 /// Represents a storage-layer error
-#[cfg_attr(any(test, feature = "public-tests"), derive(PartialEq, Eq))]
+#[cfg_attr(any(test, feature = "public_tests"), derive(PartialEq, Eq))]
 #[derive(Debug)]
 pub enum StorageError {
     /// Data wasn't found in the storage layer

--- a/akd/src/lib.rs
+++ b/akd/src/lib.rs
@@ -388,7 +388,7 @@
 //! in the event you wish to directly serialize the structures to transmit between library <-> storage layer or library <-> clients. If you're
 //! also utilizing VRFs (see (2.) below) it will additionally enable the _serde_ feature in the ed25519-dalek crate.
 //!
-//! 2. `public-tests`: Will expose some internal sanity testing functionality, which is often helpful so you don't have to write all your own
+//! 2. `public_tests`: Will expose some internal sanity testing functionality, which is often helpful so you don't have to write all your own
 //! unit test cases when implementing a storage layer yourself. This helps guarantee the sanity of a given storage implementation. Should be
 //! used only in unit testing scenarios by altering your Cargo.toml as such:
 //! ```toml
@@ -396,7 +396,7 @@
 //! akd = { version = "0.9.0-pre.1" }
 //!
 //! [dev-dependencies]
-//! akd = { version = "0.9.0-pre.1", features = ["public-tests"] }
+//! akd = { version = "0.9.0-pre.1", features = ["public_tests"] }
 //! ```
 //!
 
@@ -438,7 +438,7 @@ pub use directory::{Directory, HistoryParams};
 pub use helper_structs::EpochHash;
 
 // ========== Constants and type aliases ========== //
-#[cfg(any(test, feature = "public-tests"))]
+#[cfg(any(test, feature = "public_tests"))]
 pub mod test_utils;
 #[cfg(test)]
 mod tests;

--- a/akd/src/storage/manager/mod.rs
+++ b/akd/src/storage/manager/mod.rs
@@ -109,7 +109,7 @@ impl<Db: Database> StorageManager<Db> {
     }
 
     /// Retrieve a reference to the database implementation
-    #[cfg(any(test, feature = "public-tests"))]
+    #[cfg(any(test, feature = "public_tests"))]
     pub fn get_db(&self) -> Arc<Db> {
         self.db.clone()
     }

--- a/akd/src/storage/mod.rs
+++ b/akd/src/storage/mod.rs
@@ -30,7 +30,7 @@ pub mod memory;
 
 pub use manager::StorageManager;
 
-#[cfg(any(test, feature = "public-tests"))]
+#[cfg(any(test, feature = "public_tests"))]
 pub mod tests;
 
 /// Denotes the "state" when a batch_set is being called in the data layer

--- a/akd/src/tree_node.rs
+++ b/akd/src/tree_node.rs
@@ -163,7 +163,7 @@ impl TreeNodeWithPreviousValue {
     /// Construct a TreeNode with "previous" value where the
     /// previous value is None. This is useful for the first
     /// time a node appears in the directory data layer.
-    #[cfg(feature = "public-tests")]
+    #[cfg(feature = "public_tests")]
     pub(crate) fn from_tree_node(node: TreeNode) -> Self {
         Self {
             label: node.label,

--- a/akd/src/utils.rs
+++ b/akd/src/utils.rs
@@ -12,7 +12,7 @@
 // Creates a byte array of 32 bytes from a u64
 // Note that this representation is big-endian, and
 // places the bits to the front of the output byte_array.
-#[cfg(any(test, feature = "public-tests"))]
+#[cfg(any(test, feature = "public_tests"))]
 pub(crate) fn byte_arr_from_u64(input_int: u64) -> [u8; 32] {
     let mut output_arr = [0u8; 32];
     let input_arr = input_int.to_be_bytes();
@@ -21,7 +21,7 @@ pub(crate) fn byte_arr_from_u64(input_int: u64) -> [u8; 32] {
 }
 
 #[allow(unused)]
-#[cfg(any(test, feature = "public-tests"))]
+#[cfg(any(test, feature = "public_tests"))]
 pub(crate) fn random_label(rng: &mut impl rand::Rng) -> crate::NodeLabel {
     crate::NodeLabel {
         label_val: rng.gen::<[u8; 32]>(),

--- a/akd_local_auditor/Cargo.toml
+++ b/akd_local_auditor/Cargo.toml
@@ -34,7 +34,7 @@ thread-id = "3"
 tokio = { version = "1.21", features = ["full"] }
 tokio-stream = "0.1"
 
-akd = { path = "../akd", features = ["public-tests", "public_auditing"] }
+akd = { path = "../akd", features = ["public_tests", "public_auditing"] }
 
 [dev-dependencies]
 ctor = "0.1"

--- a/akd_mysql/Cargo.toml
+++ b/akd_mysql/Cargo.toml
@@ -30,4 +30,4 @@ akd = { path = "../akd", features = ["serde_serialization"], default-features = 
 [dev-dependencies]
 criterion = "0.3"
 serial_test = "0.5"
-akd = { path = "../akd", features = ["blake3", "public-tests"], default-features = false }
+akd = { path = "../akd", features = ["blake3", "public_tests"], default-features = false }

--- a/akd_test_tools/Cargo.toml
+++ b/akd_test_tools/Cargo.toml
@@ -27,4 +27,4 @@ akd = { path = "../akd", features = ["serde_serialization"] }
 [dev-dependencies]
 assert_fs="1"
 
-akd = { path = "../akd", features = ["public-tests", "rand", "serde_serialization"] }
+akd = { path = "../akd", features = ["public_tests", "rand", "serde_serialization"] }

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [features]
 
 [dependencies]
-akd = { path = "../akd", features = ["public-tests", "rand", "serde_serialization", "runtime_metrics"] }
+akd = { path = "../akd", features = ["public_tests", "rand", "serde_serialization", "runtime_metrics"] }
 
 [dev-dependencies]
 log = { version = "0.4.8", features = ["kv_unstable"] }

--- a/poc/Cargo.toml
+++ b/poc/Cargo.toml
@@ -17,7 +17,7 @@ thread-id = "3"
 multi_log = "0.1"
 clap = { version = "4", features = ["derive"] }
 
-akd = { path = "../akd", features = ["public-tests"] }
+akd = { path = "../akd", features = ["public_tests"] }
 akd_mysql = { path = "../akd_mysql" }
 
 [dev-dependencies]


### PR DESCRIPTION
- Simple change to rename the existing `public-tests` feature to `public_tests` to follow the naming convention of other features.
- Adds an entry to ignore .iml files in the .gitignore.