### PR TITLE
Adding lookup verify check for version number exceeding epoch

### DIFF
--- a/akd/src/lib.rs
+++ b/akd/src/lib.rs
@@ -183,6 +183,7 @@
 //! let lookup_result = akd::client::lookup_verify::<Config>(
 //!     public_key.as_bytes(),
 //!     epoch_hash.hash(),
+//!     epoch_hash.epoch(),
 //!     AkdLabel::from("first entry"),
 //!     lookup_proof,
 //! ).expect("Could not verify lookup proof");

--- a/akd_core/src/verify/history.rs
+++ b/akd_core/src/verify/history.rs
@@ -48,7 +48,7 @@ pub fn key_history_verify<TC: Configuration>(
     vrf_public_key: &[u8],
     root_hash: Digest,
     current_epoch: u64,
-    akd_key: AkdLabel,
+    akd_label: AkdLabel,
     proof: HistoryProof,
     params: HistoryVerificationParams,
 ) -> Result<Vec<VerifyResult>, VerificationError> {
@@ -60,7 +60,7 @@ pub fn key_history_verify<TC: Configuration>(
     // Make sure the update proofs are non-empty
     if num_proofs == 0 {
         return Err(VerificationError::HistoryProof(format!(
-            "No update proofs included in the proof of user {akd_key:?} at epoch {current_epoch:?}!"
+            "No update proofs included in the proof of user {akd_label:?} at epoch {current_epoch:?}!"
         )));
     }
 
@@ -102,7 +102,7 @@ pub fn key_history_verify<TC: Configuration>(
             root_hash,
             vrf_public_key,
             update_proof,
-            &akd_key,
+            &akd_label,
             params,
         )?;
         results.push(result);
@@ -118,14 +118,14 @@ pub fn key_history_verify<TC: Configuration>(
         verify_nonexistence::<TC>(
             vrf_public_key,
             root_hash,
-            &akd_key,
+            &akd_label,
             VersionFreshness::Fresh,
             version,
             &proof.until_marker_vrf_proofs[i],
             &proof.non_existence_until_marker_proofs[i],
         ).map_err(|_|
             VerificationError::HistoryProof(format!("Non-existence of next few proof of user {:?}'s version {:?} at epoch {:?} does not verify",
-                    &akd_key, version, current_epoch)))?;
+                    &akd_label, version, current_epoch)))?;
     }
 
     // Verify the VRFs and non-membership proofs for future markers
@@ -134,13 +134,13 @@ pub fn key_history_verify<TC: Configuration>(
         verify_nonexistence::<TC>(
             vrf_public_key,
             root_hash,
-            &akd_key,
+            &akd_label,
             VersionFreshness::Fresh,
             version,
             &proof.future_marker_vrf_proofs[i],
             &proof.non_existence_of_future_marker_proofs[i],
         ).map_err(|_|
-            VerificationError::HistoryProof(format!("Non-existence of future marker proof of user {akd_key:?}'s version {version:?} at epoch {current_epoch:?} does not verify")))?;
+            VerificationError::HistoryProof(format!("Non-existence of future marker proof of user {akd_label:?}'s version {version:?} at epoch {current_epoch:?} does not verify")))?;
     }
 
     Ok(results)

--- a/akd_core/src/verify/lookup.rs
+++ b/akd_core/src/verify/lookup.rs
@@ -18,9 +18,18 @@ use crate::{AkdLabel, LookupProof, VerifyResult, VersionFreshness};
 pub fn lookup_verify<TC: Configuration>(
     vrf_public_key: &[u8],
     root_hash: Digest,
+    current_epoch: u64,
     akd_label: AkdLabel,
     proof: LookupProof,
 ) -> Result<VerifyResult, VerificationError> {
+    if proof.version > current_epoch {
+        return Err(VerificationError::LookupProof(alloc::format!(
+            "Proof version {} is greater than current epoch {}",
+            proof.version,
+            current_epoch
+        )));
+    }
+
     verify_existence_with_val::<TC>(
         vrf_public_key,
         root_hash,

--- a/examples/src/mysql_demo/directory_host.rs
+++ b/examples/src/mysql_demo/directory_host.rs
@@ -98,6 +98,7 @@ where
                         let verification = akd::client::lookup_verify::<TC>(
                             vrf_pk.as_bytes(),
                             root_hash.hash(),
+                            root_hash.epoch(),
                             AkdLabel::from(&a),
                             proof,
                         );

--- a/examples/src/mysql_demo/tests/test_util.rs
+++ b/examples/src/mysql_demo/tests/test_util.rs
@@ -189,6 +189,7 @@ pub(crate) async fn test_lookups<TC: Configuration, S: Database + 'static, V: VR
                         if let Err(error) = akd::client::lookup_verify::<TC>(
                             vrf_pk.as_bytes(),
                             root_hash.hash(),
+                            root_hash.epoch(),
                             label,
                             proof,
                         ) {
@@ -220,6 +221,7 @@ pub(crate) async fn test_lookups<TC: Configuration, S: Database + 'static, V: VR
                         if let Err(error) = akd::client::lookup_verify::<TC>(
                             vrf_pk.as_bytes(),
                             root_hash.hash(),
+                            root_hash.epoch(),
                             label,
                             proof,
                         ) {
@@ -308,6 +310,7 @@ pub(crate) async fn directory_test_suite<
                         if let Err(error) = akd::client::lookup_verify::<TC>(
                             vrf_pk.as_bytes(),
                             root_hash.hash(),
+                            root_hash.epoch(),
                             key,
                             proof,
                         ) {

--- a/examples/src/wasm_client/mod.rs
+++ b/examples/src/wasm_client/mod.rs
@@ -93,6 +93,7 @@ impl LookupResult {
 fn fallible_lookup_verify<TC: Configuration>(
     vrf_public_key: &[u8],
     root_hash_ref: &[u8],
+    current_epoch: u64,
     akd_key: akd::AkdLabel,
     // protobuf encoded proof
     lookup_proof: &[u8],
@@ -104,6 +105,7 @@ fn fallible_lookup_verify<TC: Configuration>(
     akd_core::verify::lookup_verify::<TC>(
         vrf_public_key,
         root_hash,
+        current_epoch,
         akd_key,
         (&proto_proof).try_into()?,
     )
@@ -114,6 +116,7 @@ fn fallible_lookup_verify<TC: Configuration>(
 fn lookup_verify<TC: Configuration>(
     vrf_public_key: &[u8],
     root_hash_ref: &[u8],
+    current_epoch: u64,
     label: &[u8],
     // protobuf encoded proof
     lookup_proof: &[u8],
@@ -121,6 +124,7 @@ fn lookup_verify<TC: Configuration>(
     match fallible_lookup_verify::<TC>(
         vrf_public_key,
         root_hash_ref,
+        current_epoch,
         akd::AkdLabel(label.to_vec()),
         lookup_proof,
     ) {
@@ -142,6 +146,7 @@ fn lookup_verify<TC: Configuration>(
 pub fn lookup_verify_whatsapp_v1(
     vrf_public_key: &[u8],
     root_hash_ref: &[u8],
+    current_epoch: u64,
     label: &[u8],
     // protobuf encoded proof
     lookup_proof: &[u8],
@@ -149,6 +154,7 @@ pub fn lookup_verify_whatsapp_v1(
     lookup_verify::<akd_core::configuration::WhatsAppV1Configuration>(
         vrf_public_key,
         root_hash_ref,
+        current_epoch,
         label,
         lookup_proof,
     )
@@ -161,6 +167,7 @@ pub fn lookup_verify_whatsapp_v1(
 pub fn lookup_verify_experimental(
     vrf_public_key: &[u8],
     root_hash_ref: &[u8],
+    current_epoch: u64,
     label: &[u8],
     // protobuf encoded proof
     lookup_proof: &[u8],
@@ -168,6 +175,7 @@ pub fn lookup_verify_experimental(
     lookup_verify::<akd_core::configuration::ExperimentalConfiguration<akd_core::ExampleLabel>>(
         vrf_public_key,
         root_hash_ref,
+        current_epoch,
         label,
         lookup_proof,
     )
@@ -240,6 +248,7 @@ pub mod tests {
         let result = lookup_verify::<TC>(
             vrf_pk.as_bytes(),
             &root_hash.hash(),
+            root_hash.epoch(),
             &target_label,
             &encoded_proof_bytes,
         );


### PR DESCRIPTION
Closes https://github.com/facebook/akd/issues/391.

This check is necessary, since key history proofs only verify versions up until the current epoch, and so it is up to the corresponding lookup proof verifications to ensure that version numbers don't exceed the current epoch when returned.