### PR TITLE
Prepare for 0.9.0 release

### DIFF
--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd"
-version = "0.9.0-pre.1"
+version = "0.9.0"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "An implementation of an auditable key directory"
 license = "MIT OR Apache-2.0"
@@ -36,7 +36,7 @@ default = ["public_auditing", "parallel_vrf", "parallel_insert", "preload_histor
 
 [dependencies]
 ## Required dependencies ##
-akd_core = { path = "../akd_core", default-features = false, features = ["vrf"] }
+akd_core = { version = "0.9.0", path = "../akd_core", default-features = false, features = ["vrf"] }
 async-recursion = "1"
 async-trait = "0.1"
 dashmap = "5"

--- a/akd_core/Cargo.toml
+++ b/akd_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_core"
-version = "0.9.0-pre.1"
+version = "0.9.0"
 authors = ["Harjasleen Malvai <hmalvai@fb.com>", "Kevin Lewi <klewi@fb.com>", "Sean Lawlor <seanlawlor@fb.com>"]
 description = "Core utilities for the auditable-key-directory suite of crates (akd and akd_client)"
 license = "MIT OR Apache-2.0"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples"
-version = "0.9.0-pre.1"
+version = "0.0.0"
 authors = ["akd contributors"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
Prepares versions for 0.9.0 release. Also removes the version number on the examples crate since it's a non-published crate, it doesn't need to be versioned