### PR TITLE
Fixing clippy errors

### DIFF
--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -255,7 +255,7 @@ where
 
     /// Generate a lookup proof with the provided target information
     ///
-    /// * `current_azks`: The current [Akzs] element
+    /// * `current_azks`: The current [Azks] element
     /// * `lookup_info`: The information to target in the lookup request. Includes all
     /// necessary information to build the proof
     /// * `skip_preload`: Denotes if we should not preload as part of this optimization. Enabled

--- a/akd/src/lib.rs
+++ b/akd/src/lib.rs
@@ -477,10 +477,9 @@ pub mod tree_node;
 #[cfg(feature = "public_auditing")]
 pub mod local_auditing;
 
-pub use akd_core::configuration::*;
-pub use akd_core::hash::Digest;
-pub use akd_core::verify;
-pub use akd_core::*;
+pub use akd_core::{
+    configuration, configuration::*, ecvrf, hash, hash::Digest, proto, types::*, verify, ARITY,
+};
 
 #[macro_use]
 mod utils;


### PR DESCRIPTION
Clippy errors getting fixed by this commit:
```
error: private item shadows public glob re-export
Error:    --> akd/src/lib.rs:486:1
    |
486 | mod utils;
    | ^^^^^^^^^^
    |
note: the name `utils` in the type namespace is supposed to be publicly re-exported here
   --> akd/src/lib.rs:483:9
    |
483 | pub use akd_core::*;
    |         ^^^^^^^^^^^
note: but the private item here shadows it
   --> akd/src/lib.rs:486:1
    |
486 | mod utils;
    | ^^^^^^^^^^
    = note: `-D hidden-glob-reexports` implied by `-D warnings`
```