### PR TITLE
Reverting to codecov v3

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,6 +40,6 @@ jobs:
           
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           files: coverage/*.lcov


### PR DESCRIPTION
Seems like https://github.com/facebook/akd/pull/412 somehow is causing CI issues where v4 cannot be found. And I see on codecov that v4 is still in pre-release, so let's keep it at v3 for now...