### PR TITLE
Fixing publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
+        rust: [stable]
 
     steps:
     - uses: hecrj/setup-rust-action@v2


### PR DESCRIPTION
Seems like https://github.com/facebook/akd/pull/406 needed to also specify the rust toolchain in the workflow