### PR TITLE
Adding proof length check

### DIFF
--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -767,7 +767,7 @@ where
     }
 }
 
-/// A thin newtype which offers read-only interactivity with a [Directory](Directory).
+/// A thin newtype which offers read-only interactivity with a [Directory].
 #[derive(Clone)]
 pub struct ReadOnlyDirectory<TC, S, V>(Directory<TC, S, V>)
 where
@@ -781,9 +781,9 @@ where
     S: Database + 'static,
     V: VRFKeyStorage,
 {
-    /// Constructs a new instance of [ReadOnlyDirectory]. In the event that an [Azks](crate::append_only_zks::Azks)
+    /// Constructs a new instance of [ReadOnlyDirectory]. In the event that an [Azks]
     /// does not exist in the storage, or we're unable to retrieve it from storage, then
-    /// a [DirectoryError](crate::errors::DirectoryError) will be returned.
+    /// a [DirectoryError] will be returned.
     pub async fn new(storage: StorageManager<S>, vrf: V) -> Result<Self, AkdError> {
         let azks = Directory::<TC, S, V>::get_azks_from_storage(&storage, false).await;
 

--- a/akd_core/src/ecvrf/ecvrf_impl.rs
+++ b/akd_core/src/ecvrf/ecvrf_impl.rs
@@ -340,6 +340,11 @@ impl TryFrom<&[u8]> for Proof {
     type Error = VrfError;
 
     fn try_from(bytes: &[u8]) -> Result<Proof, VrfError> {
+        if bytes.len() != PROOF_LENGTH {
+            return Err(VrfError::Verification(format!(
+                "Invalid proof length, expected {PROOF_LENGTH} bytes"
+            )));
+        }
         let mut c_buf = [0u8; 32];
         c_buf[..16].copy_from_slice(&bytes[32..48]);
         let mut s_buf = [0u8; 32];

--- a/akd_core/src/ecvrf/tests.rs
+++ b/akd_core/src/ecvrf/tests.rs
@@ -18,7 +18,9 @@ use curve25519_dalek::{
     constants::ED25519_BASEPOINT_POINT, edwards::CompressedEdwardsY,
     scalar::Scalar as ed25519_Scalar,
 };
-use ed25519_dalek::{self, VerifyingKey as ed25519_PublicKey};
+use ed25519_dalek::{
+    self, VerifyingKey as ed25519_PublicKey, PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH,
+};
 #[cfg(feature = "serde_serialization")]
 use proptest::prelude::*;
 use proptest_derive::Arbitrary;
@@ -339,4 +341,22 @@ where
             KeyPair::<Priv, Pub>::generate_for_testing(&mut rng)
         })
         .no_shrink()
+}
+
+#[test]
+fn test_tryfrom_vrf_private_key() {
+    let bytes = [0u8; SECRET_KEY_LENGTH - 1];
+    assert!(VRFPrivateKey::try_from(&bytes[..]).is_err());
+}
+
+#[test]
+fn test_tryfrom_vrf_public_key() {
+    let bytes = [0u8; PUBLIC_KEY_LENGTH - 1];
+    assert!(VRFPublicKey::try_from(&bytes[..]).is_err());
+}
+
+#[test]
+fn test_tryfrom_vrf_proof() {
+    let bytes = [0u8; PROOF_LENGTH - 1];
+    assert!(Proof::try_from(&bytes[..]).is_err());
 }


### PR DESCRIPTION
Ensures that invalid-length VRF proofs will not cause a panic