### PR TITLE
Extending limited history to properly check for the existence of past values

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Installation
 Add the following line to the dependencies of your `Cargo.toml`:
 
 ```
-akd = "0.11"
+akd = "0.12.0-pre.1"
 ```
 
 ### Minimum Supported Rust Version

--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd"
-version = "0.11.0"
+version = "0.12.0-pre.1"
 authors = ["akd contributors"]
 description = "An implementation of an auditable key directory"
 license = "MIT OR Apache-2.0"
@@ -51,7 +51,7 @@ default = [
 
 [dependencies]
 ## Required dependencies ##
-akd_core = { version = "0.11.0", path = "../akd_core", default-features = false, features = [
+akd_core = { version = "0.12.0-pre.1", path = "../akd_core", default-features = false, features = [
     "vrf",
 ] }
 async-recursion = "1"

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -1668,9 +1668,7 @@ mod tests {
             // Recursively traverse the tree and check that the sibling of each node is correct
             let root_node = TreeNode::get_from_storage(&db, &NodeKey(NodeLabel::root()), 1).await?;
             let mut nodes: Vec<TreeNode> = vec![root_node];
-            while !nodes.is_empty() {
-                let current_node = nodes.pop().unwrap();
-
+            while let Some(current_node) = nodes.pop() {
                 let left_child = current_node.get_child_node(&db, Direction::Left, 1).await?;
                 let right_child = current_node
                     .get_child_node(&db, Direction::Right, 1)

--- a/akd/src/directory.rs
+++ b/akd/src/directory.rs
@@ -16,11 +16,13 @@ use crate::storage::types::{DbRecord, ValueState, ValueStateRetrievalFlag};
 use crate::storage::Database;
 use crate::{
     AkdLabel, AkdValue, AppendOnlyProof, AzksElement, Digest, EpochHash, HistoryProof, LookupProof,
-    NonMembershipProof, UpdateProof,
+    MembershipProof, NonMembershipProof, UpdateProof,
 };
 
 use crate::VersionFreshness;
 use akd_core::configuration::Configuration;
+use akd_core::utils::get_marker_versions;
+use akd_core::verify::history::HistoryParams;
 use log::{error, info};
 use std::collections::{HashMap, HashSet};
 use std::marker::PhantomData;
@@ -462,15 +464,6 @@ where
         user_data = match params {
             HistoryParams::Complete => user_data,
             HistoryParams::MostRecent(n) => user_data.into_iter().take(n).collect::<Vec<_>>(),
-            HistoryParams::SinceEpoch(epoch) => {
-                user_data = user_data
-                    .into_iter()
-                    .filter(|val| val.epoch >= epoch)
-                    .collect::<Vec<_>>();
-                // Ordering should be maintained after filtering, but let's re-sort just in case
-                user_data.sort_by(|a, b| b.epoch.cmp(&a.epoch));
-                user_data
-            }
         };
 
         if user_data.is_empty() {
@@ -496,7 +489,8 @@ where
         }
 
         let mut update_proofs = Vec::<UpdateProof>::new();
-        let mut last_version = 0;
+        let mut start_version = user_data[0].version;
+        let mut end_version = 0;
         for user_state in user_data {
             // Ignore states in storage that are ahead of current directory epoch
             if user_state.epoch <= current_epoch {
@@ -504,53 +498,64 @@ where
                     .create_single_update_proof(akd_label, &user_state)
                     .await?;
                 update_proofs.push(proof);
-                last_version = if user_state.version > last_version {
+                start_version = if user_state.version < start_version {
                     user_state.version
                 } else {
-                    last_version
+                    start_version
+                };
+                end_version = if user_state.version > end_version {
+                    user_state.version
+                } else {
+                    end_version
                 };
             }
         }
-        let next_marker = get_marker_version(last_version) + 1;
-        let final_marker = get_marker_version(current_epoch);
 
-        let mut until_marker_vrf_proofs = Vec::<Vec<u8>>::new();
-        let mut non_existence_until_marker_proofs = Vec::<NonMembershipProof>::new();
+        if start_version == 0 {
+            return Err(AkdError::Directory(DirectoryError::InvalidVersion(
+                "Computed start version for the key history should be non-zero".to_string(),
+            )));
+        }
 
-        for ver in last_version + 1..(1 << next_marker) {
-            let label_for_ver = self
+        let (past_marker_versions, future_marker_versions) =
+            get_marker_versions(start_version, end_version, current_epoch);
+
+        let mut past_marker_vrf_proofs = Vec::<Vec<u8>>::new();
+        let mut existence_of_past_marker_proofs = Vec::<MembershipProof>::new();
+
+        for version in past_marker_versions {
+            let node_label = self
                 .vrf
-                .get_node_label::<TC>(akd_label, VersionFreshness::Fresh, ver)
+                .get_node_label::<TC>(akd_label, VersionFreshness::Fresh, version)
                 .await?;
-            let non_existence_of_ver = current_azks
-                .get_non_membership_proof::<TC, _>(&self.storage, label_for_ver)
+            let existence_vrf = self
+                .vrf
+                .get_label_proof::<TC>(akd_label, VersionFreshness::Fresh, version)
                 .await?;
-            non_existence_until_marker_proofs.push(non_existence_of_ver);
-            until_marker_vrf_proofs.push(
-                self.vrf
-                    .get_label_proof::<TC>(akd_label, VersionFreshness::Fresh, ver)
-                    .await?
-                    .to_bytes()
-                    .to_vec(),
+            past_marker_vrf_proofs.push(existence_vrf.to_bytes().to_vec());
+            existence_of_past_marker_proofs.push(
+                current_azks
+                    .get_membership_proof::<TC, _>(&self.storage, node_label)
+                    .await?,
             );
         }
 
         let mut future_marker_vrf_proofs = Vec::<Vec<u8>>::new();
         let mut non_existence_of_future_marker_proofs = Vec::<NonMembershipProof>::new();
 
-        for marker_power in next_marker..final_marker + 1 {
-            let ver = 1 << marker_power;
-            let label_for_ver = self
+        for version in future_marker_versions {
+            let node_label = self
                 .vrf
-                .get_node_label::<TC>(akd_label, VersionFreshness::Fresh, ver)
+                .get_node_label::<TC>(akd_label, VersionFreshness::Fresh, version)
                 .await?;
-            let non_existence_of_ver = current_azks
-                .get_non_membership_proof::<TC, _>(&self.storage, label_for_ver)
-                .await?;
-            non_existence_of_future_marker_proofs.push(non_existence_of_ver);
+            non_existence_of_future_marker_proofs.push(
+                current_azks
+                    .get_non_membership_proof::<TC, _>(&self.storage, node_label)
+                    .await?,
+            );
             future_marker_vrf_proofs.push(
                 self.vrf
-                    .get_label_proof::<TC>(akd_label, VersionFreshness::Fresh, ver)
+                    .get_label_proof::<TC>(akd_label, VersionFreshness::Fresh, version)
                     .await?
                     .to_bytes()
                     .to_vec(),
@@ -565,8 +570,8 @@ where
         Ok((
             HistoryProof {
                 update_proofs,
-                until_marker_vrf_proofs,
-                non_existence_until_marker_proofs,
+                past_marker_vrf_proofs,
+                existence_of_past_marker_proofs,
                 future_marker_vrf_proofs,
                 non_existence_of_future_marker_proofs,
             },
@@ -852,25 +857,6 @@ where
     /// Read-only access to [Directory::get_public_key](Directory::get_public_key).
     pub async fn get_public_key(&self) -> Result<VRFPublicKey, AkdError> {
         self.0.get_public_key().await
-    }
-}
-
-/// The parameters that dictate how much of the history proof to return to the consumer
-/// (either a complete history, or some limited form).
-#[derive(Copy, Clone)]
-pub enum HistoryParams {
-    /// Returns a complete history for a label
-    Complete,
-    /// Returns up to the most recent N updates for a label
-    MostRecent(usize),
-    /// Returns all updates since a specified epoch (inclusive)
-    SinceEpoch(u64),
-}
-
-impl Default for HistoryParams {
-    /// By default, we return a complete history
-    fn default() -> Self {
-        Self::Complete
     }
 }
 

--- a/akd/src/errors.rs
+++ b/akd/src/errors.rs
@@ -230,6 +230,8 @@ pub enum DirectoryError {
     ReadOnlyDirectory(String),
     /// Publish
     Publish(String),
+    /// Detected an invalid version
+    InvalidVersion(String),
 }
 
 impl std::error::Error for DirectoryError {}
@@ -248,6 +250,9 @@ impl fmt::Display for DirectoryError {
             }
             Self::Publish(inner_message) => {
                 write!(f, "Directory publish error: {inner_message}")
+            }
+            Self::InvalidVersion(inner_message) => {
+                write!(f, "Invalid version error: {inner_message}")
             }
         }
     }

--- a/akd/src/lib.rs
+++ b/akd/src/lib.rs
@@ -198,6 +198,7 @@
 //! ```
 //!
 //! ## History Proofs
+//!
 //! As mentioned above, the security is defined by consistent views of the value for a key at any epoch.
 //! To this end, a server running an AKD needs to provide a way to check the history of a key. Note that in this case,
 //! the server is trusted for validating that a particular client is authorized to run a history check on a particular key.
@@ -245,6 +246,18 @@
 //! with respect to the latest root hash and public key, as follows. This function
 //! returns a list of values that have been associated with the specified entry, in
 //! reverse chronological order.
+//!
+//! Note that the same argument for [`HistoryParams`] that was used to generate
+//! the key history proof must also be used to verify the proof. Otherwise, verification
+//! may fail.
+//!
+//! We also use [`HistoryVerificationParams`] as an argument to the verification function,
+//! allowing the consumer to specify whether or not a "tombstoned" value should be
+//! accepted in place of a valid value for the corresponding entry. This is useful
+//! in scenarios where the consumer wishes to verify that a particular entry exists,
+//! but does not care about the value associated with it. The default behavior is to
+//! not accept tombstoned values, but [`HistoryVerificationParams::AllowMissingValues`] can
+//! be specified to enable this behavior.
 //! ```
 //! # use akd::storage::StorageManager;
 //! # use akd::storage::memory::AsyncInMemoryDatabase;
@@ -257,7 +270,7 @@
 //! # let storage_manager = StorageManager::new_no_cache(db);
 //! # let vrf = HardCodedAkdVRF{};
 //! # use akd::EpochHash;
-//! # use akd::HistoryParams;
+//! # use akd::{HistoryParams, HistoryVerificationParams};
 //! # use akd::{AkdLabel, AkdValue};
 //! # use akd::Digest;
 //! #
@@ -287,7 +300,8 @@
 //!     epoch_hash.epoch(),
 //!     AkdLabel::from("first entry"),
 //!     history_proof,
-//!     akd::HistoryVerificationParams::default(),
+//!     HistoryParams::default(),
+//!     HistoryVerificationParams::default(),
 //! ).expect("Could not verify history");
 //!
 //! assert_eq!(
@@ -476,7 +490,8 @@ pub mod tree_node;
 pub mod local_auditing;
 
 pub use akd_core::{
-    configuration, configuration::*, ecvrf, hash, hash::Digest, proto, types::*, verify, ARITY,
+    configuration, configuration::*, ecvrf, hash, hash::Digest, proto, types::*, verify,
+    verify::history::HistoryParams, ARITY,
 };
 
 #[macro_use]
@@ -485,7 +500,7 @@ mod utils;
 // ========== Type re-exports which are commonly used ========== //
 pub use append_only_zks::Azks;
 pub use client::HistoryVerificationParams;
-pub use directory::{Directory, HistoryParams};
+pub use directory::Directory;
 pub use helper_structs::EpochHash;
 
 // ========== Constants and type aliases ========== //

--- a/akd_core/Cargo.toml
+++ b/akd_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_core"
-version = "0.11.0"
+version = "0.12.0-pre.1"
 authors = ["akd contributors"]
 description = "Core utilities for the akd crate"
 license = "MIT OR Apache-2.0"

--- a/akd_core/src/proto/mod.rs
+++ b/akd_core/src/proto/mod.rs
@@ -215,7 +215,7 @@ impl TryFrom<&specs::types::SiblingProof> for crate::SiblingProof {
         let label: crate::NodeLabel = input.label.as_ref().unwrap().try_into()?;
 
         // get the raw data & it's length, but at most crate::hash::DIGEST_BYTES bytes
-        let siblings = input.siblings.get(0);
+        let siblings = input.siblings.first();
         if siblings.is_none() {
             return Err(ConversionError::Deserialization(
                 "Required field siblings missing".to_string(),
@@ -459,9 +459,9 @@ impl From<&crate::HistoryProof> for specs::types::HistoryProof {
                 .iter()
                 .map(|proof| proof.into())
                 .collect::<Vec<_>>(),
-            until_marker_vrf_proofs: input.until_marker_vrf_proofs.to_vec(),
-            non_existence_until_marker_proofs: input
-                .non_existence_until_marker_proofs
+            past_marker_vrf_proofs: input.past_marker_vrf_proofs.to_vec(),
+            existence_of_past_marker_proofs: input
+                .existence_of_past_marker_proofs
                 .iter()
                 .map(|proof| proof.into())
                 .collect::<Vec<_>>(),
@@ -482,14 +482,14 @@ impl TryFrom<&specs::types::HistoryProof> for crate::HistoryProof {
     fn try_from(input: &specs::types::HistoryProof) -> Result<Self, Self::Error> {
         let update_proofs = convert_from_vector!(input.update_proofs, crate::UpdateProof);
 
-        let until_marker_vrf_proofs = input
-            .until_marker_vrf_proofs
+        let past_marker_vrf_proofs = input
+            .past_marker_vrf_proofs
             .iter()
             .map(|item| item.to_vec())
             .collect::<Vec<_>>();
-        let non_existence_until_marker_proofs = convert_from_vector!(
-            input.non_existence_until_marker_proofs,
-            crate::NonMembershipProof
+        let existence_of_past_marker_proofs = convert_from_vector!(
+            input.existence_of_past_marker_proofs,
+            crate::MembershipProof
         );
 
         let future_marker_vrf_proofs = input
@@ -504,8 +504,8 @@ impl TryFrom<&specs::types::HistoryProof> for crate::HistoryProof {
 
         Ok(Self {
             update_proofs,
-            until_marker_vrf_proofs,
-            non_existence_until_marker_proofs,
+            past_marker_vrf_proofs,
+            existence_of_past_marker_proofs,
             future_marker_vrf_proofs,
             non_existence_of_future_marker_proofs,
         })

--- a/akd_core/src/proto/specs/types.proto
+++ b/akd_core/src/proto/specs/types.proto
@@ -87,13 +87,13 @@ message UpdateProof {
     optional bytes commitment_nonce = 8;
 }
 
-/* This proof consists of an array of [`UpdateProof`]s, non-membership proofs for 
-the versions up until the next marker, and then non-membership proofs for future markers
+/* This proof consists of an array of [`UpdateProof`]s, membership proofs for
+the past markers, and non-membership proofs for future markers
 up until the current epoch. */
 message HistoryProof {
     repeated UpdateProof update_proofs = 1;
-    repeated bytes until_marker_vrf_proofs = 2;
-    repeated NonMembershipProof non_existence_until_marker_proofs = 3;
+    repeated bytes past_marker_vrf_proofs = 2;
+    repeated MembershipProof existence_of_past_marker_proofs = 3;
     repeated bytes future_marker_vrf_proofs = 4;
     repeated NonMembershipProof non_existence_of_future_marker_proofs = 5;
 }

--- a/akd_core/src/proto/tests.rs
+++ b/akd_core/src/proto/tests.rs
@@ -185,6 +185,18 @@ fn test_convert_update_proof() {
 
 #[test]
 fn test_convert_history_proof() {
+    fn membership_proof() -> crate::MembershipProof {
+        crate::MembershipProof {
+            label: random_label(),
+            hash_val: AzksValue(random_hash()),
+            sibling_proofs: vec![crate::SiblingProof {
+                label: random_label(),
+                siblings: [random_azks_element()],
+                direction: Direction::Right,
+            }],
+        }
+    }
+
     fn non_membership_proof() -> crate::NonMembershipProof {
         crate::NonMembershipProof {
             label: random_label(),
@@ -209,40 +221,24 @@ fn test_convert_history_proof() {
             value: crate::AkdValue(random_hash().to_vec()),
             version: rng.gen(),
             existence_vrf_proof: random_hash().to_vec(),
-            existence_proof: crate::MembershipProof {
-                label: random_label(),
-                hash_val: AzksValue(random_hash()),
-                sibling_proofs: vec![crate::SiblingProof {
-                    label: random_label(),
-                    siblings: [random_azks_element()],
-                    direction: Direction::Right,
-                }],
-            },
+            existence_proof: membership_proof(),
             previous_version_vrf_proof: Some(random_hash().to_vec()),
-            previous_version_proof: Some(crate::MembershipProof {
-                label: random_label(),
-                hash_val: AzksValue(random_hash()),
-                sibling_proofs: vec![crate::SiblingProof {
-                    label: random_label(),
-                    siblings: [random_azks_element()],
-                    direction: Direction::Right,
-                }],
-            }),
+            previous_version_proof: Some(membership_proof()),
             commitment_nonce: random_hash().to_vec(),
         }
     }
 
     let original = crate::HistoryProof {
         update_proofs: vec![upd_proof(), upd_proof(), upd_proof()],
-        until_marker_vrf_proofs: vec![
+        past_marker_vrf_proofs: vec![
             random_hash().to_vec(),
             random_hash().to_vec(),
             random_hash().to_vec(),
         ],
-        non_existence_until_marker_proofs: vec![
-            non_membership_proof(),
-            non_membership_proof(),
-            non_membership_proof(),
+        existence_of_past_marker_proofs: vec![
+            membership_proof(),
+            membership_proof(),
+            membership_proof(),
         ],
         future_marker_vrf_proofs: vec![
             random_hash().to_vec(),

--- a/akd_core/src/types/mod.rs
+++ b/akd_core/src/types/mod.rs
@@ -471,10 +471,10 @@ pub struct UpdateProof {
 pub struct HistoryProof {
     /// The update proofs in the key history
     pub update_proofs: Vec<UpdateProof>,
-    /// VRF Proofs for the labels of the values until the next marker version
-    pub until_marker_vrf_proofs: Vec<Vec<u8>>,
-    /// Proof that the values until the next marker version did not exist at this time
-    pub non_existence_until_marker_proofs: Vec<NonMembershipProof>,
+    /// VRF Proofs for the labels of the values for past markers
+    pub past_marker_vrf_proofs: Vec<Vec<u8>>,
+    /// Proof that the values for the past markers exist
+    pub existence_of_past_marker_proofs: Vec<MembershipProof>,
     /// VRF proofs for the labels of future marker entries
     pub future_marker_vrf_proofs: Vec<Vec<u8>>,
     /// Proof that future markers did not exist

--- a/akd_core/src/verify/history.rs
+++ b/akd_core/src/verify/history.rs
@@ -23,6 +23,23 @@ use alloc::string::ToString;
 #[cfg(feature = "nostd")]
 use alloc::vec::Vec;
 
+/// The parameters that dictate how much of the history proof for the server to
+/// return to the consumer (either a complete history, or some limited form).
+#[derive(Copy, Clone)]
+pub enum HistoryParams {
+    /// Returns a complete history for a label
+    Complete,
+    /// Returns up to the most recent N updates for a label
+    MostRecent(usize),
+}
+
+impl Default for HistoryParams {
+    /// By default, we return a complete history
+    fn default() -> Self {
+        Self::Complete
+    }
+}
+
 /// Parameters for customizing how history proof verification proceeds
 #[derive(Copy, Clone)]
 pub enum HistoryVerificationParams {
@@ -40,21 +57,12 @@ impl Default for HistoryVerificationParams {
     }
 }
 
-/// Verifies a key history proof, given the corresponding sequence of hashes.
-/// Returns a vector of whether the validity of a hash could be verified.
-/// When false, the value <=> hash validity at the position could not be
-/// verified because the value has been removed ("tombstoned") from the storage layer.
-pub fn key_history_verify<TC: Configuration>(
-    vrf_public_key: &[u8],
-    root_hash: Digest,
+fn verify_with_history_params(
     current_epoch: u64,
-    akd_label: AkdLabel,
-    proof: HistoryProof,
-    params: HistoryVerificationParams,
-) -> Result<Vec<VerifyResult>, VerificationError> {
-    let mut results = Vec::new();
-    let mut last_version = 0;
-
+    akd_label: &AkdLabel,
+    proof: &HistoryProof,
+    params: HistoryParams,
+) -> Result<(Vec<u64>, Vec<u64>), VerificationError> {
     let num_proofs = proof.update_proofs.len();
 
     // Make sure the update proofs are non-empty
@@ -81,16 +89,118 @@ pub fn key_history_verify<TC: Configuration>(
         }
     }
 
+    let mut start_version = proof.update_proofs[0].version;
+    let mut end_version = proof.update_proofs[0].version;
+    proof.update_proofs.iter().for_each(|update_proof| {
+        if update_proof.version < start_version {
+            start_version = update_proof.version;
+        }
+        if update_proof.version > end_version {
+            end_version = update_proof.version;
+        }
+    });
+
+    if start_version == 0 {
+        return Err(VerificationError::HistoryProof(
+            "Computed start version for the key history should be non-zero".to_string(),
+        ));
+    }
+
+    if end_version > current_epoch {
+        return Err(VerificationError::HistoryProof(
+            "Computed end version for the key history should not exceed current epoch".to_string(),
+        ));
+    }
+
+    match params {
+        HistoryParams::Complete => {
+            // Make sure the start version is 1
+            if start_version != 1 {
+                return Err(VerificationError::HistoryProof(format!(
+                    "Expected start version to be 1 given that it is a complete history, but got start_version = {}",
+                    start_version
+                )));
+            }
+        }
+        HistoryParams::MostRecent(recency) =>
+        {
+            #[allow(clippy::comparison_chain)]
+            if num_proofs < recency {
+                if start_version != 1 {
+                    return Err(VerificationError::HistoryProof(format!(
+                        "Expected start version to be 1 given that the number of proofs returned was less than
+                        the recency parameter, but got start_version = {}",
+                        start_version
+                    )));
+                }
+            } else if num_proofs > recency {
+                return Err(VerificationError::HistoryProof(format!(
+                    "Expected at most {} update proofs, but got {} of them",
+                    recency, num_proofs
+                )));
+            }
+        }
+    }
+
+    let (past_marker_versions, future_marker_versions) =
+        crate::utils::get_marker_versions(start_version, end_version, current_epoch);
+
+    // Perform checks for expected number of past marker proofs
+    if past_marker_versions.len() != proof.past_marker_vrf_proofs.len() {
+        return Err(VerificationError::HistoryProof(format!(
+            "Expected {} past marker proofs, but got {}",
+            past_marker_versions.len(),
+            proof.past_marker_vrf_proofs.len()
+        )));
+    }
+    if proof.past_marker_vrf_proofs.len() != proof.existence_of_past_marker_proofs.len() {
+        return Err(VerificationError::HistoryProof(format!(
+            "Expected equal number of past marker proofs, but got ({}, {})",
+            proof.past_marker_vrf_proofs.len(),
+            proof.existence_of_past_marker_proofs.len()
+        )));
+    }
+
+    // Perform checks for expected number of future marker proofs
+    if future_marker_versions.len() != proof.future_marker_vrf_proofs.len() {
+        return Err(VerificationError::HistoryProof(format!(
+            "Expected {} future marker proofs, but got {}",
+            future_marker_versions.len(),
+            proof.future_marker_vrf_proofs.len()
+        )));
+    }
+    if proof.future_marker_vrf_proofs.len() != proof.non_existence_of_future_marker_proofs.len() {
+        return Err(VerificationError::HistoryProof(format!(
+            "Expected equal number of future marker proofs, but got ({}, {})",
+            proof.future_marker_vrf_proofs.len(),
+            proof.non_existence_of_future_marker_proofs.len()
+        )));
+    }
+
+    Ok((past_marker_versions, future_marker_versions))
+}
+
+/// Verifies a key history proof, given the corresponding sequence of hashes.
+/// Returns a vector of whether the validity of a hash could be verified.
+/// When false, the value <=> hash validity at the position could not be
+/// verified because the value has been removed ("tombstoned") from the storage layer.
+pub fn key_history_verify<TC: Configuration>(
+    vrf_public_key: &[u8],
+    root_hash: Digest,
+    current_epoch: u64,
+    akd_label: AkdLabel,
+    proof: HistoryProof,
+    params: HistoryParams,
+    verification_params: HistoryVerificationParams,
+) -> Result<Vec<VerifyResult>, VerificationError> {
+    let mut results = Vec::new();
+
+    let (past_marker_versions, future_marker_versions) =
+        verify_with_history_params(current_epoch, &akd_label, &proof, params)?;
+
     // Verify all individual update proofs
     let mut maybe_previous_update_epoch = None;
     for update_proof in proof.update_proofs.into_iter() {
-        // Get the highest version sent among the update proofs.
-        last_version = if update_proof.version > last_version {
-            update_proof.version
-        } else {
-            last_version
-        };
-
         if let Some(previous_update_epoch) = maybe_previous_update_epoch {
             // Make sure this this epoch is more than the previous epoch you checked
             if update_proof.epoch > previous_update_epoch {
@@ -107,78 +217,31 @@ pub fn key_history_verify<TC: Configuration>(
             vrf_public_key,
             update_proof,
             &akd_label,
-            params,
+            verification_params,
         )?;
         results.push(result);
     }
 
-    // Get the least and greatest marker entries for the current version
-    let next_marker = crate::utils::get_marker_version_log2(last_version) + 1;
-    let final_marker = crate::utils::get_marker_version_log2(current_epoch);
-
-    // Perform checks for expected number of until-marker proofs
-    let expected_num_until_marker_proofs = (1 << next_marker) - last_version - 1;
-    if expected_num_until_marker_proofs != proof.until_marker_vrf_proofs.len() as u64 {
-        return Err(VerificationError::HistoryProof(format!(
-            "Expected {} until-marker proofs, but got {}",
-            expected_num_until_marker_proofs,
-            proof.until_marker_vrf_proofs.len()
-        )));
-    }
-    if proof.until_marker_vrf_proofs.len() != proof.non_existence_until_marker_proofs.len() {
-        return Err(VerificationError::HistoryProof(format!(
-            "Expected equal number of until-marker proofs, but got ({}, {})",
-            proof.until_marker_vrf_proofs.len(),
-            proof.non_existence_until_marker_proofs.len()
-        )));
-    }
-
-    // Verify the non-existence of future entries, up to the next marker
-    for (i, version) in (last_version + 1..(1 << next_marker)).enumerate() {
-        verify_nonexistence::<TC>(
+    for (i, version) in past_marker_versions.iter().enumerate() {
+        verify_existence::<TC>(
             vrf_public_key,
             root_hash,
             &akd_label,
             VersionFreshness::Fresh,
-            version,
-            &proof.until_marker_vrf_proofs[i],
-            &proof.non_existence_until_marker_proofs[i],
-        )
-        .map_err(|_| {
-            VerificationError::HistoryProof(format!(
-                "Non-existence of next few proof of label {:?} with version
-                {:?} at epoch {:?} does not verify",
-                &akd_label, version, current_epoch
-            ))
-        })?;
-    }
-
-    // Perform checks for expected number of future-marker proofs
-    let expected_num_future_marker_proofs = final_marker + 1 - next_marker;
-    if expected_num_future_marker_proofs != proof.future_marker_vrf_proofs.len() as u64 {
-        return Err(VerificationError::HistoryProof(format!(
-            "Expected {} future-marker proofs, but got {}",
-            expected_num_future_marker_proofs,
-            proof.future_marker_vrf_proofs.len()
-        )));
-    }
-    if proof.future_marker_vrf_proofs.len() != proof.non_existence_of_future_marker_proofs.len() {
-        return Err(VerificationError::HistoryProof(format!(
-            "Expected equal number of future-marker proofs, but got ({}, {})",
-            proof.future_marker_vrf_proofs.len(),
-            proof.non_existence_of_future_marker_proofs.len()
-        )));
+            *version,
+            &proof.past_marker_vrf_proofs[i],
+            &proof.existence_of_past_marker_proofs[i],
+        )?;
     }
 
     // Verify the VRFs and non-membership proofs for future markers
-    for (i, pow) in (next_marker..final_marker + 1).enumerate() {
-        let version = 1 << pow;
+    for (i, version) in future_marker_versions.iter().enumerate() {
         verify_nonexistence::<TC>(
             vrf_public_key,
             root_hash,
             &akd_label,
             VersionFreshness::Fresh,
-            version,
+            *version,
             &proof.future_marker_vrf_proofs[i],
             &proof.non_existence_of_future_marker_proofs[i],
         )

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples"
-version = "0.11.0"
+version = "0.12.0-pre.1"
 authors = ["akd contributors"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/examples/src/mysql_demo/tests/test_util.rs
+++ b/examples/src/mysql_demo/tests/test_util.rs
@@ -333,6 +333,7 @@ pub(crate) async fn directory_test_suite<
                             root_hash.epoch(),
                             key,
                             proof,
+                            HistoryParams::default(),
                             akd::HistoryVerificationParams::default(),
                         ) {
                             panic!("History proof failed to verify {:?}", error);


### PR DESCRIPTION
In general, this change improves the security properties that are supposed to be attained from a limited history proof. A (full) key history proof provides a list of all past versions for a query key. A limited history proof allows for some past version to be left out of the proof. Previously, the way this was implemented was to literally truncate the older versions.

Now, we are instead properly adding the existence proofs for past marker versions and non-existence proofs for future marker versions.

Specifically in this change, it:

- Removes `HistoryParams::SinceEpoch`, since this is not really supportable by the existing construction. The only way for specifying a non-default parameter now is with `HistoryParams::MostRecent`.
- Parameters in the `HistoryProof` struct were repurposed and renamed to support past and future marker versions
- Added a new `get_marker_versions()` utility function which determines the past and future version numbers to check as part of the history proof generation and verification
- Moved `HistoryParams` out from `akd` and into `akd_core` since it is also used by verification
- Added a new `InvalidVersion` error type
- Added tests for the new history proof verification behavior, and updated docs as well

I am also bumping the version to 0.12.0-pre.1, since the introduced changes are incompatible with the previous version.