### PR TITLE
Small fixes to the READMEs and CLI help messages

### DIFF
--- a/akd_core/src/proto/mod.rs
+++ b/akd_core/src/proto/mod.rs
@@ -215,7 +215,7 @@ impl TryFrom<&specs::types::SiblingProof> for crate::SiblingProof {
         let label: crate::NodeLabel = input.label.as_ref().unwrap().try_into()?;
 
         // get the raw data & it's length, but at most crate::hash::DIGEST_BYTES bytes
-        let siblings = input.siblings.get(0);
+        let siblings = input.siblings.first();
         if siblings.is_none() {
             return Err(ConversionError::Deserialization(
                 "Required field siblings missing".to_string(),

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,7 +26,11 @@ cargo run -p examples --release -- whatsapp-kt-auditor -l
 
 This example requires setting up [Docker](https://docs.docker.com/get-docker/) (which will host the MySQL instance). Once Docker
 is up and running, you can simply run:
+```bash
+docker compose up [-d]
 ```
+in the root of repository to spin up the MySQL instance and then run:
+```bash
 cargo run -p examples --release -- mysql-demo
 ```
 to run the demo. You can also pass the `--help` argument to view various options for running benchmarks and auto-populating the instance.

--- a/examples/src/mysql_demo/commands.rs
+++ b/examples/src/mysql_demo/commands.rs
@@ -83,10 +83,9 @@ impl Command {
             "end".blue()
         );
         println!(
-            "  {}|{} {}:\t\tretrieve the root hash at given epoch (default = latest epoch)",
+            "  {}|{}\t\tretrieve the root hash at the latest epoch",
             "root".green(),
             "root_hash".green(),
-            "epoch".magenta()
         );
     }
 

--- a/examples/src/whatsapp_kt_auditor/auditor.rs
+++ b/examples/src/whatsapp_kt_auditor/auditor.rs
@@ -68,7 +68,7 @@ pub(crate) async fn audit_epoch(blob: akd::local_auditing::AuditBlob) -> Result<
     }
 }
 
-pub(crate) fn display_audit_proofs_info(info: &mut Vec<EpochSummary>) -> Result<String> {
+pub(crate) fn display_audit_proofs_info(info: &mut [EpochSummary]) -> Result<String> {
     info.sort_by(|a, b| a.name.epoch.cmp(&b.name.epoch));
     if info.is_empty() {
         bail!("There are no epochs present in the storage repository");


### PR DESCRIPTION
In this PR I
- updated the README in the example directory to include the MySQL docker instance spin-up command.
- updated the help message for the CLI in mysql_demo. Since it is no longer supported to get root_hash of an older epoch, I modified the description of root_hash command to remove the optional epoch parameter from the CLI help message. 