### PR TITLE
Update tombstone API to minimize DB ops

### DIFF
--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -593,8 +593,9 @@ impl Azks {
         let nodes = TreeNode::batch_get_from_storage(storage, &nodes, self.latest_epoch).await?;
         count += nodes.len() as u64;
 
-        // Now load the children of the nodes resolved on the direct path, which for non-already-loaded children will be the
-        // siblings necessray to generate the required proof structs.
+        // Now load the children of the nodes resolved on the direct path, which
+        // for non-already-loaded children will be the siblings necessary to
+        // generate the required proof structs.
         let children = nodes
             .into_iter()
             .flat_map(|node| match (node.left_child, node.right_child) {

--- a/akd/src/tests.rs
+++ b/akd/src/tests.rs
@@ -1073,11 +1073,9 @@ async fn test_tombstoned_key_history<TC: Configuration>() -> Result<(), AkdError
     let vrf_pk = akd.get_public_key().await?;
 
     // tombstone epochs 1 & 2
-    let tombstones = [
-        crate::storage::types::ValueStateKey("hello".as_bytes().to_vec(), 1u64),
-        crate::storage::types::ValueStateKey("hello".as_bytes().to_vec(), 2u64),
-    ];
-    storage.tombstone_value_states(&tombstones).await?;
+    storage
+        .tombstone_value_states(&AkdLabel::from("hello"), 2)
+        .await?;
 
     // Now get a history proof for this key
     let (history_proof, root_hash) = akd


### PR DESCRIPTION
## Current
Our current tombstoning API `tombstone_value_states` accepts a list of `ValueState` keys that tombstoning should be performed for. This means that the client flow will, more often than not, involve:
1. looking up all `ValueState` objects for a given user in DB
2. figuring out which objects should be tombstoned based on their epochs (relative to the current epoch)
3. passing the keys of said objects to the tombstone API

Internally, the tombstone API then does another lookup of `ValueState` objects with the keys passed, modifies the objects to "tombstone" them, then another write to commit the now-tombstoned objects.

## Proposed
We can cut out the DB lookup pre-API call by having the API take in an epoch and a username, then tombstoning all `ValueState` objects for the user with an epoch less than or equal to the passed epoch. Clients will not need any knowledge of what `ValueState` objects a user has, and just need to inform the API which epoch to stop tombstoning at.

In addition, before we write the tombstoned records, we should filter out any objects that are already tombstoned, to avoid unnecessary writes.