### PR TITLE
Prepare for 0.12.0-pre.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.12.0-pre.1 (March 26, 2024)
+* Updated storage tombstone API params to be more ergonomic
+* Renamed HistoryParams enum variants to highlight caveats
+* Added NCC audit report to README
+* Improved documentation
+
 ## 0.11.0 (October 26, 2023)
 * Added error-handling for various edge-cases when performing akd_core verification
 * Updated dependencies

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Installation
 Add the following line to the dependencies of your `Cargo.toml`:
 
 ```
-akd = "0.11"
+akd = "0.12.0-pre.1"
 ```
 
 ### Minimum Supported Rust Version

--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd"
-version = "0.11.0"
+version = "0.12.0-pre.1"
 authors = ["akd contributors"]
 description = "An implementation of an auditable key directory"
 license = "MIT OR Apache-2.0"
@@ -51,7 +51,7 @@ default = [
 
 [dependencies]
 ## Required dependencies ##
-akd_core = { version = "0.11.0", path = "../akd_core", default-features = false, features = [
+akd_core = { version = "0.12.0-pre.1", path = "../akd_core", default-features = false, features = [
     "vrf",
 ] }
 async-recursion = "1"

--- a/akd_core/Cargo.toml
+++ b/akd_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_core"
-version = "0.11.0"
+version = "0.12.0-pre.1"
 authors = ["akd contributors"]
 description = "Core utilities for the akd crate"
 license = "MIT OR Apache-2.0"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples"
-version = "0.11.0"
+version = "0.12.0-pre.1"
 authors = ["akd contributors"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 0.12.0-pre.1 (March 26, 2024)
* Updated storage tombstone API params to be more ergonomic
* Renamed HistoryParams variants to highlight caveats
* Added NCC audit report to README
* Improved documentation