### PR TITLE
Support pre-release version numbers in deploy script

### DIFF
--- a/.github/workflows/wait-for-crate-dependency.sh
+++ b/.github/workflows/wait-for-crate-dependency.sh
@@ -10,6 +10,7 @@ get_crate_expected_version_number()
     # Additionally this regex with grep works for both the notations
     # 1. crate = { some_other_options ... version = "x.y.z" ... other_options }
     # 2. crate = "x.y.z"
+    # It also supports optional pre-release suffixes in the form of "-pre.x"
     # 3. crate = "w.x.y-pre.z"
     local EXPECTED_VERSION=$(grep "$TARGET_CRATE" $INDEX_TOML_FILE | grep -o '[0-9]\.[0-9\.]\+\(-pre\.[0-9]\+\)\?'| head -n 1)
     echo $EXPECTED_VERSION

--- a/.github/workflows/wait-for-crate-dependency.sh
+++ b/.github/workflows/wait-for-crate-dependency.sh
@@ -10,7 +10,8 @@ get_crate_expected_version_number()
     # Additionally this regex with grep works for both the notations
     # 1. crate = { some_other_options ... version = "x.y.z" ... other_options }
     # 2. crate = "x.y.z"
-    local EXPECTED_VERSION=$(grep "$TARGET_CRATE" $INDEX_TOML_FILE | grep -o '[0-9]\.[0-9\.]\+' | head -n 1)
+    # 3. crate = "w.x.y-pre.z"
+    local EXPECTED_VERSION=$(grep "$TARGET_CRATE" $INDEX_TOML_FILE | grep -o '[0-9]\.[0-9\.]\+\(-pre\.[0-9]\+\)\?'| head -n 1)
     echo $EXPECTED_VERSION
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.12.0-pre.2 (March 26, 2024)
+* Updated deploy script to support pre-release version strings
+
 ## 0.12.0-pre.1 (March 26, 2024)
 * Updated storage tombstone API params to be more ergonomic
 * Renamed HistoryParams enum variants to highlight caveats

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,11 @@
 # Changelog
 
 ## 0.12.0-pre.2 (March 26, 2024)
-* Updated deploy script to support pre-release version strings
-
-## 0.12.0-pre.1 (March 26, 2024)
 * Updated storage tombstone API params to be more ergonomic
 * Renamed HistoryParams enum variants to highlight caveats
 * Added NCC audit report to README
 * Improved documentation
+* Updated deploy script to support pre-release version strings
 
 ## 0.11.0 (October 26, 2023)
 * Added error-handling for various edge-cases when performing akd_core verification

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Installation
 Add the following line to the dependencies of your `Cargo.toml`:
 
 ```
-akd = "0.12.0-pre.1"
+akd = "0.12.0-pre.2"
 ```
 
 ### Minimum Supported Rust Version

--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd"
-version = "0.12.0-pre.1"
+version = "0.12.0-pre.2"
 authors = ["akd contributors"]
 description = "An implementation of an auditable key directory"
 license = "MIT OR Apache-2.0"
@@ -51,7 +51,7 @@ default = [
 
 [dependencies]
 ## Required dependencies ##
-akd_core = { version = "0.12.0-pre.1", path = "../akd_core", default-features = false, features = [
+akd_core = { version = "0.12.0-pre.2", path = "../akd_core", default-features = false, features = [
     "vrf",
 ] }
 async-recursion = "1"

--- a/akd_core/Cargo.toml
+++ b/akd_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_core"
-version = "0.12.0-pre.1"
+version = "0.12.0-pre.2"
 authors = ["akd contributors"]
 description = "Core utilities for the akd crate"
 license = "MIT OR Apache-2.0"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples"
-version = "0.12.0-pre.1"
+version = "0.12.0-pre.2"
 authors = ["akd contributors"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
Updates our deploy script to handle pre-release version strings. Without it, our deploy script currently hangs with the following log:
```
...
Available akd_core versions: "0.8.0" "0.8.2" "0.8.3" "0.8.4" "0.8.5" "0.8.6" "0.8.7" "0.8.8" "0.8.9" "0.9.0" "0.10.0" "0.11.0" "0.12.0-pre.1" 
Expected version of akd_core (0.12.0) is not yet published. Retrying after a wait
...
```

Also bumps our version to `0.12.0-pre.2` to re-attempt deploy.

## Regex Test
```
% echo "0.11" | grep -o '[0-9]\.[0-9\.]\+\(-pre\.[0-9]\+\)\?'  
0.11

% echo "0.11.1" | grep -o '[0-9]\.[0-9\.]\+\(-pre\.[0-9]\+\)\?' 
0.11.1

% echo "0.11.11" | grep -o '[0-9]\.[0-9\.]\+\(-pre\.[0-9]\+\)\?' 
0.11.11

% echo "0.11-pre.1" | grep -o '[0-9]\.[0-9\.]\+\(-pre\.[0-9]\+\)\?' 
0.11-pre.1

% echo "0.11.0-pre.12" | grep -o '[0-9]\.[0-9\.]\+\(-pre\.[0-9]\+\)\?' 
0.11.0-pre.12