### PR TITLE
Only instantiate storage metrics when runtime_metrics is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.0-pre.5 (June 3, 2024)
+* Only instantiate metrics attribute in storage manager when runtime metrics is enabled. This avoids an unnecessary
+import of atomic types, which not all architectures support.
+
 ## 0.12.0-pre.4 (May 31, 2024)
 * Upgrades history proof generation to properly support the MostRecent parameter (giving a limited
   history proof)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Installation
 Add the following line to the dependencies of your `Cargo.toml`:
 
 ```
-akd = "0.12.0-pre.4"
+akd = "0.12.0-pre.5"
 ```
 
 ### Minimum Supported Rust Version

--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd"
-version = "0.12.0-pre.4"
+version = "0.12.0-pre.5"
 authors = ["akd contributors"]
 description = "An implementation of an auditable key directory"
 license = "MIT OR Apache-2.0"
@@ -51,7 +51,7 @@ default = [
 
 [dependencies]
 ## Required dependencies ##
-akd_core = { version = "0.12.0-pre.4", path = "../akd_core", default-features = false, features = [
+akd_core = { version = "0.12.0-pre.5", path = "../akd_core", default-features = false, features = [
     "vrf",
 ] }
 async-recursion = "1"

--- a/akd/src/storage/manager/mod.rs
+++ b/akd/src/storage/manager/mod.rs
@@ -26,6 +26,7 @@ use log::debug;
 use log::{error, info, warn};
 use std::collections::HashMap;
 use std::collections::HashSet;
+#[cfg(feature = "runtime_metrics")]
 use std::sync::atomic::AtomicU64;
 #[cfg(feature = "runtime_metrics")]
 use std::sync::atomic::Ordering;
@@ -47,6 +48,7 @@ const METRIC_GET_USER_STATE: Metric = 7;
 const METRIC_GET_USER_DATA: Metric = 8;
 const METRIC_GET_USER_STATE_VERSIONS: Metric = 9;
 
+#[cfg(feature = "runtime_metrics")]
 const NUM_METRICS: usize = 10;
 
 #[cfg(test)]
@@ -59,7 +61,7 @@ pub struct StorageManager<Db: Database> {
     transaction: Transaction,
     /// The underlying database managed by this storage manager
     db: Arc<Db>,
-
+    #[cfg(feature = "runtime_metrics")]
     metrics: [Arc<AtomicU64>; NUM_METRICS],
 }
 
@@ -69,6 +71,7 @@ impl<Db: Database> Clone for StorageManager<Db> {
             cache: self.cache.clone(),
             transaction: self.transaction.clone(),
             db: self.db.clone(),
+            #[cfg(feature = "runtime_metrics")]
             metrics: self.metrics.clone(),
         }
     }
@@ -84,6 +87,7 @@ impl<Db: Database> StorageManager<Db> {
             cache: None,
             transaction: Transaction::new(),
             db: Arc::new(db),
+            #[cfg(feature = "runtime_metrics")]
             metrics: [0; NUM_METRICS].map(|_| Arc::new(AtomicU64::new(0))),
         }
     }
@@ -103,6 +107,7 @@ impl<Db: Database> StorageManager<Db> {
             )),
             transaction: Transaction::new(),
             db: Arc::new(db),
+            #[cfg(feature = "runtime_metrics")]
             metrics: [0; NUM_METRICS].map(|_| Arc::new(AtomicU64::new(0))),
         }
     }

--- a/akd/src/tests.rs
+++ b/akd/src/tests.rs
@@ -30,6 +30,7 @@ use crate::{
     VerifyResult,
 };
 
+#[allow(dead_code)]
 #[derive(Clone)]
 pub struct LocalDatabase;
 

--- a/akd_core/Cargo.toml
+++ b/akd_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_core"
-version = "0.12.0-pre.4"
+version = "0.12.0-pre.5"
 authors = ["akd contributors"]
 description = "Core utilities for the akd crate"
 license = "MIT OR Apache-2.0"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples"
-version = "0.12.0-pre.4"
+version = "0.12.0-pre.5"
 authors = ["akd contributors"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
Only instantiate metrics attribute in storage manager when the `runtime_metrics` feature is enabled. This avoids an unnecessary import of atomic types, which not all architectures support.