### PR TITLE
[akd] add marker proof nodes to preload caching for v2 lookup proofs

### DIFF
--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -623,9 +623,10 @@ impl Azks {
         &self,
         storage: &StorageManager<S>,
         lookup_infos: &[LookupInfo],
+        marker_labels: Option<Vec<NodeLabel>>,
     ) -> Result<u64, AkdError> {
         // Collect lookup labels needed and convert them into Nodes for preloading.
-        let lookup_nodes: Vec<AzksElement> = lookup_infos
+        let mut lookup_nodes: Vec<AzksElement> = lookup_infos
             .iter()
             .flat_map(|li| vec![li.existent_label, li.marker_label, li.non_existent_label])
             .map(|l| AzksElement {
@@ -633,6 +634,13 @@ impl Azks {
                 value: AzksValue(EMPTY_DIGEST),
             })
             .collect();
+
+        if let Some(labels) = marker_labels {
+            lookup_nodes.extend(labels.iter().map(|l| AzksElement {
+                label: *l,
+                value: AzksValue(EMPTY_DIGEST),
+            }))
+        }
 
         // Load nodes.
         self.preload_nodes(storage, &AzksElementSet::from(lookup_nodes))

--- a/akd/src/tests.rs
+++ b/akd/src/tests.rs
@@ -110,10 +110,6 @@ fn setup_mocked_db(db: &mut MockLocalDatabase, test_db: &AsyncInMemoryDatabase) 
             futures::executor::block_on(tmp_db.batch_get::<TreeNodeWithPreviousValue>(key))
         });
 
-    let tmp_db = test_db.clone();
-    db.expect_batch_get::<Azks>()
-        .returning(move |key| futures::executor::block_on(tmp_db.batch_get::<Azks>(key)));
-
     // ===== Get User Data ===== //
     let tmp_db = test_db.clone();
     db.expect_get_user_data()


### PR DESCRIPTION
lookup v2 performs marker proof for past markers (membership proofs) and future parkers (non-membership proofs). To keep the number of DB reads low, we currently rely on `preload_nodes` to BFS down from the root to all nodes who share a prefix for target labels and their immediate children. This PR *should* include the marker proofs (past/future versions of the same akd_label and freshness) in the BFS traversal to take greater advantage of existing caching.

ATM, there do no appear to be specific tests for cache-traversal inclusion. Rust is not my forte, so please review carefully.