### PR TITLE
[akd] Fix prefetch bug

### DIFF
--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -623,9 +623,10 @@ impl Azks {
         &self,
         storage: &StorageManager<S>,
         lookup_infos: &[LookupInfo],
+        marker_labels: Option<Vec<NodeLabel>>,
     ) -> Result<u64, AkdError> {
         // Collect lookup labels needed and convert them into Nodes for preloading.
-        let lookup_nodes: Vec<AzksElement> = lookup_infos
+        let mut lookup_nodes: Vec<AzksElement> = lookup_infos
             .iter()
             .flat_map(|li| vec![li.existent_label, li.marker_label, li.non_existent_label])
             .map(|l| AzksElement {
@@ -633,6 +634,13 @@ impl Azks {
                 value: AzksValue(EMPTY_DIGEST),
             })
             .collect();
+
+        if let Some(labels) = marker_labels {
+            lookup_nodes.extend(labels.iter().map(|l| AzksElement {
+                label: *l,
+                value: AzksValue(EMPTY_DIGEST),
+            }))
+        }
 
         // Load nodes.
         self.preload_nodes(storage, &AzksElementSet::from(lookup_nodes))

--- a/akd/src/tests.rs
+++ b/akd/src/tests.rs
@@ -110,10 +110,6 @@ fn setup_mocked_db(db: &mut MockLocalDatabase, test_db: &AsyncInMemoryDatabase) 
             futures::executor::block_on(tmp_db.batch_get::<TreeNodeWithPreviousValue>(key))
         });
 
-    let tmp_db = test_db.clone();
-    db.expect_batch_get::<Azks>()
-        .returning(move |key| futures::executor::block_on(tmp_db.batch_get::<Azks>(key)));
-
     // ===== Get User Data ===== //
     let tmp_db = test_db.clone();
     db.expect_get_user_data()


### PR DESCRIPTION
My original diff added a bug by moving the pre-fetch down to the code-block where version-range was in scope. This means that the update proof was run before the pre-load, resulting in extra fetches.

https://github.com/facebook/akd/pull/436

This PR *should* address that my moving the pre-fetch block back to its original position, and moving the range-selection to a separate earlier block.

From initial canary, the latency appears to be improved:

<img width="169" alt="Screenshot 2024-06-26 at 4 01 21 PM" src="https://github.com/facebook/akd/assets/13973013/61eb7224-55c0-4d46-a14f-908c41ed67ab">
