### PR TITLE
[akd] fix prefetch ordering bug

### DIFF
--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -626,21 +626,15 @@ impl Azks {
         marker_labels: Option<Vec<NodeLabel>>,
     ) -> Result<u64, AkdError> {
         // Collect lookup labels needed and convert them into Nodes for preloading.
-        let mut lookup_nodes: Vec<AzksElement> = lookup_infos
+        let lookup_nodes: Vec<AzksElement> = lookup_infos
             .iter()
             .flat_map(|li| vec![li.existent_label, li.marker_label, li.non_existent_label])
+            .chain(marker_labels.unwrap_or_default().iter().cloned())
             .map(|l| AzksElement {
                 label: l,
                 value: AzksValue(EMPTY_DIGEST),
             })
             .collect();
-
-        if let Some(labels) = marker_labels {
-            lookup_nodes.extend(labels.iter().map(|l| AzksElement {
-                label: *l,
-                value: AzksValue(EMPTY_DIGEST),
-            }))
-        }
 
         // Load nodes.
         self.preload_nodes(storage, &AzksElementSet::from(lookup_nodes))


### PR DESCRIPTION
My original diff added a bug by moving the pre-fetch down to the code-block where version-range was in scope. This means that the update proof was run before the pre-load, resulting in extra fetches.

https://github.com/facebook/akd/pull/436

This PR should address that my moving the pre-fetch block back to its original position, and moving the range-selection to a separate earlier block.

From initial canary, the latency appears to be improved:

<img width="169" alt="Screenshot 2024-06-26 at 4 01 21 PM" src="https://github.com/facebook/akd/assets/13973013/f35ca3eb-34a7-45ab-894a-0e8e1a722f13">
