### PR TITLE
Prepare for 0.12.0-pre.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.12.0-pre.8 (August 23, 2024)
+* Fixed a bug in key history API that occurs when a proof is being generated while a transaction is
+  being committed
+* Updated test vectors to the latest version
+
 ## 0.12.0-pre.7 (July 22, 2024)
 * Added an efficiency optimization for history proof generation and
   verification (incompatible with previous logic)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Installation
 Add the following line to the dependencies of your `Cargo.toml`:
 
 ```
-akd = "0.12.0-pre.7"
+akd = "0.12.0-pre.8"
 ```
 
 ### Minimum Supported Rust Version

--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd"
-version = "0.12.0-pre.7"
+version = "0.12.0-pre.8"
 authors = ["akd contributors"]
 description = "An implementation of an auditable key directory"
 license = "MIT OR Apache-2.0"
@@ -52,7 +52,7 @@ default = [
 
 [dependencies]
 ## Required dependencies ##
-akd_core = { version = "0.12.0-pre.7", path = "../akd_core", default-features = false, features = [
+akd_core = { version = "0.12.0-pre.8", path = "../akd_core", default-features = false, features = [
     "vrf",
 ] }
 async-recursion = "1"

--- a/akd_core/Cargo.toml
+++ b/akd_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_core"
-version = "0.12.0-pre.7"
+version = "0.12.0-pre.8"
 authors = ["akd contributors"]
 description = "Core utilities for the akd crate"
 license = "MIT OR Apache-2.0"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples"
-version = "0.12.0-pre.7"
+version = "0.12.0-pre.8"
 authors = ["akd contributors"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 0.12.0-pre.8 (August 23, 2024)
* Fixed a bug in key history API that occurs when a proof is being generated while a transaction is
  being committed
* Updated test vectors to the latest version