### PR TITLE
Improve NotFound Error Accuracy in key_history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.12.0-pre.9 (August 28, 2024)
+* Fixed a bug in key history API that can incorrectly return HistoryProofs without UpdateProofs.
+
 ## 0.12.0-pre.8 (August 23, 2024)
 * Fixed a bug in key history API that occurs when a proof is being generated while a transaction is
   being committed

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Installation
 Add the following line to the dependencies of your `Cargo.toml`:
 
 ```
-akd = "0.12.0-pre.8"
+akd = "0.12.0-pre.9"
 ```
 
 ### Minimum Supported Rust Version

--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd"
-version = "0.12.0-pre.8"
+version = "0.12.0-pre.9"
 authors = ["akd contributors"]
 description = "An implementation of an auditable key directory"
 license = "MIT OR Apache-2.0"
@@ -52,7 +52,7 @@ default = [
 
 [dependencies]
 ## Required dependencies ##
-akd_core = { version = "0.12.0-pre.8", path = "../akd_core", default-features = false, features = [
+akd_core = { version = "0.12.0-pre.9", path = "../akd_core", default-features = false, features = [
     "vrf",
 ] }
 async-recursion = "1"

--- a/akd_core/Cargo.toml
+++ b/akd_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_core"
-version = "0.12.0-pre.8"
+version = "0.12.0-pre.9"
 authors = ["akd contributors"]
 description = "Core utilities for the akd crate"
 license = "MIT OR Apache-2.0"

--- a/akd_core/src/types/node_label/mod.rs
+++ b/akd_core/src/types/node_label/mod.rs
@@ -22,7 +22,7 @@ use alloc::vec::Vec;
 #[cfg(test)]
 mod tests;
 
-/// Represents the label of a AKD node
+/// Represents the label of an AKD node
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(
     feature = "serde_serialization",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples"
-version = "0.12.0-pre.8"
+version = "0.12.0-pre.9"
 authors = ["akd contributors"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
**Issue**
Prior to this patch, the `Directory::key_history` API had potential to return a `HistoryProof` with no `UpdateProof`'s included in it. Considering that `HistoryProof`s can be thought of as an array of `UpdateProof`'s (see: https://docs.rs/akd/0.11.0/akd/struct.HistoryProof.html), the presence of at least one `UpdateProof` is required.

The issue detailed above can happen in instances where we perform a read of user states during a publish operation. For example:
- The `Directory` has a latest epoch of 10.
- A client of AKD performs a read during a publish operation.
- `Directory::key_history` reads user states from storage and sees a User U's states with an epoch of 11, indicating that User U has just been added to AKD.
- Existing checks which build the `UpdateProof`s to return in the `HistoryProof` filter out the user state associated with epoch 11 since the `Directory`'s latest epoch is only 10.

Despite filtering out User U's `ValueState` for epoch 11 correctly (i.e. we cannot include data ahead of the `Directory`), AKD would return a `HistoryProof` containing 0 `UpdateProof`'s. As a result, verification for the `HistoryProof` would fail.

**Solution**
The solution to the issue mentioned above simply filters out any user's `ValueState`'s which have an epoch greater than the the `Directory`'s current epoch, which then triggers an existing check to return an `AkdError::Storage(StroageError::NotFound)` error. The error more appropriately indicates that the `Directory` does not technically have history for the user yet, at least not until it's latest epoch is updated (via its `aZKS`).

**Verfication**
To verify that the solution works as intended, we update the `test_errors::test_read_during_publish` test to insert a label which has an epoch greater than the directory's. Prior to including changes made to the directory in this patch, the resultant `HistoryProof` fails to verify due to `UpdateProof`'s not being present:

```
thread 'tests::test_errors::test_read_during_publish_experimental_config' panicked at akd/src/tests/test_errors.rs:269:10:
called `Result::unwrap()` on an `Err` value: HistoryProof("No update proofs included in the proof of user AkdLabel([104, 101, 108, 108, 111]) at epoch 2!")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
[00:00:00.057] INFO   No cache found, skipping preload (append_only_zks:651)
test tests::test_errors::test_read_during_publish_experimental_config ... FAILED
thread 'tests::test_errors::test_read_during_publish_whatsapp_v1_config' panicked at akd/src/tests/test_errors.rs:269:10:
called `Result::unwrap()` on an `Err` value: HistoryProof("No update proofs included in the proof of user AkdLabel([104, 101, 108, 108, 111]) at epoch 2!")
test tests::test_errors::test_read_during_publish_whatsapp_v1_config ... FAILED

failures:

failures:
    tests::test_errors::test_read_during_publish_experimental_config
    tests::test_errors::test_read_during_publish_whatsapp_v1_config

test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 100 filtered out; finished in 0.05s
```

After the change, we can see that the `Directory::key_history` API not more accruately returns an `AkdError::Storage(StoragerError::NotFound)` error:

```
    // History proof for the most recently added key (ahead of directory epoch) should
    // result in the entry not being found.
    let recently_added_label_result = akd
        .key_history(&AkdLabel::from("hello3"), HistoryParams::default())
        .await;
    assert!(matches!(
        recently_added_label_result,
        Err(AkdError::Storage(StorageError::NotFound(_)))
    ));
```

```
running 2 tests
test tests::test_errors::test_read_during_publish_experimental_config ... ok
test tests::test_errors::test_read_during_publish_whatsapp_v1_config ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 100 filtered out; finished in 0.03s
```