### PR TITLE
Add Support for Tracing

### DIFF
--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -14,32 +14,6 @@ readme = "../README.md"
 whatsapp_v1 = ["akd_core/whatsapp_v1"]
 experimental = ["akd_core/experimental"]
 
-rand = ["dep:rand"]
-bench = ["experimental", "public_tests", "tokio/rt-multi-thread"]
-public_tests = [
-    "rand",
-    "dep:colored",
-    "dep:once_cell",
-    "serde_serialization",
-    "akd_core/public_tests",
-    "akd_core/rand",
-    "dep:paste",
-]
-public_auditing = ["dep:protobuf", "akd_core/protobuf"]
-serde_serialization = ["dep:serde", "akd_core/serde_serialization"]
-# Collect runtime metrics on db access calls + timing
-runtime_metrics = []
-# Parallelize VRF calculations during publish
-parallel_vrf = ["akd_core/parallel_vrf"]
-# Parallelize node insertion during publish
-parallel_insert = []
-# Enable pre-loading of the nodes when generating history proofs
-preload_history = []
-# TESTING ONLY: Artifically slow the in-memory database (for benchmarking)
-slow_internal_db = []
-# Greedy loading of lookup proof nodes
-greedy_lookup_preload = []
-
 # Default features mix (experimental + audit-proof protobuf mgmt support)
 default = [
     "public_auditing",
@@ -49,6 +23,36 @@ default = [
     "greedy_lookup_preload",
     "experimental",
 ]
+
+bench = ["experimental", "public_tests", "tokio/rt-multi-thread"]
+# Greedy loading of lookup proof nodes
+greedy_lookup_preload = []
+public_auditing = ["dep:protobuf", "akd_core/protobuf"]
+# Parallelize node insertion during publish
+parallel_insert = []
+# Parallelize VRF calculations during publish
+parallel_vrf = ["akd_core/parallel_vrf"]
+# Enable pre-loading of the nodes when generating history proofs
+preload_history = []
+public_tests = [
+    "rand",
+    "dep:colored",
+    "dep:once_cell",
+    "serde_serialization",
+    "akd_core/public_tests",
+    "akd_core/rand",
+    "dep:paste",
+]
+rand = ["dep:rand"]
+# Collect runtime metrics on db access calls + timing
+runtime_metrics = []
+serde_serialization = ["dep:serde", "akd_core/serde_serialization"]
+# TESTING ONLY: Artifically slow the in-memory database (for benchmarking)
+slow_internal_db = []
+# Tracing instrumentation
+tracing = ["dep:tracing"]
+# Tracing-based instrumentation
+tracing_instrument = ["tracing/attributes"]
 
 [dependencies]
 ## Required dependencies ##
@@ -63,12 +67,13 @@ log = { version = "0.4", features = ["kv_unstable"] }
 tokio = { version = "1", features = ["sync", "time", "rt"] }
 
 ## Optional dependencies ##
-serde = { version = "1", features = ["derive"], optional = true }
-rand = { version = "0.8", optional = true }
 colored = { version = "2", optional = true }
 once_cell = { version = "1", optional = true }
-protobuf = { version = "3", optional = true }
 paste = { version = "1", optional = true }
+protobuf = { version = "3", optional = true }
+rand = { version = "0.8", optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
+tracing = {version = "0.1.40", optional = true }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -9,6 +9,7 @@
 
 use crate::hash::EMPTY_DIGEST;
 use crate::helper_structs::LookupInfo;
+use crate::log::{debug, info};
 use crate::storage::manager::StorageManager;
 use crate::storage::types::StorageType;
 use crate::tree_node::{
@@ -22,8 +23,8 @@ use crate::{
     AppendOnlyProof, AzksElement, AzksValue, Digest, Direction, MembershipProof, NodeLabel,
     NonMembershipProof, PrefixOrdering, SiblingProof, SingleAppendOnlyProof, SizeOf, ARITY,
 };
+
 use async_recursion::async_recursion;
-use log::info;
 use std::cmp::Ordering;
 #[cfg(feature = "greedy_lookup_preload")]
 use std::collections::HashSet;
@@ -528,7 +529,7 @@ impl Azks {
         }
     }
 
-    /// Builds all of the POSSIBLE paths along the route from root node to
+    /// Builds all the POSSIBLE paths along the route from root node to
     /// leaf node. This will be grossly over-estimating the true size of the
     /// tree and the number of nodes required to be fetched, however
     /// it allows a single batch-get call in necessary scenarios
@@ -564,7 +565,7 @@ impl Azks {
         Ok(results)
     }
 
-    /// Preload for a single lookup operation by loading all of the nodes along
+    /// Preload for a single lookup operation by loading all the nodes along
     /// the direct path, and the children of resolved nodes on the path. This
     /// minimizes the number of batch_get operations to the storage layer which are
     /// called
@@ -676,13 +677,14 @@ impl Azks {
                 .collect();
         }
 
-        info!("Preload of tree ({} nodes) completed", load_count);
+        debug!("Preload of tree ({} nodes) completed", load_count);
 
         Ok(load_count)
     }
 
     /// Returns the Merkle membership proof for the trie as it stood at epoch
     // Assumes the verifier has access to the root at epoch
+    #[cfg_attr(feature = "tracing_instrument", tracing::instrument(skip_all))]
     pub async fn get_membership_proof<TC: Configuration, S: Database>(
         &self,
         storage: &StorageManager<S>,
@@ -697,6 +699,7 @@ impl Azks {
     /// In a compressed trie, the proof consists of the longest prefix
     /// of the label that is included in the trie, as well as its children, to show that
     /// none of the children is equal to the given label.
+    #[cfg_attr(feature = "tracing_instrument", tracing::instrument(skip_all))]
     pub async fn get_non_membership_proof<TC: Configuration, S: Database>(
         &self,
         storage: &StorageManager<S>,
@@ -759,6 +762,7 @@ impl Azks {
     /// **RESTRICTIONS**: Note that `start_epoch` and `end_epoch` are valid only when the following are true
     /// * `start_epoch` <= `end_epoch`
     /// * `start_epoch` and `end_epoch` are both existing epochs of this AZKS
+    #[cfg_attr(feature = "tracing_instrument", tracing::instrument(skip_all))]
     pub async fn get_append_only_proof<TC: Configuration, S: Database + 'static>(
         &self,
         storage: &StorageManager<S>,
@@ -802,7 +806,7 @@ impl Azks {
                     load_count
                 );
             }
-            storage.log_metrics(log::Level::Info).await;
+            storage.log_metrics().await;
 
             let (unchanged, leaves) = Self::get_append_only_proof_helper::<TC, _>(
                 latest_epoch,
@@ -1027,6 +1031,7 @@ impl Azks {
     }
 
     /// Gets the root hash for this azks
+    #[cfg_attr(feature = "tracing_instrument", tracing::instrument(skip_all))]
     pub async fn get_root_hash<TC: Configuration, S: Database>(
         &self,
         storage: &StorageManager<S>,
@@ -1037,6 +1042,7 @@ impl Azks {
 
     /// Gets the root hash of the tree at the latest epoch if the passed epoch
     /// is equal to the latest epoch. Will return an error otherwise.
+    #[cfg_attr(feature = "tracing_instrument", tracing::instrument(skip_all))]
     pub(crate) async fn get_root_hash_safe<TC: Configuration, S: Database>(
         &self,
         storage: &StorageManager<S>,

--- a/akd/src/auditor.rs
+++ b/akd/src/auditor.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 
 /// Verifies an audit proof, given start and end hashes for a merkle patricia tree.
+#[cfg_attr(feature = "tracing_instrument", tracing::instrument(skip_all))]
 pub async fn audit_verify<TC: Configuration>(
     hashes: Vec<Digest>,
     proof: AppendOnlyProof,
@@ -52,7 +53,8 @@ pub async fn audit_verify<TC: Configuration>(
     Ok(())
 }
 
-/// Helper for audit, verifies an append-only proof
+/// Helper for audit, verifies an append-only proof.
+#[cfg_attr(feature = "tracing_instrument", tracing::instrument(skip_all))]
 pub async fn verify_consecutive_append_only<TC: Configuration>(
     proof: &SingleAppendOnlyProof,
     start_hash: Digest,

--- a/akd/src/lib.rs
+++ b/akd/src/lib.rs
@@ -254,7 +254,7 @@
 //! First, it encodes a [`HistoryParams`]. Note that the same argument for [`HistoryParams`] that was used to generate
 //! the key history proof must also be used to verify the proof. Otherwise, verification may fail.
 //!
-//! [`HistoryVerificationParams`] also allows the consumer to specify whether or not a "tombstoned" value should be
+//! [`HistoryVerificationParams`] also allows the consumer to specify whether a "tombstoned" value should be
 //! accepted in place of a valid value for the corresponding entry. This is useful
 //! in scenarios where the consumer wishes to verify that a particular entry exists,
 //! but does not care about the value associated with it. The default behavior is to
@@ -460,12 +460,16 @@
 //! Performance optimizations:
 //! - `parallel_vrf`: Enables the VRF computations to be run in parallel
 //! - `parallel_insert`: Enables nodes to be inserted via multiple threads during a publish operation
-//! - `preload_history`: Enable pre-loading of the nodes when generating history proofs
+//! - `preload_history`: Enables pre-loading of nodes when generating history proofs
 //! - `greedy_lookup_preload`: Greedy loading of lookup proof nodes
 //!
 //! Benchmarking:
 //! - `bench`: Feature used when running benchmarks
-//! - `slow_internal_db`: Artifically slow the in-memory database (for benchmarking)
+//! - `slow_internal_db`: Artificially slow the in-memory database (for benchmarking)
+//!
+//! Tracing:
+//! - `tracing`: Enables [tracing](https://docs.rs/tracing/latest/tracing/). If not set, then the library default to [log](https://docs.rs/log/latest/log/).
+//! - `tracing_instrument`: Enables (tracing) instrumentation at the directory level. As a result, the library will generate spans for annotated functions.
 //!
 //! Utilities:
 //! - `public_auditing`: Enables the publishing of audit proofs
@@ -473,9 +477,10 @@
 //!   in the event you wish to directly serialize the structures to transmit between library <-> storage layer or library <-> clients. If you're
 //!   also utilizing VRFs (see (2.) below) it will additionally enable the _serde_ feature in the ed25519-dalek crate.
 //! - `runtime_metrics`: Collects metrics on the accesses to the storage layer
-//! - `public_tests`: Will expose some internal sanity testing functionality, which is often helpful so you don't have to write all your own
+//! - `public_tests`: Will expose some internal sanity testing functionality, which is often helpful, so you don't have to write all your own
 //!   unit test cases when implementing a storage layer yourself. This helps guarantee the sanity of a given storage implementation. Should be
-//!   used only in unit testing scenarios by altering your Cargo.toml as such:
+//!   used only in unit testing scenarios by altering your Cargo.toml as such.
+//!
 //!
 
 #![warn(missing_docs)]
@@ -498,6 +503,16 @@ pub mod errors;
 pub mod helper_structs;
 pub mod storage;
 pub mod tree_node;
+
+/// Shim module to group logging-related macros more easily
+/// when switching between [log](https://docs.rs/log/latest/log/)
+/// and [tracing](https://docs.rs/tracing/latest/tracing/).
+pub mod log {
+    #[cfg(not(feature = "tracing"))]
+    pub use log::{debug, error, info, trace, warn};
+    #[cfg(feature = "tracing")]
+    pub use tracing::{debug, error, info, trace, warn};
+}
 
 #[cfg(feature = "public_auditing")]
 pub mod local_auditing;

--- a/akd/src/local_auditing.rs
+++ b/akd/src/local_auditing.rs
@@ -8,7 +8,7 @@
 //! This module contains all the type conversions between internal AKD & message types
 //! with the protobuf types
 //!
-//! Additionally it supports the conversion between the output from the `Directory` to
+//! Additionally, it supports the conversion between the output from the `Directory` to
 //! public-storage safe blob types encoded with Protobuf. Download and upload
 //! to the blob storage medium is left to the new application crate akd_local_auditor
 

--- a/akd/src/storage/types.rs
+++ b/akd/src/storage/types.rs
@@ -147,7 +147,7 @@ pub enum ValueStateRetrievalFlag {
 
 // == New Data Retrieval Logic == //
 
-/// This needs to be PUBLIC public, since anyone implementing a data-layer will need
+/// This needs to be public, since anyone implementing a data-layer will need
 /// to be able to access this and all the internal types
 #[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(

--- a/examples/src/mysql_demo/mod.rs
+++ b/examples/src/mysql_demo/mod.rs
@@ -248,7 +248,7 @@ async fn process_input(
                     assert_eq!(Ok(()), storage.batch_set(data).await);
                     let toc: Duration = Instant::now() - tic;
                     println!("Insert batch of {} items in {} ms", len, toc.as_millis());
-                    storage.log_metrics(log::Level::Warn).await;
+                    storage.log_metrics().await;
                 } else {
                     error!("Command available with MySQL db's only");
                 }

--- a/examples/src/mysql_demo/tests/mysql_tests.rs
+++ b/examples/src/mysql_demo/tests/mysql_tests.rs
@@ -54,7 +54,7 @@ async fn test_directory_operations<TC: Configuration>() {
         let storage_manager = StorageManager::new_no_cache(mysql_db.clone());
         directory_test_suite::<TC, _, HardCodedAkdVRF>(&storage_manager, 50, &vrf).await;
 
-        storage_manager.log_metrics(log::Level::Trace).await;
+        storage_manager.log_metrics().await;
 
         // clean the test infra
         if let Err(mysql_async::Error::Server(error)) = storage_manager.get_db().drop_tables().await
@@ -111,7 +111,7 @@ async fn test_directory_operations_with_caching<TC: Configuration>() {
         let storage_manager = StorageManager::new(mysql_db.clone(), None, None, None);
         directory_test_suite::<TC, _, HardCodedAkdVRF>(&storage_manager, 50, &vrf).await;
 
-        storage_manager.log_metrics(log::Level::Trace).await;
+        storage_manager.log_metrics().await;
 
         // clean the test infra
         if let Err(mysql_async::Error::Server(error)) = storage_manager.get_db().drop_tables().await

--- a/examples/src/mysql_demo/tests/test_util.rs
+++ b/examples/src/mysql_demo/tests/test_util.rs
@@ -246,7 +246,7 @@ pub(crate) async fn test_lookups<TC: Configuration, S: Database + 'static, V: VR
 // These allow us to accurately assess the additional efficiency of
 // bulk lookup proofs.
 async fn reset_mysql_db<S: Database>(mysql_db: &StorageManager<S>) {
-    mysql_db.log_metrics(Level::Warn).await;
+    mysql_db.log_metrics().await;
     mysql_db.flush_cache().await;
 }
 
@@ -343,13 +343,13 @@ pub(crate) async fn directory_test_suite<
 
             // Perform an audit proof from 1u64 -> 2u64
 
-            mysql_db.log_metrics(log::Level::Info).await;
+            mysql_db.log_metrics().await;
             log::warn!("Beginning audit proof generation");
             mysql_db.flush_cache().await;
             match dir.audit(1u64, 2u64).await {
                 Err(error) => panic!("Error perform audit proof retrieval {:?}", error),
                 Ok(proof) => {
-                    mysql_db.log_metrics(log::Level::Info).await;
+                    mysql_db.log_metrics().await;
                     log::warn!("Done with audit proof generation");
                     let start_root_hash = root_hashes[0];
                     let end_root_hash = root_hashes[1];


### PR DESCRIPTION
**Context**
The [`tracing`](https://docs.rs/tracing/latest/tracing/index.html) crate enables more robust instrumentation of Rust programs compared to basic logging. With this patch, we introduce the `tracing` crate into AKD and only enable it when the `tracing` feature is specified. By default, the feature is disabled and we continue to leverage basic logging.

In addition to adding `tracing` based logging and instrumentation throughout the `akd` lib (i.e. not `akd_core`), various grammatical and organizational improvements were made in areas where tracing was being added. Notably, the `log_metrics` functions which exist throughout the storage layer were updated to simply log with `info` level instead of taking an argument to specify the level. Rationale being that the `log_metrics` functions are only called when the `runtime_metrics` feature is enabled and `info` is a fair median to assume.

**Testing**
Since no major functional changes were made, the changes were tested via existing automated tests with various different feature flags being passed to toggle `tracing` on and off.