### PR TITLE
Parallelize node preloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.0-pre.10 (Oct 17, 2024)
+* Added parallelization for node preloads during insertion
+* Added support for [tracing](https://docs.rs/tracing/latest/tracing/index.html)
+
 ## 0.12.0-pre.9 (August 28, 2024)
 * Fixed a bug in key history API that can incorrectly return HistoryProofs without UpdateProofs.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Installation
 Add the following line to the dependencies of your `Cargo.toml`:
 
 ```
-akd = "0.12.0-pre.9"
+akd = "0.12.0-pre.10"
 ```
 
 ### Minimum Supported Rust Version

--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd"
-version = "0.12.0-pre.9"
+version = "0.12.0-pre.10"
 authors = ["akd contributors"]
 description = "An implementation of an auditable key directory"
 license = "MIT OR Apache-2.0"
@@ -56,7 +56,7 @@ tracing_instrument = ["tracing/attributes"]
 
 [dependencies]
 ## Required dependencies ##
-akd_core = { version = "0.12.0-pre.9", path = "../akd_core", default-features = false, features = [
+akd_core = { version = "0.12.0-pre.10", path = "../akd_core", default-features = false, features = [
     "vrf",
 ] }
 async-recursion = "1"
@@ -73,7 +73,7 @@ paste = { version = "1", optional = true }
 protobuf = { version = "3", optional = true }
 rand = { version = "0.8", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
-tracing = {version = "0.1.40", optional = true }
+tracing = { version = "0.1.40", optional = true }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -32,7 +32,7 @@ runtime_metrics = []
 # Parallelize VRF calculations during publish
 parallel_vrf = ["akd_core/parallel_vrf"]
 # Parallelize node insertion during publish
-parallel_insert = []
+parallel_azks = []
 # Enable pre-loading of the nodes when generating history proofs
 preload_history = []
 # TESTING ONLY: Artifically slow the in-memory database (for benchmarking)
@@ -44,7 +44,7 @@ greedy_lookup_preload = []
 default = [
     "public_auditing",
     "parallel_vrf",
-    "parallel_insert",
+    "parallel_azks",
     "preload_history",
     "greedy_lookup_preload",
     "experimental",

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -1674,7 +1674,7 @@ mod tests {
             "Preload count returned unexpected value!"
         );
 
-        // Test preload with no_parallelism
+        // Test preload with parallelism disabled
         let actual_preload_count = azks
             .preload_nodes(
                 &storage_manager,

--- a/akd/src/append_only_zks.rs
+++ b/akd/src/append_only_zks.rs
@@ -36,7 +36,7 @@ pub const DEFAULT_AZKS_KEY: u8 = 1u8;
 
 /// The default available parallelism for parallel batch insertions, used when
 /// available parallelism cannot be determined at runtime. Should be > 1
-#[cfg(feature = "parallel_insert")]
+#[cfg(feature = "parallel_azks")]
 pub const DEFAULT_AVAILABLE_PARALLELISM: usize = 32;
 
 async fn tic_toc<T>(f: impl core::future::Future<Output = T>) -> (T, Option<f64>) {
@@ -52,10 +52,10 @@ async fn tic_toc<T>(f: impl core::future::Future<Output = T>) -> (T, Option<f64>
 }
 
 fn get_parallel_levels() -> Option<u8> {
-    #[cfg(not(feature = "parallel_insert"))]
+    #[cfg(not(feature = "parallel_azks"))]
     return None;
 
-    #[cfg(feature = "parallel_insert")]
+    #[cfg(feature = "parallel_azks")]
     {
         // Based on profiling results, the best performance is achieved when the
         // number of spawned tasks is equal to the number of available threads.
@@ -922,7 +922,7 @@ impl Azks {
             let maybe_task: Option<
                 tokio::task::JoinHandle<Result<(Vec<AzksElement>, Vec<AzksElement>), AkdError>>,
             > = if let Some(left_child) = node.left_child {
-                #[cfg(feature = "parallel_insert")]
+                #[cfg(feature = "parallel_azks")]
                 {
                     if parallel_levels.map(|p| p as u64 > level).unwrap_or(false) {
                         // we can parallelise further!
@@ -971,7 +971,7 @@ impl Azks {
                     }
                 }
 
-                #[cfg(not(feature = "parallel_insert"))]
+                #[cfg(not(feature = "parallel_azks"))]
                 {
                     // NO Parallelism, BAD! parallelism. Get your nose out of the garbage!
                     let child_node =

--- a/akd/src/lib.rs
+++ b/akd/src/lib.rs
@@ -459,7 +459,7 @@
 //!
 //! Performance optimizations:
 //! - `parallel_vrf`: Enables the VRF computations to be run in parallel
-//! - `parallel_azks`: Enables nodes to be read and inserted via multiple threads during a publish operation
+//! - `parallel_azks`: Enables nodes to be fetched and inserted via multiple threads during a publish operation
 //! - `preload_history`: Enable pre-loading of the nodes when generating history proofs
 //! - `greedy_lookup_preload`: Greedy loading of lookup proof nodes
 //!

--- a/akd/src/lib.rs
+++ b/akd/src/lib.rs
@@ -458,10 +458,10 @@
 //! - `experimental`: Enables usage of `ExperimentalConfiguration`
 //!
 //! Performance optimizations:
-//! - `parallel_vrf`: Enables the VRF computations to be run in parallel
-//! - `parallel_azks`: Enables nodes to be fetched and inserted via multiple threads during a publish operation
-//! - `preload_history`: Enables pre-loading of nodes when generating history proofs
 //! - `greedy_lookup_preload`: Greedy loading of lookup proof nodes
+//! - `parallel_azks`: Enables nodes to be fetched and inserted via multiple threads during a publish operation
+//! - `parallel_vrf`: Enables the VRF computations to be run in parallel
+//! - `preload_history`: Enables pre-loading of nodes when generating history proofs
 //!
 //! Benchmarking:
 //! - `bench`: Feature used when running benchmarks

--- a/akd/src/lib.rs
+++ b/akd/src/lib.rs
@@ -459,7 +459,7 @@
 //!
 //! Performance optimizations:
 //! - `parallel_vrf`: Enables the VRF computations to be run in parallel
-//! - `parallel_insert`: Enables nodes to be inserted via multiple threads during a publish operation
+//! - `parallel_azks`: Enables nodes to be read and inserted via multiple threads during a publish operation
 //! - `preload_history`: Enable pre-loading of the nodes when generating history proofs
 //! - `greedy_lookup_preload`: Greedy loading of lookup proof nodes
 //!

--- a/akd_core/Cargo.toml
+++ b/akd_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_core"
-version = "0.12.0-pre.9"
+version = "0.12.0-pre.10"
 authors = ["akd contributors"]
 description = "Core utilities for the akd crate"
 license = "MIT OR Apache-2.0"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples"
-version = "0.12.0-pre.9"
+version = "0.12.0-pre.10"
 authors = ["akd contributors"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## Overview
This PR adds parallelization for node preloading. This primarily benefits publishing, which performs node preloading prior to node insertion and audit proof generation.

During node preloading, we perform a Breadth First Search on the tree starting from the root, fetching each level of the tree in sequence. This operation's latency is lower bounded since a certain minimum number of back-to-back round trips to DB is always required. However, the amount of work performed between each DB read is not trivial, and can contribute significantly to the overall preload latency when publishing hundreds of thousands of keys.

We can improve preload latency and bring it closer to the theoretical lower bound, by parallelizing the work performed between DB fetches. In this PR, I do so by having having each step in the BFS split the subsequent work for the next level into two chunks, having each chunk be processed concurrently. The storage layer might also benefit from performing DB operations in batches that are not overly large.

Note that node preloading is used in publishing and lookups, and parallelism is always disabled for the lookup path. This is because lookups are likely performed on a machine that services client requests. We do not want a single lookup to consume all the resources on the machine and starve other client requests.

## Benchmark

Ran the azks benchmark, on trunk ([fcd665a](https://github.com/facebook/akd/commit/fcd665aa20f829cd9e06cb3d70cbe0c32ffe6b67)) and on this PR:

```
cargo bench -p akd --bench azks -F bench
```

**Batch Insertion (1000 Initial Leaves, 1000 Inserted Leaves)**

Trunk:
![image](https://github.com/user-attachments/assets/b357c476-2c3a-4007-8e90-c616a2481826)

This PR:
![image](https://github.com/user-attachments/assets/9ad974f7-f970-47de-bf3c-754897636776)


**Batch Insertion (200,000 Initial Leaves, 200,000 Inserted Leaves)**

Trunk:
![image](https://github.com/user-attachments/assets/3deb0bb5-5c4e-459a-95d4-5b68044c384e)


This PR:
![image](https://github.com/user-attachments/assets/af085fae-fe30-426d-a57e-5e9aacac62c7)


On my 10-core Macbook Pro, we get a decent amount of improvement (~27%).  This improvement should be larger on higher core count machines, and at higher load levels.
