### PR TITLE
Allow Azks parallelism to be configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.12.0-pre.11 (Nov 21, 2024)
+* Added parallelization for node preloads during audit proof generation
+* Removed `parallel_azks` feature in favor of explicit parallelism configuration object allowing the
+setting of static or dynamic parallelism across insertion and preloads
+
 ## 0.12.0-pre.10 (Oct 17, 2024)
 * Added parallelization for node preloads during insertion
 * Added support for [tracing](https://docs.rs/tracing/latest/tracing/index.html)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Installation
 Add the following line to the dependencies of your `Cargo.toml`:
 
 ```
-akd = "0.12.0-pre.10"
+akd = "0.12.0-pre.11"
 ```
 
 ### Minimum Supported Rust Version

--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -18,7 +18,6 @@ experimental = ["akd_core/experimental"]
 default = [
     "public_auditing",
     "parallel_vrf",
-    "parallel_azks",
     "preload_history",
     "greedy_lookup_preload",
     "experimental",
@@ -28,8 +27,6 @@ bench = ["experimental", "public_tests", "tokio/rt-multi-thread"]
 # Greedy loading of lookup proof nodes
 greedy_lookup_preload = []
 public_auditing = ["dep:protobuf", "akd_core/protobuf"]
-# Parallelize node fetch and insertion during publish
-parallel_azks = []
 # Parallelize VRF calculations during publish
 parallel_vrf = ["akd_core/parallel_vrf"]
 # Enable pre-loading of the nodes when generating history proofs

--- a/akd/Cargo.toml
+++ b/akd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd"
-version = "0.12.0-pre.10"
+version = "0.12.0-pre.11"
 authors = ["akd contributors"]
 description = "An implementation of an auditable key directory"
 license = "MIT OR Apache-2.0"
@@ -53,7 +53,7 @@ tracing_instrument = ["tracing/attributes"]
 
 [dependencies]
 ## Required dependencies ##
-akd_core = { version = "0.12.0-pre.10", path = "../akd_core", default-features = false, features = [
+akd_core = { version = "0.12.0-pre.11", path = "../akd_core", default-features = false, features = [
     "vrf",
 ] }
 async-recursion = "1"

--- a/akd/benches/directory.rs
+++ b/akd/benches/directory.rs
@@ -10,6 +10,7 @@ extern crate criterion;
 
 mod common;
 
+use akd::append_only_zks::AzksParallelismConfig;
 use akd::ecvrf::HardCodedAkdVRF;
 use akd::storage::manager::StorageManager;
 use akd::storage::memory::AsyncInMemoryDatabase;
@@ -56,7 +57,9 @@ fn history_generation<TC: NamedConfiguration>(c: &mut Criterion) {
                 );
                 let db_clone = db.clone();
                 let directory = runtime
-                    .block_on(async move { Directory::<TC, _, _>::new(db, vrf).await })
+                    .block_on(async move {
+                        Directory::<TC, _, _>::new(db, vrf, AzksParallelismConfig::default()).await
+                    })
                     .unwrap();
 
                 for _epoch in 1..num_updates {

--- a/akd/src/auditor.rs
+++ b/akd/src/auditor.rs
@@ -9,6 +9,7 @@
 
 use akd_core::configuration::Configuration;
 
+use crate::append_only_zks::AzksParallelismConfig;
 use crate::AzksValue;
 use crate::{
     append_only_zks::InsertMode,
@@ -65,8 +66,13 @@ pub async fn verify_consecutive_append_only<TC: Configuration>(
     let manager = StorageManager::new_no_cache(db);
 
     let mut azks = Azks::new::<TC, _>(&manager).await?;
-    azks.batch_insert_nodes::<TC, _>(&manager, proof.unchanged_nodes.clone(), InsertMode::Auditor)
-        .await?;
+    azks.batch_insert_nodes::<TC, _>(
+        &manager,
+        proof.unchanged_nodes.clone(),
+        InsertMode::Auditor,
+        AzksParallelismConfig::default(),
+    )
+    .await?;
     let computed_start_root_hash: Digest = azks.get_root_hash::<TC, _>(&manager).await?;
     let mut verified = computed_start_root_hash == start_hash;
     azks.latest_epoch = end_epoch - 1;
@@ -79,8 +85,13 @@ pub async fn verify_consecutive_append_only<TC: Configuration>(
             y
         })
         .collect();
-    azks.batch_insert_nodes::<TC, _>(&manager, updated_inserted, InsertMode::Auditor)
-        .await?;
+    azks.batch_insert_nodes::<TC, _>(
+        &manager,
+        updated_inserted,
+        InsertMode::Auditor,
+        AzksParallelismConfig::default(),
+    )
+    .await?;
     let computed_end_root_hash: Digest = azks.get_root_hash::<TC, _>(&manager).await?;
     verified = verified && (computed_end_root_hash == end_hash);
     if !verified {

--- a/akd/src/lib.rs
+++ b/akd/src/lib.rs
@@ -553,7 +553,7 @@ pub use akd_core::{
 mod utils;
 
 // ========== Type re-exports which are commonly used ========== //
-pub use append_only_zks::Azks;
+pub use append_only_zks::{Azks, AzksParallelismConfig, AzksParallelismOption};
 pub use client::HistoryVerificationParams;
 pub use directory::Directory;
 pub use helper_structs::EpochHash;

--- a/akd/src/lib.rs
+++ b/akd/src/lib.rs
@@ -51,6 +51,7 @@
 //! [`storage::memory::AsyncInMemoryDatabase`] as in-memory storage, and [`ecvrf::HardCodedAkdVRF`] as the VRF.
 //! The [`directory::ReadOnlyDirectory`] creates a read-only directory which cannot be updated.
 //! ```
+//! use akd::append_only_zks::AzksParallelismConfig;
 //! use akd::storage::StorageManager;
 //! use akd::storage::memory::AsyncInMemoryDatabase;
 //! use akd::ecvrf::HardCodedAkdVRF;
@@ -63,7 +64,7 @@
 //! let vrf = HardCodedAkdVRF{};
 //!
 //! # tokio_test::block_on(async {
-//! let mut akd = Directory::<Config, _, _>::new(storage_manager, vrf)
+//! let mut akd = Directory::<Config, _, _>::new(storage_manager, vrf, AzksParallelismConfig::default())
 //!     .await
 //!     .expect("Could not create a new directory");
 //! # });
@@ -76,6 +77,7 @@
 //! with a list of the pairs. In the following example, we derive the labels and values from strings. After publishing,
 //! the new epoch number and root hash are returned.
 //! ```
+//! # use akd::append_only_zks::AzksParallelismConfig;
 //! # use akd::storage::StorageManager;
 //! # use akd::storage::memory::AsyncInMemoryDatabase;
 //! # use akd::ecvrf::HardCodedAkdVRF;
@@ -99,7 +101,11 @@
 //!
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<Config, _, _>::new(storage_manager, vrf).await.unwrap();
+//! #     let mut akd = Directory::<Config, _, _>::new(
+//! #         storage_manager,
+//! #         vrf,
+//! #         AzksParallelismConfig::default()
+//! #     ).await.unwrap();
 //! let EpochHash(epoch, root_hash) = akd.publish(entries)
 //!     .await.expect("Error with publishing");
 //! println!("Published epoch {} with root hash: {}", epoch, hex::encode(root_hash));
@@ -112,6 +118,7 @@
 //! We can call [`Directory::lookup`] to generate a [`LookupProof`] that proves the correctness
 //! of a client lookup for an existing entry.
 //! ```
+//! # use akd::append_only_zks::AzksParallelismConfig;
 //! # use akd::storage::StorageManager;
 //! # use akd::storage::memory::AsyncInMemoryDatabase;
 //! # use akd::ecvrf::HardCodedAkdVRF;
@@ -135,7 +142,11 @@
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<Config, _, _>::new(storage_manager, vrf).await.unwrap();
+//! #     let mut akd = Directory::<Config, _, _>::new(
+//! #         storage_manager,
+//! #         vrf,
+//! #         AzksParallelismConfig::default()
+//! #     ).await.unwrap();
 //! #     let EpochHash(epoch, root_hash) = akd.publish(entries)
 //! #         .await.expect("Error with publishing");
 //! let (lookup_proof, epoch_hash) = akd.lookup(
@@ -147,6 +158,7 @@
 //! To verify a valid proof, we call [`client::lookup_verify`], with respect to the root hash and
 //! the server's public key.
 //! ```
+//! # use akd::append_only_zks::AzksParallelismConfig;
 //! # use akd::storage::StorageManager;
 //! # use akd::storage::memory::AsyncInMemoryDatabase;
 //! # use akd::ecvrf::HardCodedAkdVRF;
@@ -170,7 +182,7 @@
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<Config, _, _>::new(storage_manager, vrf).await.unwrap();
+//! #     let mut akd = Directory::<Config, _, _>::new(storage_manager, vrf, AzksParallelismConfig::default()).await.unwrap();
 //! #     let _ = akd.publish(entries)
 //! #         .await.expect("Error with publishing");
 //! #     let (lookup_proof, epoch_hash) = akd.lookup(
@@ -207,6 +219,7 @@
 //! example we default to a complete history. For more information on the parameters, see the
 //! [History Parameters](#history-parameters) section.
 //! ```
+//! # use akd::append_only_zks::AzksParallelismConfig;
 //! # use akd::storage::StorageManager;
 //! # use akd::storage::memory::AsyncInMemoryDatabase;
 //! # use akd::ecvrf::HardCodedAkdVRF;
@@ -230,7 +243,7 @@
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<Config, _, _>::new(storage_manager, vrf).await.unwrap();
+//! #     let mut akd = Directory::<Config, _, _>::new(storage_manager, vrf, AzksParallelismConfig::default()).await.unwrap();
 //! #     let EpochHash(epoch, root_hash) = akd.publish(entries)
 //! #         .await.expect("Error with publishing");
 //! use akd::HistoryParams;
@@ -271,6 +284,7 @@
 //! # let db = AsyncInMemoryDatabase::new();
 //! # let storage_manager = StorageManager::new_no_cache(db);
 //! # let vrf = HardCodedAkdVRF{};
+//! # use akd::append_only_zks::AzksParallelismConfig;
 //! # use akd::EpochHash;
 //! # use akd::HistoryParams;
 //! # use akd::{AkdLabel, AkdValue};
@@ -285,7 +299,11 @@
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<Config, _, _>::new(storage_manager, vrf).await.unwrap();
+//! #     let mut akd = Directory::<Config, _, _>::new(
+//! #         storage_manager,
+//! #         vrf,
+//! #         AzksParallelismConfig::default()
+//! #     ).await.unwrap();
 //! #     let _ = akd.publish(entries)
 //! #         .await.expect("Error with publishing");
 //! #     let _ = akd.publish(
@@ -337,6 +355,7 @@
 //! # let db = AsyncInMemoryDatabase::new();
 //! # let storage_manager = StorageManager::new_no_cache(db);
 //! # let vrf = HardCodedAkdVRF{};
+//! # use akd::append_only_zks::AzksParallelismConfig;
 //! # use akd::EpochHash;
 //! # use akd::{AkdLabel, AkdValue};
 //! # use akd::Digest;
@@ -350,7 +369,11 @@
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<Config, _, _>::new(storage_manager, vrf).await.unwrap();
+//! #     let mut akd = Directory::<Config, _, _>::new(
+//! #         storage_manager,
+//! #         vrf,
+//! #         AzksParallelismConfig::default()
+//! #     ).await.unwrap();
 //! #     let EpochHash(epoch, root_hash) = akd.publish(entries)
 //! #         .await.expect("Error with publishing");
 //! // Publish new entries into a second epoch
@@ -368,6 +391,7 @@
 //! ```
 //! The auditor then verifies the above [`AppendOnlyProof`] using [`auditor::audit_verify`].
 //! ```
+//! # use akd::append_only_zks::AzksParallelismConfig;
 //! # use akd::storage::StorageManager;
 //! # use akd::storage::memory::AsyncInMemoryDatabase;
 //! # use akd::ecvrf::HardCodedAkdVRF;
@@ -391,7 +415,11 @@
 //! #
 //! # tokio_test::block_on(async {
 //! #     let vrf = HardCodedAkdVRF{};
-//! #     let mut akd = Directory::<Config, _, _>::new(storage_manager, vrf).await.unwrap();
+//! #     let mut akd = Directory::<Config, _, _>::new(
+//! #         storage_manager,
+//! #         vrf,
+//! #         AzksParallelismConfig::default()
+//! #     ).await.unwrap();
 //! #     let EpochHash(epoch, root_hash) = akd.publish(entries)
 //! #         .await.expect("Error with publishing");
 //! #     // Publish new entries into a second epoch
@@ -459,7 +487,6 @@
 //!
 //! Performance optimizations:
 //! - `greedy_lookup_preload`: Greedy loading of lookup proof nodes
-//! - `parallel_azks`: Enables nodes to be fetched and inserted via multiple threads during a publish operation
 //! - `parallel_vrf`: Enables the VRF computations to be run in parallel
 //! - `preload_history`: Enables pre-loading of nodes when generating history proofs
 //!

--- a/akd/src/tests/test_preloads.rs
+++ b/akd/src/tests/test_preloads.rs
@@ -10,6 +10,7 @@
 use akd_core::configuration::Configuration;
 
 use crate::{
+    append_only_zks::AzksParallelismConfig,
     directory::Directory,
     ecvrf::HardCodedAkdVRF,
     errors::{AkdError, StorageError},
@@ -31,7 +32,7 @@ async fn test_publish_op_makes_no_get_requests<TC: Configuration>() -> Result<()
 
     let storage = StorageManager::new_no_cache(db);
     let vrf = HardCodedAkdVRF {};
-    let akd = Directory::<TC, _, _>::new(storage, vrf)
+    let akd = Directory::<TC, _, _>::new(storage, vrf, AzksParallelismConfig::default())
         .await
         .expect("Failed to create directory");
 
@@ -61,7 +62,7 @@ async fn test_publish_op_makes_no_get_requests<TC: Configuration>() -> Result<()
 
     let storage = StorageManager::new_no_cache(db2);
     let vrf = HardCodedAkdVRF {};
-    let akd = Directory::<TC, _, _>::new(storage, vrf)
+    let akd = Directory::<TC, _, _>::new(storage, vrf, AzksParallelismConfig::default())
         .await
         .expect("Failed to create directory");
 

--- a/akd_core/Cargo.toml
+++ b/akd_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akd_core"
-version = "0.12.0-pre.10"
+version = "0.12.0-pre.11"
 authors = ["akd contributors"]
 description = "Core utilities for the akd crate"
 license = "MIT OR Apache-2.0"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples"
-version = "0.12.0-pre.10"
+version = "0.12.0-pre.11"
 authors = ["akd contributors"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/examples/src/fixture_generator/examples/example_tests.rs
+++ b/examples/src/fixture_generator/examples/example_tests.rs
@@ -10,6 +10,7 @@
 use std::fs::File;
 
 use akd::{
+    append_only_zks::AzksParallelismConfig,
     directory::Directory,
     ecvrf::HardCodedAkdVRF,
     storage::{memory::AsyncInMemoryDatabase, Database, StorageManager, StorageUtil},
@@ -39,9 +40,13 @@ async fn test_use_fixture<TC: NamedConfiguration>() {
         .unwrap();
     let vrf = HardCodedAkdVRF {};
     let storage_manager = StorageManager::new_no_cache(db);
-    let akd = Directory::<TC, _, _>::new(storage_manager.clone(), vrf)
-        .await
-        .unwrap();
+    let akd = Directory::<TC, _, _>::new(
+        storage_manager.clone(),
+        vrf,
+        AzksParallelismConfig::default(),
+    )
+    .await
+    .unwrap();
 
     // publish delta updates
     let delta = reader.read_delta(epochs[1]).unwrap();

--- a/examples/src/fixture_generator/generator.rs
+++ b/examples/src/fixture_generator/generator.rs
@@ -13,6 +13,7 @@ use std::env;
 use std::fs::File;
 use std::io::Write;
 
+use akd::append_only_zks::AzksParallelismConfig;
 use akd::directory::Directory;
 use akd::storage::types::DbRecord;
 use akd::storage::{StorageManager, StorageUtil};
@@ -129,9 +130,13 @@ pub(crate) async fn generate<TC: NamedConfiguration, L: DomainLabel>(args: &Args
     let db = akd::storage::memory::AsyncInMemoryDatabase::new();
     let vrf = akd::ecvrf::HardCodedAkdVRF {};
     let storage_manager = StorageManager::new_no_cache(db);
-    let akd = Directory::<TC, _, _>::new(storage_manager.clone(), vrf)
-        .await
-        .unwrap();
+    let akd = Directory::<TC, _, _>::new(
+        storage_manager.clone(),
+        vrf,
+        AzksParallelismConfig::default(),
+    )
+    .await
+    .unwrap();
 
     for epoch in 1..=args.epochs {
         // gather specified key updates

--- a/examples/src/mysql_demo/mod.rs
+++ b/examples/src/mysql_demo/mod.rs
@@ -7,6 +7,7 @@
 
 //! An example tool for running AKD backed by MySQL storage
 
+use akd::append_only_zks::AzksParallelismConfig;
 use akd::ecvrf::HardCodedAkdVRF;
 use akd::storage::StorageManager;
 use akd::Directory;
@@ -144,9 +145,10 @@ pub(crate) async fn render_cli(args: CliArgs) -> Result<()> {
     if cli.memory_db {
         let db = akd::storage::memory::AsyncInMemoryDatabase::new();
         let storage_manager = StorageManager::new_no_cache(db);
-        let mut directory = Directory::<TC, _, _>::new(storage_manager, vrf)
-            .await
-            .unwrap();
+        let mut directory =
+            Directory::<TC, _, _>::new(storage_manager, vrf, AzksParallelismConfig::default())
+                .await
+                .unwrap();
         if let Some(()) = pre_process_input(&cli, None).await {
             return Ok(());
         }
@@ -175,9 +177,13 @@ pub(crate) async fn render_cli(args: CliArgs) -> Result<()> {
             None,
             Some(Duration::from_secs(15)),
         );
-        let mut directory = Directory::<TC, _, _>::new(storage_manager.clone(), vrf)
-            .await
-            .unwrap();
+        let mut directory = Directory::<TC, _, _>::new(
+            storage_manager.clone(),
+            vrf,
+            AzksParallelismConfig::default(),
+        )
+        .await
+        .unwrap();
         tokio::spawn(async move {
             directory_host::init_host::<TC, _, HardCodedAkdVRF>(&mut rx, &mut directory).await
         });

--- a/examples/src/mysql_demo/tests/test_util.rs
+++ b/examples/src/mysql_demo/tests/test_util.rs
@@ -7,6 +7,7 @@
 
 extern crate thread_id;
 
+use akd::append_only_zks::AzksParallelismConfig;
 use akd::configuration::Configuration;
 use akd::ecvrf::VRFKeyStorage;
 use akd::storage::{Database, StorageManager};
@@ -144,7 +145,12 @@ pub(crate) async fn test_lookups<TC: Configuration, S: Database + 'static, V: VR
     }
 
     // create & test the directory
-    let maybe_dir = Directory::<TC, _, _>::new(mysql_db.clone(), vrf.clone()).await;
+    let maybe_dir = Directory::<TC, _, _>::new(
+        mysql_db.clone(),
+        vrf.clone(),
+        AzksParallelismConfig::default(),
+    )
+    .await;
     match maybe_dir {
         Err(akd_error) => panic!("Error initializing directory: {:?}", akd_error),
         Ok(dir) => {
@@ -279,7 +285,12 @@ pub(crate) async fn directory_test_suite<
     }
     let mut root_hashes = vec![];
     // create & test the directory
-    let maybe_dir = Directory::<TC, _, _>::new(mysql_db.clone(), vrf.clone()).await;
+    let maybe_dir = Directory::<TC, _, _>::new(
+        mysql_db.clone(),
+        vrf.clone(),
+        AzksParallelismConfig::default(),
+    )
+    .await;
     match maybe_dir {
         Err(akd_error) => panic!("Error initializing directory: {:?}", akd_error),
         Ok(dir) => {

--- a/examples/src/test_vectors/mod.rs
+++ b/examples/src/test_vectors/mod.rs
@@ -10,6 +10,7 @@
 
 use crate::fixture_generator::writer::yaml::YamlWriter;
 use crate::fixture_generator::writer::Writer;
+use akd::append_only_zks::AzksParallelismConfig;
 use akd::directory::Directory;
 use akd::ecvrf::HardCodedAkdVRF;
 use akd::hash::DIGEST_BYTES;
@@ -146,7 +147,8 @@ async fn generate_impl<TC: NamedConfiguration>() -> Result<TestVectorBytes> {
     let storage_manager = StorageManager::new_no_cache(db);
     let vrf = HardCodedAkdVRF {};
     // epoch 0
-    let akd = Directory::<TC, _, _>::new(storage_manager, vrf).await?;
+    let akd =
+        Directory::<TC, _, _>::new(storage_manager, vrf, AzksParallelismConfig::default()).await?;
     let vrf_pk = akd.get_public_key().await?;
 
     let num_labels = 5;

--- a/examples/src/wasm_client/mod.rs
+++ b/examples/src/wasm_client/mod.rs
@@ -185,6 +185,7 @@ pub fn lookup_verify_experimental(
 pub mod tests {
     extern crate wasm_bindgen_test;
 
+    use akd::append_only_zks::AzksParallelismConfig;
     use akd::errors::AkdError;
     use akd::storage::memory::AsyncInMemoryDatabase;
     use akd::storage::StorageManager;
@@ -216,7 +217,7 @@ pub mod tests {
         let db = AsyncInMemoryDatabase::new();
         let storage = StorageManager::new_no_cache(db);
         let vrf = HardCodedAkdVRF {};
-        let akd = Directory::<TC, _, _>::new(storage, vrf)
+        let akd = Directory::<TC, _, _>::new(storage, vrf, AzksParallelismConfig::default())
             .await
             .expect("Failed to construct directory");
 


### PR DESCRIPTION
This PR is stacked on #456. It refactors Azks parallelism in the following ways:
- Simplifies parallelism logic in `get_append_only_proof_helper` 
- Removes the `parallel_azks` feature in favor of explicit configuration (see next point), to avoid interactions between multiple configuration methods.
- Creates an `AzksParallelismConfig` struct, allowing users to set parallelism for different operation types (`insertion` and `preload`). Each operation can have one of the parallelism settings:
  - No parallelism
  - Static parallelism
  - Dynamic parallelism (derived from core count)
