### PR TITLE
Add epoch-range storage query: get_user_data_in_range

### DIFF
--- a/akd/src/storage/manager/mod.rs
+++ b/akd/src/storage/manager/mod.rs
@@ -540,6 +540,58 @@ impl<Db: Database> StorageManager<Db> {
         }
     }
 
+    /// Retrieve all value states for a given user within the epoch range [start_epoch, end_epoch].
+    pub async fn get_user_data_in_range(
+        &self,
+        username: &AkdLabel,
+        start_epoch: u64,
+        end_epoch: u64,
+    ) -> Result<KeyData, StorageError> {
+        let maybe_db_data = match self
+            .tic_toc(
+                METRIC_READ_TIME,
+                self.db
+                    .get_user_data_in_range(username, start_epoch, end_epoch),
+            )
+            .await
+        {
+            Err(StorageError::NotFound(_)) => Ok(None),
+            Ok(something) => Ok(Some(something)),
+            Err(other) => Err(other),
+        }?;
+        self.increment_metric(METRIC_GET_USER_DATA);
+
+        if self.is_transaction_active() {
+            let mut map = maybe_db_data
+                .map(|data| {
+                    data.states
+                        .into_iter()
+                        .map(|state| (state.epoch, state))
+                        .collect::<HashMap<u64, _>>()
+                })
+                .unwrap_or_else(HashMap::new);
+
+            for record in self
+                .transaction
+                .get_user_data_in_range(username, start_epoch, end_epoch)
+            {
+                map.insert(record.epoch, record);
+            }
+
+            let mut states: Vec<ValueState> = map.into_values().collect();
+            states.sort_by_key(|s| s.epoch);
+            return Ok(KeyData { states });
+        }
+
+        if let Some(data) = maybe_db_data {
+            Ok(data)
+        } else {
+            Err(StorageError::NotFound(format!(
+                "ValueState records for {username:?}"
+            )))
+        }
+    }
+
     /// Retrieve the user -> state version mapping in bulk. This is the same as get_user_state in a loop, but with less data retrieved from the storage layer.
     pub async fn get_user_state_versions(
         &self,

--- a/akd/src/storage/memory.rs
+++ b/akd/src/storage/memory.rs
@@ -192,6 +192,26 @@ impl Database for AsyncInMemoryDatabase {
         }
     }
 
+    /// Retrieve the user data for a given user within the epoch range [start_epoch, end_epoch]
+    async fn get_user_data_in_range(
+        &self,
+        username: &AkdLabel,
+        start_epoch: u64,
+        end_epoch: u64,
+    ) -> Result<KeyData, StorageError> {
+        if let Some(result) = self.user_info.get(&username.0) {
+            let mut results: Vec<ValueState> = result
+                .values()
+                .filter(|state| state.epoch >= start_epoch && state.epoch <= end_epoch)
+                .cloned()
+                .collect();
+            results.sort_by_key(|a| a.epoch);
+            Ok(KeyData { states: results })
+        } else {
+            Err(StorageError::NotFound(format!("ValueState {username:?}")))
+        }
+    }
+
     /// Retrieve a specific state for a given user
     async fn get_user_state(
         &self,

--- a/akd/src/storage/mod.rs
+++ b/akd/src/storage/mod.rs
@@ -118,6 +118,14 @@ pub trait Database: Send + Sync {
     /// Retrieve the user data for a given user
     async fn get_user_data(&self, username: &AkdLabel) -> Result<types::KeyData, StorageError>;
 
+    /// Retrieve the user data for a given user within the epoch range [start_epoch, end_epoch]
+    async fn get_user_data_in_range(
+        &self,
+        username: &AkdLabel,
+        start_epoch: u64,
+        end_epoch: u64,
+    ) -> Result<types::KeyData, StorageError>;
+
     /// Retrieve a specific state for a given user
     async fn get_user_state(
         &self,

--- a/akd/src/storage/transaction.rs
+++ b/akd/src/storage/transaction.rs
@@ -209,6 +209,23 @@ impl Transaction {
         results
     }
 
+    /// Retrieve all user data for a given username within the epoch range [start_epoch, end_epoch].
+    ///
+    /// Note: This is a FULL SCAN operation of the entire transaction log.
+    pub fn get_user_data_in_range(
+        &self,
+        username: &crate::AkdLabel,
+        start_epoch: u64,
+        end_epoch: u64,
+    ) -> Vec<ValueState> {
+        self.get_users_data(slice::from_ref(username))
+            .remove(username)
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|state| state.epoch >= start_epoch && state.epoch <= end_epoch)
+            .collect()
+    }
+
     /// Retrieve the user state given the specified value state retrieval mode.
     ///
     /// Note: This is a FULL SCAN operation of the entire transaction log.

--- a/examples/src/mysql_demo/mysql.rs
+++ b/examples/src/mysql_demo/mysql.rs
@@ -930,6 +930,83 @@ impl Database for AsyncMySqlDatabase {
         }
     }
 
+    async fn get_user_data_in_range(
+        &self,
+        username: &AkdLabel,
+        start_epoch: u64,
+        end_epoch: u64,
+    ) -> core::result::Result<KeyData, StorageError> {
+        self.record_call_stats('r', "get_user_data_in_range".to_string(), "".to_string())
+            .await;
+
+        let result = async {
+            let mut conn = self.get_connection().await?;
+            let statement_text =
+                "SELECT `username`, `epoch`, `version`, `node_label_val`, `node_label_len`, `data` FROM `"
+                    .to_owned()
+                    + TABLE_USER
+                    + "` WHERE `username` = :the_user AND `epoch` >= :start_epoch AND `epoch` <= :end_epoch";
+            let mut result = conn
+                .exec_iter(
+                    statement_text,
+                    params! {
+                        "the_user" => username.0.clone(),
+                        "start_epoch" => start_epoch,
+                        "end_epoch" => end_epoch,
+                    },
+                )
+                .await?;
+            let out = result
+                .map(|mut row| {
+                    if let (
+                        Some(username),
+                        Some(epoch),
+                        Some(version),
+                        Some(node_label_val),
+                        Some(node_label_len),
+                        Some(data),
+                    ) = (
+                        row.take(0),
+                        row.take(1),
+                        row.take(2),
+                        row.take::<Vec<u8>, _>(3),
+                        row.take(4),
+                        row.take(5),
+                    ) {
+                        let r: core::result::Result<[u8; 32], _> = node_label_val.try_into();
+                        if let Ok(label_val) = r {
+                            return Some(ValueState {
+                                epoch,
+                                version,
+                                label: NodeLabel {
+                                    label_val,
+                                    label_len: node_label_len,
+                                },
+                                value: AkdValue(data),
+                                username: AkdLabel(username),
+                            });
+                        }
+                    }
+                    None
+                })
+                .await
+                .map(|a| a.into_iter().flatten().collect::<Vec<_>>());
+
+            let selected_records = self.check_for_infra_error(out)?;
+            Ok::<KeyData, MySqlError>(KeyData {
+                states: selected_records,
+            })
+        };
+
+        match result.await {
+            Ok(output) => Ok(output),
+            Err(error) => {
+                error!("MySQL error {error}");
+                Err(StorageError::Other(format!("MySQL Error {error}")))
+            }
+        }
+    }
+
     async fn get_user_state(
         &self,
         username: &AkdLabel,


### PR DESCRIPTION
## Summary
- Adds `get_user_data_in_range(username, start_epoch, end_epoch)` to the `Database` trait
- Implements it in `AsyncInMemoryDatabase`, `Transaction`, `StorageManager`, and `AsyncMySqlDatabase`
- MySQL implementation pushes the range filter to the query layer to avoid over-fetching

Closes #165